### PR TITLE
feat: reduced output verbosity of MCP (dense output instead of JSON)

### DIFF
--- a/src/database/bulk_operations.rs
+++ b/src/database/bulk_operations.rs
@@ -225,10 +225,7 @@ impl SymbolDatabase {
         }
 
         let start_time = std::time::Instant::now();
-        info!(
-            "🚀 Starting bulk insert of {} types",
-            types.len()
-        );
+        info!("🚀 Starting bulk insert of {} types", types.len());
 
         let original_sync: i64 = self
             .conn
@@ -279,13 +276,19 @@ impl SymbolDatabase {
             for chunk in types.chunks(BATCH_SIZE) {
                 for type_info in chunk {
                     // Serialize JSON fields
-                    let generic_params_json = type_info.generic_params.as_ref()
+                    let generic_params_json = type_info
+                        .generic_params
+                        .as_ref()
                         .map(|v| serde_json::to_string(v).ok())
                         .flatten();
-                    let constraints_json = type_info.constraints.as_ref()
+                    let constraints_json = type_info
+                        .constraints
+                        .as_ref()
                         .map(|v| serde_json::to_string(v).ok())
                         .flatten();
-                    let metadata_json = type_info.metadata.as_ref()
+                    let metadata_json = type_info
+                        .metadata
+                        .as_ref()
                         .map(|m| serde_json::to_string(m).ok())
                         .flatten();
 
@@ -321,10 +324,7 @@ impl SymbolDatabase {
 
         if indexes_dropped {
             if let Err(e) = self.create_type_indexes() {
-                warn!(
-                    "Failed to rebuild type indexes after bulk insert: {}",
-                    e
-                );
+                warn!("Failed to rebuild type indexes after bulk insert: {}", e);
                 if result.is_ok() {
                     result = Err(e);
                 }
@@ -873,13 +873,19 @@ impl SymbolDatabase {
                 )?;
 
                 for type_info in new_types {
-                    let generic_params_json = type_info.generic_params.as_ref()
+                    let generic_params_json = type_info
+                        .generic_params
+                        .as_ref()
                         .map(serde_json::to_string)
                         .transpose()?;
-                    let constraints_json = type_info.constraints.as_ref()
+                    let constraints_json = type_info
+                        .constraints
+                        .as_ref()
                         .map(serde_json::to_string)
                         .transpose()?;
-                    let metadata_json = type_info.metadata.as_ref()
+                    let metadata_json = type_info
+                        .metadata
+                        .as_ref()
                         .map(serde_json::to_string)
                         .transpose()?;
 
@@ -914,21 +920,12 @@ impl SymbolDatabase {
                     "INSERT INTO symbols_fts(symbols_fts) VALUES('delete-all')",
                     [],
                 )?;
-                outer_tx.execute(
-                    "INSERT INTO symbols_fts(symbols_fts) VALUES('rebuild')",
-                    [],
-                )?;
+                outer_tx.execute("INSERT INTO symbols_fts(symbols_fts) VALUES('rebuild')", [])?;
                 debug!("✅ Symbols FTS5 index rebuilt");
 
                 // Rebuild files_fts (inline to avoid borrow conflict)
-                outer_tx.execute(
-                    "INSERT INTO files_fts(files_fts) VALUES('delete-all')",
-                    [],
-                )?;
-                outer_tx.execute(
-                    "INSERT INTO files_fts(files_fts) VALUES('rebuild')",
-                    [],
-                )?;
+                outer_tx.execute("INSERT INTO files_fts(files_fts) VALUES('delete-all')", [])?;
+                outer_tx.execute("INSERT INTO files_fts(files_fts) VALUES('rebuild')", [])?;
                 debug!("✅ Files FTS5 index rebuilt");
             }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -19,8 +19,8 @@ mod migrations;
 mod relationships;
 mod schema;
 mod symbols;
-pub mod types;
 mod type_queries;
+pub mod types;
 mod workspace;
 
 // Re-export public types

--- a/src/database/relationships.rs
+++ b/src/database/relationships.rs
@@ -165,7 +165,8 @@ impl SymbolDatabase {
             .map(|p| p.as_ref() as &dyn rusqlite::ToSql)
             .collect();
 
-        let relationship_iter = stmt.query_map(&param_refs[..], |row| self.row_to_relationship(row))?;
+        let relationship_iter =
+            stmt.query_map(&param_refs[..], |row| self.row_to_relationship(row))?;
 
         let mut relationships = Vec::new();
         for relationship_result in relationship_iter {

--- a/src/database/type_queries.rs
+++ b/src/database/type_queries.rs
@@ -10,9 +10,9 @@ use anyhow::Result;
 use rusqlite::OptionalExtension;
 use tracing::debug;
 
-use crate::extractors::Symbol;
 use crate::database::SymbolDatabase;
 use crate::database::helpers::SYMBOL_COLUMNS;
+use crate::extractors::Symbol;
 
 impl SymbolDatabase {
     /// Find all symbols that implement a given interface/trait
@@ -78,7 +78,11 @@ impl SymbolDatabase {
             }
         }
 
-        debug!("Found {} implementations of {}", implementations.len(), type_name);
+        debug!(
+            "Found {} implementations of {}",
+            implementations.len(),
+            type_name
+        );
         Ok(implementations)
     }
 
@@ -134,7 +138,8 @@ impl SymbolDatabase {
         let mut returners = Vec::new();
 
         if let Some(lang) = language {
-            let rows = stmt.query_map([&type_pattern as &str, lang], |row| self.row_to_symbol(row))?;
+            let rows =
+                stmt.query_map([&type_pattern as &str, lang], |row| self.row_to_symbol(row))?;
             for row in rows {
                 returners.push(row?);
             }
@@ -145,7 +150,11 @@ impl SymbolDatabase {
             }
         }
 
-        debug!("Found {} functions returning {}", returners.len(), type_name);
+        debug!(
+            "Found {} functions returning {}",
+            returners.len(),
+            type_name
+        );
         Ok(returners)
     }
 
@@ -192,7 +201,8 @@ impl SymbolDatabase {
         let mut acceptors = Vec::new();
 
         if let Some(lang) = language {
-            let rows = stmt.query_map([&type_pattern as &str, lang], |row| self.row_to_symbol(row))?;
+            let rows =
+                stmt.query_map([&type_pattern as &str, lang], |row| self.row_to_symbol(row))?;
             for row in rows {
                 acceptors.push(row?);
             }
@@ -203,7 +213,11 @@ impl SymbolDatabase {
             }
         }
 
-        debug!("Found {} functions with parameter type {}", acceptors.len(), type_name);
+        debug!(
+            "Found {} functions with parameter type {}",
+            acceptors.len(),
+            type_name
+        );
         Ok(acceptors)
     }
 
@@ -275,13 +289,17 @@ impl SymbolDatabase {
         let mut ids = Vec::new();
 
         if let Some(lang) = language {
-            let mut stmt = self.conn.prepare("SELECT id FROM symbols WHERE name = ?1 AND language = ?2")?;
+            let mut stmt = self
+                .conn
+                .prepare("SELECT id FROM symbols WHERE name = ?1 AND language = ?2")?;
             let rows = stmt.query_map([name, lang], |row| row.get::<_, String>(0))?;
             for row in rows {
                 ids.push(row?);
             }
         } else {
-            let mut stmt = self.conn.prepare("SELECT id FROM symbols WHERE name = ?1")?;
+            let mut stmt = self
+                .conn
+                .prepare("SELECT id FROM symbols WHERE name = ?1")?;
             let rows = stmt.query_map([name], |row| row.get::<_, String>(0))?;
             for row in rows {
                 ids.push(row?);
@@ -302,7 +320,9 @@ impl SymbolDatabase {
     /// // Returns: Some("Promise<UserProfile>") or None
     /// ```
     pub fn get_type_for_symbol(&self, symbol_id: &str) -> Result<Option<String>> {
-        let mut stmt = self.conn.prepare("SELECT resolved_type FROM types WHERE symbol_id = ?1")?;
+        let mut stmt = self
+            .conn
+            .prepare("SELECT resolved_type FROM types WHERE symbol_id = ?1")?;
         let type_result = stmt.query_row([symbol_id], |row| row.get(0)).optional()?;
         Ok(type_result)
     }

--- a/src/embeddings/model_manager.rs
+++ b/src/embeddings/model_manager.rs
@@ -70,14 +70,20 @@ impl ModelManager {
             ("BAAI/bge-small-en-v1.5", "onnx/model.onnx")
         };
 
-        info!("📥 Ensuring BGE-Small-EN-V1.5 model is available (quantized: {})...", USE_QUANTIZED_MODELS);
+        info!(
+            "📥 Ensuring BGE-Small-EN-V1.5 model is available (quantized: {})...",
+            USE_QUANTIZED_MODELS
+        );
 
         // Get the repository handle
         let repo = self.api.model(repo_id.to_string());
 
         // Download required files with timeout (Issue #5 fix)
         // HuggingFace Hub will cache these and skip download if already present
-        info!("📥 Downloading {} (this may take a while on first run)...", model_filename);
+        info!(
+            "📥 Downloading {} (this may take a while on first run)...",
+            model_filename
+        );
         let model_path = tokio::time::timeout(
             std::time::Duration::from_secs(300), // 5 minute timeout
             repo.get(model_filename),

--- a/src/embeddings/ort_model.rs
+++ b/src/embeddings/ort_model.rs
@@ -662,14 +662,14 @@ impl OrtEmbeddingModel {
                 Some(memory_bytes)
             }
             Ok(result) => {
-                tracing::warn!(
-                    "nvidia-smi command failed with status: {}",
-                    result.status
-                );
+                tracing::warn!("nvidia-smi command failed with status: {}", result.status);
                 None
             }
             Err(e) => {
-                tracing::warn!("Failed to execute nvidia-smi: {} - using fallback batch size", e);
+                tracing::warn!(
+                    "Failed to execute nvidia-smi: {} - using fallback batch size",
+                    e
+                );
                 None
             }
         }

--- a/src/extractors/c/mod.rs
+++ b/src/extractors/c/mod.rs
@@ -74,7 +74,9 @@ impl CExtractor {
 
         for symbol in symbols {
             if let Some(ref signature) = symbol.signature {
-                if let Some(inferred_type) = self.extract_type_from_signature(signature, &symbol.kind, &symbol.name) {
+                if let Some(inferred_type) =
+                    self.extract_type_from_signature(signature, &symbol.kind, &symbol.name)
+                {
                     type_map.insert(symbol.id.clone(), inferred_type);
                 }
             }
@@ -83,7 +85,12 @@ impl CExtractor {
         type_map
     }
 
-    fn extract_type_from_signature(&self, signature: &str, kind: &crate::extractors::base::SymbolKind, name: &str) -> Option<String> {
+    fn extract_type_from_signature(
+        &self,
+        signature: &str,
+        kind: &crate::extractors::base::SymbolKind,
+        name: &str,
+    ) -> Option<String> {
         use crate::extractors::base::SymbolKind;
 
         match kind {

--- a/src/extractors/factory.rs
+++ b/src/extractors/factory.rs
@@ -56,17 +56,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "typescript" | "tsx" => {
@@ -84,17 +90,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "javascript" | "jsx" => {
@@ -113,17 +125,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "python" => {
@@ -139,24 +157,35 @@ pub fn extract_symbols_and_relationships(
 
             // DEBUG: Log what we extracted
             if !_identifiers.is_empty() || !_types.is_empty() {
-                eprintln!("🔍 PYTHON {}: {} identifiers, {} types", file_path, _identifiers.len(), _types.len());
+                eprintln!(
+                    "🔍 PYTHON {}: {} identifiers, {} types",
+                    file_path,
+                    _identifiers.len(),
+                    _types.len()
+                );
             }
 
             Ok(ExtractionResults {
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "java" => {
@@ -174,17 +203,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "csharp" => {
@@ -202,17 +237,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "php" => {
@@ -230,17 +271,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "ruby" => {
@@ -251,7 +298,8 @@ pub fn extract_symbols_and_relationships(
             );
             let symbols = extractor.extract_symbols(tree);
             let relationships = extractor.extract_relationships(tree, &symbols);
-            let _identifiers = extractor.extract_identifiers(tree, &symbols);            Ok(ExtractionResults {
+            let _identifiers = extractor.extract_identifiers(tree, &symbols);
+            Ok(ExtractionResults {
                 symbols,
                 relationships,
                 identifiers: _identifiers,
@@ -273,17 +321,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "kotlin" => {
@@ -301,17 +355,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "dart" => {
@@ -329,17 +389,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "go" => {
@@ -357,17 +423,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "c" => {
@@ -386,17 +458,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "cpp" => {
@@ -413,17 +491,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: "cpp".to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: "cpp".to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "lua" => {
@@ -435,7 +519,8 @@ pub fn extract_symbols_and_relationships(
             );
             let symbols = extractor.extract_symbols(tree);
             let relationships = extractor.extract_relationships(tree, &symbols);
-            let _identifiers = extractor.extract_identifiers(tree, &symbols);            Ok(ExtractionResults {
+            let _identifiers = extractor.extract_identifiers(tree, &symbols);
+            Ok(ExtractionResults {
                 symbols,
                 relationships,
                 identifiers: _identifiers,
@@ -451,7 +536,8 @@ pub fn extract_symbols_and_relationships(
             );
             let symbols = extractor.extract_symbols(tree);
             let relationships = extractor.extract_relationships(tree, &symbols);
-            let _identifiers = extractor.extract_identifiers(tree, &symbols);            Ok(ExtractionResults {
+            let _identifiers = extractor.extract_identifiers(tree, &symbols);
+            Ok(ExtractionResults {
                 symbols,
                 relationships,
                 identifiers: _identifiers,
@@ -467,7 +553,8 @@ pub fn extract_symbols_and_relationships(
             );
             let symbols = extractor.extract_symbols(tree);
             let relationships = extractor.extract_relationships(tree, &symbols);
-            let _identifiers = extractor.extract_identifiers(tree, &symbols);            Ok(ExtractionResults {
+            let _identifiers = extractor.extract_identifiers(tree, &symbols);
+            Ok(ExtractionResults {
                 symbols,
                 relationships,
                 identifiers: _identifiers,
@@ -489,17 +576,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "html" => {
@@ -517,17 +610,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "css" => {
@@ -538,10 +637,9 @@ pub fn extract_symbols_and_relationships(
                 workspace_root,
             );
             let symbols = extractor.extract_symbols(tree);
-            let _identifiers = extractor.extract_identifiers(tree, &symbols);            // CSSExtractor doesn't have extract_relationships method yet
+            let _identifiers = extractor.extract_identifiers(tree, &symbols); // CSSExtractor doesn't have extract_relationships method yet
 
             Ok(ExtractionResults {
-
                 symbols,
 
                 relationships: Vec::new(),
@@ -549,7 +647,6 @@ pub fn extract_symbols_and_relationships(
                 identifiers: _identifiers,
 
                 types: HashMap::new(),
-
             })
         }
         "vue" => {
@@ -567,17 +664,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "razor" => {
@@ -595,17 +698,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "bash" => {
@@ -623,17 +732,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "powershell" => {
@@ -651,17 +766,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "gdscript" => {
@@ -673,7 +794,8 @@ pub fn extract_symbols_and_relationships(
             );
             let symbols = extractor.extract_symbols(tree);
             let relationships = extractor.extract_relationships(tree, &symbols);
-            let _identifiers = extractor.extract_identifiers(tree, &symbols);            Ok(ExtractionResults {
+            let _identifiers = extractor.extract_identifiers(tree, &symbols);
+            Ok(ExtractionResults {
                 symbols,
                 relationships,
                 identifiers: _identifiers,
@@ -695,17 +817,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "regex" => {
@@ -723,17 +851,23 @@ pub fn extract_symbols_and_relationships(
                 symbols,
                 relationships,
                 identifiers: _identifiers,
-                types: _types.into_iter().map(|(symbol_id, type_string)| {
-                    (symbol_id.clone(), TypeInfo {
-                        symbol_id,
-                        resolved_type: type_string,
-                        generic_params: None,
-                        constraints: None,
-                        is_inferred: true,
-                        language: language.to_string(),
-                        metadata: None,
+                types: _types
+                    .into_iter()
+                    .map(|(symbol_id, type_string)| {
+                        (
+                            symbol_id.clone(),
+                            TypeInfo {
+                                symbol_id,
+                                resolved_type: type_string,
+                                generic_params: None,
+                                constraints: None,
+                                is_inferred: true,
+                                language: language.to_string(),
+                                metadata: None,
+                            },
+                        )
                     })
-                }).collect(),
+                    .collect(),
             })
         }
         "markdown" => {
@@ -744,10 +878,9 @@ pub fn extract_symbols_and_relationships(
                 workspace_root,
             );
             let symbols = extractor.extract_symbols(tree);
-            let _identifiers = extractor.extract_identifiers(tree, &symbols);            // Markdown is documentation - no code relationships
+            let _identifiers = extractor.extract_identifiers(tree, &symbols); // Markdown is documentation - no code relationships
 
             Ok(ExtractionResults {
-
                 symbols,
 
                 relationships: Vec::new(),
@@ -755,7 +888,6 @@ pub fn extract_symbols_and_relationships(
                 identifiers: _identifiers,
 
                 types: HashMap::new(),
-
             })
         }
         "json" => {
@@ -770,7 +902,6 @@ pub fn extract_symbols_and_relationships(
             // JSON is configuration data - no code relationships
 
             Ok(ExtractionResults {
-
                 symbols,
 
                 relationships: Vec::new(),
@@ -778,7 +909,6 @@ pub fn extract_symbols_and_relationships(
                 identifiers: _identifiers,
 
                 types: HashMap::new(),
-
             })
         }
         "toml" => {
@@ -793,7 +923,6 @@ pub fn extract_symbols_and_relationships(
             // TOML is configuration data - no code relationships
 
             Ok(ExtractionResults {
-
                 symbols,
 
                 relationships: Vec::new(),
@@ -801,7 +930,6 @@ pub fn extract_symbols_and_relationships(
                 identifiers: _identifiers,
 
                 types: HashMap::new(),
-
             })
         }
         "yaml" => {
@@ -816,7 +944,6 @@ pub fn extract_symbols_and_relationships(
             // YAML is configuration data - no code relationships
 
             Ok(ExtractionResults {
-
                 symbols,
 
                 relationships: Vec::new(),
@@ -824,7 +951,6 @@ pub fn extract_symbols_and_relationships(
                 identifiers: _identifiers,
 
                 types: HashMap::new(),
-
             })
         }
 
@@ -854,7 +980,11 @@ mod factory_consistency_tests {
         let supported = manager.supported_languages();
 
         // Verify we have all 27 languages
-        assert_eq!(supported.len(), 29, "Expected 29 language entries (27 languages, 2 with aliases)");
+        assert_eq!(
+            supported.len(),
+            29,
+            "Expected 29 language entries (27 languages, 2 with aliases)"
+        );
 
         let workspace_root = PathBuf::from("/tmp/test");
 
@@ -934,15 +1064,15 @@ def foo():
     bar()
     x.method()
 "#;
-        
+
         let workspace_root = PathBuf::from("/tmp");
-        
+
         // Parse the code
         let mut parser = Parser::new();
         let language = tree_sitter_python::LANGUAGE;
         parser.set_language(&language.into()).unwrap();
         let tree = parser.parse(code, None).unwrap();
-        
+
         // Call the factory
         let results = crate::extractors::factory::extract_symbols_and_relationships(
             &tree,
@@ -950,14 +1080,18 @@ def foo():
             code,
             "python",
             &workspace_root,
-        ).unwrap();
-        
+        )
+        .unwrap();
+
         // Assert we got identifiers
         println!("Symbols: {}", results.symbols.len());
         println!("Identifiers: {}", results.identifiers.len());
         println!("Types: {}", results.types.len());
-        
+
         assert!(results.symbols.len() > 0, "Should extract symbols");
-        assert!(results.identifiers.len() > 0, "Factory should return identifiers from Python code!");
+        assert!(
+            results.identifiers.len() > 0,
+            "Factory should return identifiers from Python code!"
+        );
     }
 }

--- a/src/extractors/javascript/mod.rs
+++ b/src/extractors/javascript/mod.rs
@@ -69,7 +69,11 @@ impl JavaScriptExtractor {
         type_map
     }
 
-    fn extract_jsdoc_type(&self, doc_comment: &str, kind: &crate::extractors::base::SymbolKind) -> Option<String> {
+    fn extract_jsdoc_type(
+        &self,
+        doc_comment: &str,
+        kind: &crate::extractors::base::SymbolKind,
+    ) -> Option<String> {
         use crate::extractors::base::SymbolKind;
 
         match kind {

--- a/src/extractors/qml/identifiers.rs
+++ b/src/extractors/qml/identifiers.rs
@@ -116,8 +116,12 @@ fn extract_identifier_from_node(
             // Only create variable reference if not already handled by call or member access
             if let Some(parent) = node.parent() {
                 match parent.kind() {
-                    "call_expression" | "member_expression" | "function_declaration"
-                    | "ui_object_definition" | "ui_property" | "ui_signal" => {
+                    "call_expression"
+                    | "member_expression"
+                    | "function_declaration"
+                    | "ui_object_definition"
+                    | "ui_property"
+                    | "ui_signal" => {
                         return; // Skip - handled elsewhere or is a definition
                     }
                     _ => {

--- a/src/extractors/qml/mod.rs
+++ b/src/extractors/qml/mod.rs
@@ -115,11 +115,7 @@ impl QmlExtractor {
         }
     }
 
-    pub fn extract_relationships(
-        &self,
-        tree: &Tree,
-        symbols: &[Symbol],
-    ) -> Vec<Relationship> {
+    pub fn extract_relationships(&self, tree: &Tree, symbols: &[Symbol]) -> Vec<Relationship> {
         relationships::extract_relationships(self, tree, symbols)
     }
 

--- a/src/extractors/qml/relationships.rs
+++ b/src/extractors/qml/relationships.rs
@@ -14,7 +14,12 @@ pub(super) fn extract_relationships(
     let mut relationships = Vec::new();
     extract_call_relationships(extractor, tree.root_node(), symbols, &mut relationships);
     extract_instantiation_relationships(extractor, tree.root_node(), symbols, &mut relationships);
-    extract_property_binding_relationships(extractor, tree.root_node(), symbols, &mut relationships);
+    extract_property_binding_relationships(
+        extractor,
+        tree.root_node(),
+        symbols,
+        &mut relationships,
+    );
     relationships
 }
 

--- a/src/extractors/r/mod.rs
+++ b/src/extractors/r/mod.rs
@@ -111,11 +111,7 @@ impl RExtractor {
         }
     }
 
-    pub fn extract_relationships(
-        &self,
-        tree: &Tree,
-        symbols: &[Symbol],
-    ) -> Vec<Relationship> {
+    pub fn extract_relationships(&self, tree: &Tree, symbols: &[Symbol]) -> Vec<Relationship> {
         relationships::extract_relationships(self, tree, symbols)
     }
 

--- a/src/extractors/r/relationships.rs
+++ b/src/extractors/r/relationships.rs
@@ -220,10 +220,9 @@ fn find_containing_function<'a>(node: Node, symbols: &'a [Symbol]) -> Option<&'a
                 if right_child.kind() == "function_definition" {
                     // Find the symbol that matches this function
                     let func_line = parent.start_position().row + 1;
-                    if let Some(symbol) = symbols
-                        .iter()
-                        .find(|s| s.kind == SymbolKind::Function && s.start_line == func_line as u32)
-                    {
+                    if let Some(symbol) = symbols.iter().find(|s| {
+                        s.kind == SymbolKind::Function && s.start_line == func_line as u32
+                    }) {
                         return Some(symbol);
                     }
                 }

--- a/src/extractors/vue/mod.rs
+++ b/src/extractors/vue/mod.rs
@@ -128,7 +128,9 @@ impl VueExtractor {
                 }
             }
             // Check for propertyType (from props/data)
-            else if let Some(property_type) = metadata.as_ref().and_then(|m| m.get("propertyType")) {
+            else if let Some(property_type) =
+                metadata.as_ref().and_then(|m| m.get("propertyType"))
+            {
                 if let Some(type_str) = property_type.as_str() {
                     types.insert(symbol.id.clone(), type_str.to_string());
                 }

--- a/src/tests/core/database.rs
+++ b/src/tests/core/database.rs
@@ -1988,7 +1988,10 @@ fn test_wal_checkpoint_restart_mode() {
     let (busy, log, checkpointed) = result.unwrap();
 
     // Verify checkpoint results
-    assert_eq!(busy, 0, "RESTART mode should successfully checkpoint all frames");
+    assert_eq!(
+        busy, 0,
+        "RESTART mode should successfully checkpoint all frames"
+    );
     assert!(log >= 0, "Log should contain frames");
     assert!(checkpointed >= 0, "Should checkpoint frames");
 

--- a/src/tests/core/embeddings/quantization.rs
+++ b/src/tests/core/embeddings/quantization.rs
@@ -1,5 +1,5 @@
-use crate::embeddings::EmbeddingEngine;
 use super::create_test_db;
+use crate::embeddings::EmbeddingEngine;
 use tempfile::TempDir;
 
 #[tokio::test]
@@ -18,16 +18,21 @@ async fn test_quantized_embedding_generation() {
 
     // Generate an embedding
     let text = "Hello, quantized world!";
-    let embedding = engine.embed_text(text).expect("Failed to generate embedding");
+    let embedding = engine
+        .embed_text(text)
+        .expect("Failed to generate embedding");
 
     assert_eq!(embedding.len(), 384);
-    
+
     // Check if model_quantized.onnx exists in the cache
     // The cache structure is likely: cache_dir/bge-small/onnx/model_quantized.onnx
     // or similar depending on ModelManager implementation.
     // Let's check the file system.
-    let model_path = cache_dir.join("bge-small").join("onnx").join("model_quantized.onnx");
-    
+    let model_path = cache_dir
+        .join("bge-small")
+        .join("onnx")
+        .join("model_quantized.onnx");
+
     // Note: This check depends on implementation details of ModelManager.
     // If ModelManager puts it elsewhere, this might fail.
     // But based on previous code reading, it seemed to use a structured path.
@@ -36,9 +41,9 @@ async fn test_quantized_embedding_generation() {
     // In tests, we pass `cache_dir`.
     // `ModelManager::new(cache_dir)` sets the cache.
     // `ensure_model_downloaded` uses `ApiRepo::new_with_token`? No, `ApiBuilder`.
-    
+
     // Let's just verify it works for now. The existence of the file is secondary
     // (and hard to predict exact path with hf-hub's hashing).
-    
+
     println!("✅ Quantized embedding generated successfully");
 }

--- a/src/tests/extractors/bash/types.rs
+++ b/src/tests/extractors/bash/types.rs
@@ -34,14 +34,9 @@ double_value() {
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.sh",
-            code,
-            "bash",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.sh", code, "bash", &workspace_root)
+                .expect("Extraction failed");
 
         assert!(
             !results.types.is_empty(),
@@ -50,7 +45,10 @@ double_value() {
 
         println!("Extracted {} types from Bash code", results.types.len());
         for (symbol_id, type_info) in &results.types {
-            println!("  {} -> {} (inferred: {})", symbol_id, type_info.resolved_type, type_info.is_inferred);
+            println!(
+                "  {} -> {} (inferred: {})",
+                symbol_id, type_info.resolved_type, type_info.is_inferred
+            );
         }
 
         assert!(results.types.len() >= 1);

--- a/src/tests/extractors/c/types.rs
+++ b/src/tests/extractors/c/types.rs
@@ -47,16 +47,34 @@ void process_data() {
     assert!(!types.is_empty(), "Should extract at least one type");
 
     // Find function symbols
-    let get_count_symbol = symbols.iter().find(|s| s.name == "get_count").expect("Should find get_count");
-    let get_name_symbol = symbols.iter().find(|s| s.name == "get_name").expect("Should find get_name");
-    let get_user_symbol = symbols.iter().find(|s| s.name == "get_user").expect("Should find get_user");
-    let process_data_symbol = symbols.iter().find(|s| s.name == "process_data").expect("Should find process_data");
+    let get_count_symbol = symbols
+        .iter()
+        .find(|s| s.name == "get_count")
+        .expect("Should find get_count");
+    let get_name_symbol = symbols
+        .iter()
+        .find(|s| s.name == "get_name")
+        .expect("Should find get_name");
+    let get_user_symbol = symbols
+        .iter()
+        .find(|s| s.name == "get_user")
+        .expect("Should find get_user");
+    let process_data_symbol = symbols
+        .iter()
+        .find(|s| s.name == "process_data")
+        .expect("Should find process_data");
 
     // Verify types were extracted
     assert_eq!(types.get(&get_count_symbol.id), Some(&"int".to_string()));
     assert_eq!(types.get(&get_name_symbol.id), Some(&"char*".to_string()));
-    assert_eq!(types.get(&get_user_symbol.id), Some(&"struct User*".to_string()));
-    assert_eq!(types.get(&process_data_symbol.id), Some(&"void".to_string()));
+    assert_eq!(
+        types.get(&get_user_symbol.id),
+        Some(&"struct User*".to_string())
+    );
+    assert_eq!(
+        types.get(&process_data_symbol.id),
+        Some(&"void".to_string())
+    );
 }
 
 #[test]

--- a/src/tests/extractors/csharp/types.rs
+++ b/src/tests/extractors/csharp/types.rs
@@ -39,14 +39,9 @@ public class UserService
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.cs",
-            code,
-            "csharp",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.cs", code, "csharp", &workspace_root)
+                .expect("Extraction failed");
 
         // CRITICAL: Verify types HashMap is NOT empty
         assert!(

--- a/src/tests/extractors/dart/types.rs
+++ b/src/tests/extractors/dart/types.rs
@@ -31,14 +31,9 @@ class UserService {
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.dart",
-            code,
-            "dart",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.dart", code, "dart", &workspace_root)
+                .expect("Extraction failed");
 
         assert!(
             !results.types.is_empty(),
@@ -47,7 +42,10 @@ class UserService {
 
         println!("Extracted {} types from Dart code", results.types.len());
         for (symbol_id, type_info) in &results.types {
-            println!("  {} -> {} (inferred: {})", symbol_id, type_info.resolved_type, type_info.is_inferred);
+            println!(
+                "  {} -> {} (inferred: {})",
+                symbol_id, type_info.resolved_type, type_info.is_inferred
+            );
         }
 
         assert!(results.types.len() >= 1);

--- a/src/tests/extractors/go/types.rs
+++ b/src/tests/extractors/go/types.rs
@@ -31,14 +31,9 @@ func GetUserScores() map[string]int {
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.go",
-            code,
-            "go",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.go", code, "go", &workspace_root)
+                .expect("Extraction failed");
 
         assert!(
             !results.types.is_empty(),
@@ -47,7 +42,10 @@ func GetUserScores() map[string]int {
 
         println!("Extracted {} types from Go code", results.types.len());
         for (symbol_id, type_info) in &results.types {
-            println!("  {} -> {} (inferred: {})", symbol_id, type_info.resolved_type, type_info.is_inferred);
+            println!(
+                "  {} -> {} (inferred: {})",
+                symbol_id, type_info.resolved_type, type_info.is_inferred
+            );
         }
 
         assert!(results.types.len() >= 1);

--- a/src/tests/extractors/html/types.rs
+++ b/src/tests/extractors/html/types.rs
@@ -29,14 +29,9 @@ mod tests {
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.html",
-            code,
-            "html",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.html", code, "html", &workspace_root)
+                .expect("Extraction failed");
 
         assert!(
             !results.types.is_empty(),
@@ -45,7 +40,10 @@ mod tests {
 
         println!("Extracted {} types from HTML code", results.types.len());
         for (symbol_id, type_info) in &results.types {
-            println!("  {} -> {} (inferred: {})", symbol_id, type_info.resolved_type, type_info.is_inferred);
+            println!(
+                "  {} -> {} (inferred: {})",
+                symbol_id, type_info.resolved_type, type_info.is_inferred
+            );
         }
 
         assert!(results.types.len() >= 1);

--- a/src/tests/extractors/java/types.rs
+++ b/src/tests/extractors/java/types.rs
@@ -35,14 +35,9 @@ public class Calculator {
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.java",
-            code,
-            "java",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.java", code, "java", &workspace_root)
+                .expect("Extraction failed");
 
         // CRITICAL: Verify types HashMap is NOT empty
         assert!(

--- a/src/tests/extractors/javascript/types.rs
+++ b/src/tests/extractors/javascript/types.rs
@@ -52,17 +52,35 @@ async function processData() {
     let types = extractor.infer_types(&symbols);
 
     // Should extract return types from JSDoc for all 3 functions
-    assert!(!types.is_empty(), "Should extract at least one type from JSDoc");
+    assert!(
+        !types.is_empty(),
+        "Should extract at least one type from JSDoc"
+    );
 
     // Find function symbols
-    let get_name_symbol = symbols.iter().find(|s| s.name == "getName").expect("Should find getName");
-    let calculate_age_symbol = symbols.iter().find(|s| s.name == "calculateAge").expect("Should find calculateAge");
-    let process_data_symbol = symbols.iter().find(|s| s.name == "processData").expect("Should find processData");
+    let get_name_symbol = symbols
+        .iter()
+        .find(|s| s.name == "getName")
+        .expect("Should find getName");
+    let calculate_age_symbol = symbols
+        .iter()
+        .find(|s| s.name == "calculateAge")
+        .expect("Should find calculateAge");
+    let process_data_symbol = symbols
+        .iter()
+        .find(|s| s.name == "processData")
+        .expect("Should find processData");
 
     // Verify types were extracted from JSDoc
     assert_eq!(types.get(&get_name_symbol.id), Some(&"string".to_string()));
-    assert_eq!(types.get(&calculate_age_symbol.id), Some(&"number".to_string()));
-    assert_eq!(types.get(&process_data_symbol.id), Some(&"Promise<Array<number>>".to_string()));
+    assert_eq!(
+        types.get(&calculate_age_symbol.id),
+        Some(&"number".to_string())
+    );
+    assert_eq!(
+        types.get(&process_data_symbol.id),
+        Some(&"Promise<Array<number>>".to_string())
+    );
 }
 
 #[test]
@@ -112,6 +130,9 @@ var users = [];
     }
 
     if let Some(users_symbol) = symbols.iter().find(|s| s.name == "users") {
-        assert_eq!(types.get(&users_symbol.id), Some(&"Array<User>".to_string()));
+        assert_eq!(
+            types.get(&users_symbol.id),
+            Some(&"Array<User>".to_string())
+        );
     }
 }

--- a/src/tests/extractors/kotlin/types.rs
+++ b/src/tests/extractors/kotlin/types.rs
@@ -35,14 +35,9 @@ class UserService {
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.kt",
-            code,
-            "kotlin",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.kt", code, "kotlin", &workspace_root)
+                .expect("Extraction failed");
 
         // CRITICAL: Verify types HashMap is NOT empty
         assert!(

--- a/src/tests/extractors/php/types.rs
+++ b/src/tests/extractors/php/types.rs
@@ -36,14 +36,9 @@ class UserService {
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.php",
-            code,
-            "php",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.php", code, "php", &workspace_root)
+                .expect("Extraction failed");
 
         // CRITICAL: Verify types HashMap is NOT empty
         assert!(

--- a/src/tests/extractors/powershell/types.rs
+++ b/src/tests/extractors/powershell/types.rs
@@ -49,9 +49,15 @@ function Get-AllUsers {
             "PowerShell type extraction returned EMPTY types HashMap!"
         );
 
-        println!("Extracted {} types from PowerShell code", results.types.len());
+        println!(
+            "Extracted {} types from PowerShell code",
+            results.types.len()
+        );
         for (symbol_id, type_info) in &results.types {
-            println!("  {} -> {} (inferred: {})", symbol_id, type_info.resolved_type, type_info.is_inferred);
+            println!(
+                "  {} -> {} (inferred: {})",
+                symbol_id, type_info.resolved_type, type_info.is_inferred
+            );
         }
 
         assert!(results.types.len() >= 1);

--- a/src/tests/extractors/python/mod.rs
+++ b/src/tests/extractors/python/mod.rs
@@ -30,7 +30,8 @@ mod python_extractor_tests {
             .unwrap();
         let tree = parser.parse(code, None).unwrap();
         let workspace_root = PathBuf::from("/tmp/test");
-        let extractor = PythonExtractor::new("test.py".to_string(), code.to_string(), &workspace_root);
+        let extractor =
+            PythonExtractor::new("test.py".to_string(), code.to_string(), &workspace_root);
         (extractor, tree)
     }
 
@@ -53,26 +54,32 @@ class Admin(User):
         assert!(user_class.is_some());
         let user_class = user_class.unwrap();
         assert_eq!(user_class.kind, SymbolKind::Class);
-        assert!(user_class
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("class User"));
-        assert!(user_class
-            .doc_comment
-            .as_ref()
-            .unwrap()
-            .contains("A user class for managing user data"));
+        assert!(
+            user_class
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("class User")
+        );
+        assert!(
+            user_class
+                .doc_comment
+                .as_ref()
+                .unwrap()
+                .contains("A user class for managing user data")
+        );
 
         let admin_class = symbols.iter().find(|s| s.name == "Admin");
         assert!(admin_class.is_some());
         let admin_class = admin_class.unwrap();
         assert_eq!(admin_class.kind, SymbolKind::Class);
-        assert!(admin_class
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("class Admin extends User"));
+        assert!(
+            admin_class
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("class Admin extends User")
+        );
     }
 
     #[test]
@@ -90,12 +97,14 @@ class Product:
 
         let product_class = symbols.iter().find(|s| s.name == "Product");
         assert!(product_class.is_some());
-        assert!(product_class
-            .unwrap()
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("@dataclass @final class Product"));
+        assert!(
+            product_class
+                .unwrap()
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("@dataclass @final class Product")
+        );
     }
 
     #[test]
@@ -117,31 +126,39 @@ async def fetch_data(url: str) -> dict:
         assert!(calculate_tax.is_some());
         let calculate_tax = calculate_tax.unwrap();
         assert_eq!(calculate_tax.kind, SymbolKind::Function);
-        assert!(calculate_tax
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("def calculate_tax(amount: float, rate: float = 0.1): float"));
-        assert!(calculate_tax
-            .doc_comment
-            .as_ref()
-            .unwrap()
-            .contains("Calculate tax amount."));
+        assert!(
+            calculate_tax
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("def calculate_tax(amount: float, rate: float = 0.1): float")
+        );
+        assert!(
+            calculate_tax
+                .doc_comment
+                .as_ref()
+                .unwrap()
+                .contains("Calculate tax amount.")
+        );
 
         let fetch_data = symbols.iter().find(|s| s.name == "fetch_data");
         assert!(fetch_data.is_some());
         let fetch_data = fetch_data.unwrap();
         assert_eq!(fetch_data.kind, SymbolKind::Function);
-        assert!(fetch_data
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("async def fetch_data(url: str): dict"));
-        assert!(fetch_data
-            .doc_comment
-            .as_ref()
-            .unwrap()
-            .contains("Async function to fetch data."));
+        assert!(
+            fetch_data
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("async def fetch_data(url: str): dict")
+        );
+        assert!(
+            fetch_data
+                .doc_comment
+                .as_ref()
+                .unwrap()
+                .contains("Async function to fetch data.")
+        );
     }
 
     #[test]
@@ -162,21 +179,25 @@ def full_name(self) -> str:
 
         let get_config = symbols.iter().find(|s| s.name == "get_config");
         assert!(get_config.is_some());
-        assert!(get_config
-            .unwrap()
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("@staticmethod @cached def get_config"));
+        assert!(
+            get_config
+                .unwrap()
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("@staticmethod @cached def get_config")
+        );
 
         let full_name = symbols.iter().find(|s| s.name == "full_name");
         assert!(full_name.is_some());
-        assert!(full_name
-            .unwrap()
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("@property def full_name"));
+        assert!(
+            full_name
+                .unwrap()
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("@property def full_name")
+        );
     }
 
     #[test]
@@ -217,16 +238,20 @@ class Calculator:
         assert!(add_method.is_some());
         let add_method = add_method.unwrap();
         assert_eq!(add_method.kind, SymbolKind::Method);
-        assert!(add_method
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("def add(self, a: float, b: float): float"));
-        assert!(add_method
-            .doc_comment
-            .as_ref()
-            .unwrap()
-            .contains("Add two numbers."));
+        assert!(
+            add_method
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("def add(self, a: float, b: float): float")
+        );
+        assert!(
+            add_method
+                .doc_comment
+                .as_ref()
+                .unwrap()
+                .contains("Add two numbers.")
+        );
 
         let internal_method = symbols.iter().find(|s| s.name == "_internal_method");
         assert!(internal_method.is_some());
@@ -265,11 +290,13 @@ class Config:
         assert!(api_url.is_some());
         let api_url = api_url.unwrap();
         assert_eq!(api_url.kind, SymbolKind::Constant);
-        assert!(api_url
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains(": str = \"https://api.example.com\""));
+        assert!(
+            api_url
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains(": str = \"https://api.example.com\"")
+        );
 
         let max_retries = symbols.iter().find(|s| s.name == "MAX_RETRIES");
         assert!(max_retries.is_some());
@@ -279,11 +306,13 @@ class Config:
         assert!(database_url.is_some());
         let database_url = database_url.unwrap();
         assert_eq!(database_url.kind, SymbolKind::Property); // self.attribute = property
-        assert!(database_url
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains(": str = \"postgresql://localhost\""));
+        assert!(
+            database_url
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains(": str = \"postgresql://localhost\"")
+        );
 
         let secret_key = symbols.iter().find(|s| s.name == "_secret_key");
         assert!(secret_key.is_some());
@@ -601,31 +630,37 @@ class Container(Generic[T]):
 
         let t_var = symbols.iter().find(|s| s.name == "T");
         assert!(t_var.is_some());
-        assert!(t_var
-            .unwrap()
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("TypeVar('T', bound='Comparable')"));
+        assert!(
+            t_var
+                .unwrap()
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("TypeVar('T', bound='Comparable')")
+        );
 
         let api_version = symbols.iter().find(|s| s.name == "API_VERSION");
         assert!(api_version.is_some());
-        assert!(api_version
-            .unwrap()
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("Final[str] = \"v1.2.3\""));
+        assert!(
+            api_version
+                .unwrap()
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("Final[str] = \"v1.2.3\"")
+        );
 
         let color_enum = symbols.iter().find(|s| s.name == "Color");
         assert!(color_enum.is_some());
         let color_enum = color_enum.unwrap();
         assert_eq!(color_enum.kind, SymbolKind::Enum);
-        assert!(color_enum
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("class Color extends Enum"));
+        assert!(
+            color_enum
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("class Color extends Enum")
+        );
 
         let red_value = symbols.iter().find(|s| s.name == "RED");
         assert!(red_value.is_some());
@@ -635,34 +670,42 @@ class Container(Generic[T]):
         assert!(comparable.is_some());
         let comparable = comparable.unwrap();
         assert_eq!(comparable.kind, SymbolKind::Interface); // Protocol = Interface
-        assert!(comparable
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("class Comparable extends Protocol"));
+        assert!(
+            comparable
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("class Comparable extends Protocol")
+        );
 
         let point = symbols.iter().find(|s| s.name == "Point");
         assert!(point.is_some());
         let point = point.unwrap();
-        assert!(point
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("@dataclass class Point"));
-        assert!(point
-            .doc_comment
-            .as_ref()
-            .unwrap()
-            .contains("Immutable point with slots."));
+        assert!(
+            point
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("@dataclass class Point")
+        );
+        assert!(
+            point
+                .doc_comment
+                .as_ref()
+                .unwrap()
+                .contains("Immutable point with slots.")
+        );
 
         let container = symbols.iter().find(|s| s.name == "Container");
         assert!(container.is_some());
-        assert!(container
-            .unwrap()
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("class Container extends Generic[T]"));
+        assert!(
+            container
+                .unwrap()
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("class Container extends Generic[T]")
+        );
     }
 
     #[test]
@@ -718,29 +761,35 @@ def process_users(users: List[User]) -> List[str]:
         assert!(symbols.iter().find(|s| s.name == "display_name").is_some());
         assert!(symbols.iter().find(|s| s.name == "create_admin").is_some());
         assert!(symbols.iter().find(|s| s.name == "fetch_user").is_some());
-        assert!(symbols
-            .iter()
-            .find(|s| s.name == "_validate_user")
-            .is_some());
+        assert!(
+            symbols
+                .iter()
+                .find(|s| s.name == "_validate_user")
+                .is_some()
+        );
         assert!(symbols.iter().find(|s| s.name == "DEBUG").is_some());
         assert!(symbols.iter().find(|s| s.name == "process_users").is_some());
 
         // Check specific features
         let user_class = symbols.iter().find(|s| s.name == "User");
-        assert!(user_class
-            .unwrap()
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("@dataclass class User"));
+        assert!(
+            user_class
+                .unwrap()
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("@dataclass class User")
+        );
 
         let fetch_user = symbols.iter().find(|s| s.name == "fetch_user");
-        assert!(fetch_user
-            .unwrap()
-            .signature
-            .as_ref()
-            .unwrap()
-            .contains("async def fetch_user"));
+        assert!(
+            fetch_user
+                .unwrap()
+                .signature
+                .as_ref()
+                .unwrap()
+                .contains("async def fetch_user")
+        );
 
         let validate_user = symbols.iter().find(|s| s.name == "_validate_user");
         assert_eq!(

--- a/src/tests/extractors/python/types.rs
+++ b/src/tests/extractors/python/types.rs
@@ -34,14 +34,9 @@ class UserService:
 
         // Extract through factory
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.py",
-            code,
-            "python",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.py", code, "python", &workspace_root)
+                .expect("Extraction failed");
 
         // CRITICAL: Verify types HashMap is NOT empty
         assert!(
@@ -89,14 +84,9 @@ def old_style_function(x, y):
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.py",
-            code,
-            "python",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.py", code, "python", &workspace_root)
+                .expect("Extraction failed");
 
         // For untyped Python, types may be empty or minimal
         // This is expected - not all code has type annotations

--- a/src/tests/extractors/qml/identifiers.rs
+++ b/src/tests/extractors/qml/identifiers.rs
@@ -85,7 +85,9 @@ Rectangle {
 
         // Should find property access patterns
         assert!(
-            member_names.iter().any(|&name| name == "width" || name == "height"),
+            member_names
+                .iter()
+                .any(|&name| name == "width" || name == "height"),
             "Should extract property access identifiers"
         );
     }

--- a/src/tests/extractors/qml/relationships.rs
+++ b/src/tests/extractors/qml/relationships.rs
@@ -60,9 +60,7 @@ Item {
 
         let call_rel = call_relationships
             .iter()
-            .find(|r| {
-                r.from_symbol_id == calculate_total.id && r.to_symbol_id == sum_values.id
-            })
+            .find(|r| r.from_symbol_id == calculate_total.id && r.to_symbol_id == sum_values.id)
             .expect("Should find call relationship from calculateTotal to sumValues");
 
         assert_eq!(call_rel.kind, RelationshipKind::Calls);

--- a/src/tests/extractors/r/identifiers.rs
+++ b/src/tests/extractors/r/identifiers.rs
@@ -140,14 +140,8 @@ process <- function(data) {
         );
 
         let call_names: Vec<&str> = call_identifiers.iter().map(|id| id.name.as_str()).collect();
-        assert!(
-            call_names.contains(&"filter"),
-            "Should extract filter call"
-        );
-        assert!(
-            call_names.contains(&"select"),
-            "Should extract select call"
-        );
+        assert!(call_names.contains(&"filter"), "Should extract filter call");
+        assert!(call_names.contains(&"select"), "Should extract select call");
         assert!(
             call_names.contains(&"arrange"),
             "Should extract arrange call"

--- a/src/tests/extractors/r/relationships.rs
+++ b/src/tests/extractors/r/relationships.rs
@@ -103,9 +103,7 @@ process_data <- function(data) {
         // Pipe operators create "Uses" or "Calls" relationships
         let pipe_relationships: Vec<&Relationship> = relationships
             .iter()
-            .filter(|r| {
-                r.kind == RelationshipKind::Calls || r.kind == RelationshipKind::Uses
-            })
+            .filter(|r| r.kind == RelationshipKind::Calls || r.kind == RelationshipKind::Uses)
             .collect();
 
         assert!(

--- a/src/tests/extractors/razor/types.rs
+++ b/src/tests/extractors/razor/types.rs
@@ -35,14 +35,9 @@ mod tests {
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.razor",
-            code,
-            "razor",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.razor", code, "razor", &workspace_root)
+                .expect("Extraction failed");
 
         assert!(
             !results.types.is_empty(),
@@ -51,7 +46,10 @@ mod tests {
 
         println!("Extracted {} types from Razor code", results.types.len());
         for (symbol_id, type_info) in &results.types {
-            println!("  {} -> {} (inferred: {})", symbol_id, type_info.resolved_type, type_info.is_inferred);
+            println!(
+                "  {} -> {} (inferred: {})",
+                symbol_id, type_info.resolved_type, type_info.is_inferred
+            );
         }
 
         assert!(results.types.len() >= 1);

--- a/src/tests/extractors/regex/types.rs
+++ b/src/tests/extractors/regex/types.rs
@@ -21,14 +21,9 @@ mod tests {
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.regex",
-            code,
-            "regex",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.regex", code, "regex", &workspace_root)
+                .expect("Extraction failed");
 
         assert!(
             !results.types.is_empty(),
@@ -37,7 +32,10 @@ mod tests {
 
         println!("Extracted {} types from Regex code", results.types.len());
         for (symbol_id, type_info) in &results.types {
-            println!("  {} -> {} (inferred: {})", symbol_id, type_info.resolved_type, type_info.is_inferred);
+            println!(
+                "  {} -> {} (inferred: {})",
+                symbol_id, type_info.resolved_type, type_info.is_inferred
+            );
         }
 
         assert!(results.types.len() >= 1);

--- a/src/tests/extractors/rust/types.rs
+++ b/src/tests/extractors/rust/types.rs
@@ -43,7 +43,10 @@ fn process_data() -> Result<Vec<u8>, std::io::Error> {
     assert!(!types.is_empty(), "Should extract at least one type");
 
     // Find the process_data symbol (known to have return type in signature)
-    let process_data_symbol = symbols.iter().find(|s| s.name == "process_data").expect("Should find process_data");
+    let process_data_symbol = symbols
+        .iter()
+        .find(|s| s.name == "process_data")
+        .expect("Should find process_data");
 
     // Verify the type was extracted correctly
     assert_eq!(

--- a/src/tests/extractors/sql/types.rs
+++ b/src/tests/extractors/sql/types.rs
@@ -30,14 +30,9 @@ $$ LANGUAGE plpgsql;
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.sql",
-            code,
-            "sql",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.sql", code, "sql", &workspace_root)
+                .expect("Extraction failed");
 
         assert!(
             !results.types.is_empty(),
@@ -46,7 +41,10 @@ $$ LANGUAGE plpgsql;
 
         println!("Extracted {} types from SQL code", results.types.len());
         for (symbol_id, type_info) in &results.types {
-            println!("  {} -> {} (inferred: {})", symbol_id, type_info.resolved_type, type_info.is_inferred);
+            println!(
+                "  {} -> {} (inferred: {})",
+                symbol_id, type_info.resolved_type, type_info.is_inferred
+            );
         }
 
         assert!(results.types.len() >= 1);

--- a/src/tests/extractors/swift/types.rs
+++ b/src/tests/extractors/swift/types.rs
@@ -31,14 +31,9 @@ class UserService {
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.swift",
-            code,
-            "swift",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.swift", code, "swift", &workspace_root)
+                .expect("Extraction failed");
 
         assert!(
             !results.types.is_empty(),
@@ -47,7 +42,10 @@ class UserService {
 
         println!("Extracted {} types from Swift code", results.types.len());
         for (symbol_id, type_info) in &results.types {
-            println!("  {} -> {} (inferred: {})", symbol_id, type_info.resolved_type, type_info.is_inferred);
+            println!(
+                "  {} -> {} (inferred: {})",
+                symbol_id, type_info.resolved_type, type_info.is_inferred
+            );
         }
 
         assert!(results.types.len() >= 1);

--- a/src/tests/extractors/typescript/types.rs
+++ b/src/tests/extractors/typescript/types.rs
@@ -55,7 +55,10 @@ interface User {
         );
 
         // Verify we got TypeInfo for the typed symbols
-        println!("Extracted {} types from TypeScript code", results.types.len());
+        println!(
+            "Extracted {} types from TypeScript code",
+            results.types.len()
+        );
         for (symbol_id, type_info) in &results.types {
             println!(
                 "  {} -> {} (inferred: {})",

--- a/src/tests/extractors/vue/types.rs
+++ b/src/tests/extractors/vue/types.rs
@@ -38,14 +38,9 @@ export default {
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.vue",
-            code,
-            "vue",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.vue", code, "vue", &workspace_root)
+                .expect("Extraction failed");
 
         // Vue should extract types from prop definitions and other metadata
         println!("Extracted {} types from Vue code", results.types.len());

--- a/src/tests/extractors/zig/types.rs
+++ b/src/tests/extractors/zig/types.rs
@@ -31,14 +31,9 @@ pub fn getUserScores() std.StringHashMap(i32) {
         let tree = parser.parse(code, None).expect("Error parsing code");
 
         let workspace_root = PathBuf::from("/tmp/test");
-        let results = extract_symbols_and_relationships(
-            &tree,
-            "test.zig",
-            code,
-            "zig",
-            &workspace_root,
-        )
-        .expect("Extraction failed");
+        let results =
+            extract_symbols_and_relationships(&tree, "test.zig", code, "zig", &workspace_root)
+                .expect("Extraction failed");
 
         assert!(
             !results.types.is_empty(),
@@ -47,7 +42,10 @@ pub fn getUserScores() std.StringHashMap(i32) {
 
         println!("Extracted {} types from Zig code", results.types.len());
         for (symbol_id, type_info) in &results.types {
-            println!("  {} -> {} (inferred: {})", symbol_id, type_info.resolved_type, type_info.is_inferred);
+            println!(
+                "  {} -> {} (inferred: {})",
+                symbol_id, type_info.resolved_type, type_info.is_inferred
+            );
         }
 
         assert!(results.types.len() >= 1);

--- a/src/tests/integration/lock_contention.rs
+++ b/src/tests/integration/lock_contention.rs
@@ -336,7 +336,11 @@ async fn test_concurrent_content_searches_no_corruption() -> Result<()> {
     let mut tasks = vec![];
     for i in 0..10 {
         let handler_clone = handler.clone();
-        let query = if i % 2 == 0 { "summary findings" } else { "recommendations" };
+        let query = if i % 2 == 0 {
+            "summary findings"
+        } else {
+            "recommendations"
+        };
 
         let task = tokio::spawn(async move {
             // Use LINE MODE with file pattern - this is what triggers the bug!

--- a/src/tests/integration/watcher_handlers.rs
+++ b/src/tests/integration/watcher_handlers.rs
@@ -541,7 +541,10 @@ async fn test_transaction_leak_on_error() {
                 );
             } else {
                 // Some other error - not the bug we're testing
-                println!("DEBUG: Different error (not transaction leak): {}", error_msg);
+                println!(
+                    "DEBUG: Different error (not transaction leak): {}",
+                    error_msg
+                );
             }
         }
     }
@@ -576,9 +579,11 @@ async fn test_transaction_leak_on_error() {
                     error_msg
                 );
             } else {
-                println!("DEBUG: Second file failed with different error: {}", error_msg);
+                println!(
+                    "DEBUG: Second file failed with different error: {}",
+                    error_msg
+                );
             }
         }
     }
 }
-

--- a/src/tests/regression_prevention_tests.rs
+++ b/src/tests/regression_prevention_tests.rs
@@ -140,9 +140,7 @@ mod wal_growth_prevention {
     /// Returns 0 if WAL file doesn't exist
     fn get_wal_file_size(db_path: &std::path::Path) -> u64 {
         let wal_path = db_path.with_extension("db-wal");
-        fs::metadata(&wal_path)
-            .map(|m| m.len())
-            .unwrap_or(0)
+        fs::metadata(&wal_path).map(|m| m.len()).unwrap_or(0)
     }
 
     /// Test that bulk_store_embeddings() doesn't cause unbounded WAL growth
@@ -348,9 +346,7 @@ mod batch_size_caching {
             .expect("Should create engine");
 
         // Get cached batch size multiple times (simulating 239 batches during indexing)
-        let batch_sizes: Vec<usize> = (0..239)
-            .map(|_| engine.get_cached_batch_size())
-            .collect();
+        let batch_sizes: Vec<usize> = (0..239).map(|_| engine.get_cached_batch_size()).collect();
 
         // CRITICAL: All calls should return the SAME value (cached, not recalculated)
         let first_value = batch_sizes[0];

--- a/src/tests/tools/navigation/mod.rs
+++ b/src/tests/tools/navigation/mod.rs
@@ -810,8 +810,11 @@ mod navigation_tools_tests {
         };
 
         // Store identifiers
-        db.bulk_store_identifiers(&vec![call_identifier.clone(), member_access_identifier.clone()], "test_workspace")
-            .expect("Failed to store identifiers");
+        db.bulk_store_identifiers(
+            &vec![call_identifier.clone(), member_access_identifier.clone()],
+            "test_workspace",
+        )
+        .expect("Failed to store identifiers");
 
         // Create relationships matching the identifiers
         let call_relationship = Relationship {
@@ -836,8 +839,11 @@ mod navigation_tools_tests {
             metadata: None,
         };
 
-        db.bulk_store_relationships(&vec![call_relationship.clone(), member_relationship.clone()])
-            .expect("Failed to store relationships");
+        db.bulk_store_relationships(&vec![
+            call_relationship.clone(),
+            member_relationship.clone(),
+        ])
+        .expect("Failed to store relationships");
 
         // Test 1: Filter by "call" - should return only call relationship
         let call_refs = db
@@ -846,14 +852,13 @@ mod navigation_tools_tests {
 
         println!("DEBUG: Found {} call references", call_refs.len());
         for r in &call_refs {
-            println!("  - {} at {}:{}", r.to_symbol_id, r.file_path, r.line_number);
+            println!(
+                "  - {} at {}:{}",
+                r.to_symbol_id, r.file_path, r.line_number
+            );
         }
 
-        assert_eq!(
-            call_refs.len(),
-            1,
-            "Should find exactly 1 call reference"
-        );
+        assert_eq!(call_refs.len(), 1, "Should find exactly 1 call reference");
         assert_eq!(call_refs[0].id, "rel1");
         assert_eq!(call_refs[0].file_path, "caller1.rs");
         assert_eq!(call_refs[0].line_number, 10);

--- a/src/tests/tools/search_context_lines.rs
+++ b/src/tests/tools/search_context_lines.rs
@@ -9,11 +9,19 @@ use tempfile::TempDir;
 
 use crate::extractors::Symbol;
 use crate::handler::JulieServerHandler;
+use crate::tests::tools::search_quality::helpers::parse_dense_output;
 use crate::tools::{FastSearchTool, ManageWorkspaceTool};
-use rust_mcp_sdk::schema::CallToolResult;
+use rust_mcp_sdk::schema::{CallToolResult, ContentBlock};
 
 /// Extract structured content as symbols from CallToolResult
 fn extract_symbols_from_result(result: &CallToolResult) -> Vec<Symbol> {
+    if let Some(ContentBlock::TextContent(text)) = result.content.first() {
+        let dense = parse_dense_output(&text.text);
+        if !dense.is_empty() {
+            return dense;
+        }
+    }
+
     result
         .structured_content
         .as_ref()

--- a/src/tests/tools/search_quality/mod.rs
+++ b/src/tests/tools/search_quality/mod.rs
@@ -23,4 +23,4 @@
 //! 3. Test passes - regression prevented!
 
 mod dogfood_tests;
-mod helpers;
+pub mod helpers;

--- a/src/tools/navigation/fast_refs.rs
+++ b/src/tools/navigation/fast_refs.rs
@@ -301,7 +301,8 @@ impl FastRefsTool {
                     };
                     // Single batch query, optionally filtered by identifier kind
                     if let Some(kind) = reference_kind_filter {
-                        db_lock.get_relationships_to_symbols_filtered_by_kind(&definition_ids, &kind)
+                        db_lock
+                            .get_relationships_to_symbols_filtered_by_kind(&definition_ids, &kind)
                     } else {
                         db_lock.get_relationships_to_symbols(&definition_ids)
                     }

--- a/src/tools/search/mod.rs
+++ b/src/tools/search/mod.rs
@@ -212,7 +212,10 @@ impl FastSearchTool {
         // Auto-detect search method if needed
         let search_method = if self.search_method == "auto" {
             let detected = detect_search_method(&self.query);
-            debug!("🔍 Auto-detected search method: {} (query: {})", detected, self.query);
+            debug!(
+                "🔍 Auto-detected search method: {} (query: {})",
+                detected, self.query
+            );
             detected
         } else {
             self.search_method.as_str()
@@ -335,24 +338,10 @@ impl FastSearchTool {
                         // Optimize for tokens
                         optimized.optimize_for_tokens(Some(self.limit as usize));
 
-                        // Return structured + human-readable output
-                        let markdown =
-                            formatting::format_optimized_results(&self.query, &optimized);
+                        // Return ultra-compact output (no JSON payload)
+                        let dense = formatting::format_dense_results(&optimized);
 
-                        // Serialize to JSON for structured_content
-                        let structured = serde_json::to_value(&optimized)
-                            .map_err(|e| anyhow::anyhow!("Failed to serialize response: {}", e))?;
-
-                        let structured_map = if let serde_json::Value::Object(map) = structured {
-                            map
-                        } else {
-                            return Err(anyhow::anyhow!("Expected JSON object"));
-                        };
-
-                        return Ok(
-                            CallToolResult::text_content(vec![TextContent::from(markdown)])
-                                .with_structured_content(structured_map),
-                        );
+                        return Ok(CallToolResult::text_content(vec![TextContent::from(dense)]));
                     }
                     Ok(_) => {
                         debug!("⚠️ Semantic fallback also returned 0 results");
@@ -374,24 +363,10 @@ impl FastSearchTool {
             )]));
         }
 
-        // Return structured + human-readable output
-        // Agents parse structured_content, format markdown for humans
-        let markdown = formatting::format_optimized_results(&self.query, &optimized);
+        // Return ultra-compact output (no JSON payload)
+        let dense = formatting::format_dense_results(&optimized);
 
-        // Serialize to JSON for structured_content
-        let structured = serde_json::to_value(&optimized)
-            .map_err(|e| anyhow::anyhow!("Failed to serialize response: {}", e))?;
-
-        let structured_map = if let serde_json::Value::Object(map) = structured {
-            map
-        } else {
-            return Err(anyhow::anyhow!("Expected JSON object"));
-        };
-
-        Ok(
-            CallToolResult::text_content(vec![TextContent::from(markdown)])
-                .with_structured_content(structured_map),
-        )
+        Ok(CallToolResult::text_content(vec![TextContent::from(dense)]))
     }
 
     /// Resolve workspace filtering parameter to a list of workspace IDs

--- a/src/tools/workspace/indexing/extractor.rs
+++ b/src/tools/workspace/indexing/extractor.rs
@@ -42,7 +42,12 @@ impl ManageWorkspaceTool {
 
         debug!(
             "🎯 extract_symbols_static returning: {} symbols, {} relationships, {} identifiers, {} types for {} file: {}",
-            results.symbols.len(), results.relationships.len(), results.identifiers.len(), results.types.len(), language, file_path
+            results.symbols.len(),
+            results.relationships.len(),
+            results.identifiers.len(),
+            results.types.len(),
+            language,
+            file_path
         );
 
         Ok(results)


### PR DESCRIPTION
Sorry about all the formatting, but the `cargo fmt` command did that.

The ideia is that the current MCP is outputting too verbosely. So it uses too much tokens.


**Currently(JSON - High token usage):**
```json
[
  {
    "file_path": "src/main.rs",
    "line_number": 10,
    "content": "fn main() {",
    "confidence": 0.9
  },
  {
    "file_path": "src/main.rs",
    "line_number": 15,
    "content": "    println!(\"Hello\");",
    "confidence": 0.8
  }
]
```

**New (Dense Format- ~60% less tokens):**
```text
src/main.rs: 10-15: main: function 
fn main() {
    println!("Hello");
```

Maybe we could add an option to the MCP endpoint letting the LLM decide the output format.