### PR TITLE
call_path + rewrite_symbol hardening (dogfood-driven)

### DIFF
--- a/.memories/2026-04-19/155211_c0b2.md
+++ b/.memories/2026-04-19/155211_c0b2.md
@@ -1,0 +1,59 @@
+---
+id: checkpoint_c0b22847
+timestamp: 2026-04-19T15:52:11.283Z
+tags:
+  - rewrite_symbol
+  - call_path
+  - dogfood
+  - hardening
+  - team-dispatch
+git:
+  branch: feature/call-path-rewrite-symbol-hardening
+  commit: ff4de4ac
+  files:
+    - .gitignore
+    - README.md
+summary: "Phase 1 complete: plan approved, 2 teammates dispatched for call_path
+  + rewrite_symbol hardening"
+briefId: julie-world-class-systems-program
+type: checkpoint
+next: Wait for teammate reports; do inline review per spec compliance + code
+  quality; run cargo xtask test dev once both land; invoke pre-merge-review with
+  Codex; finish with finishing-a-development-branch.
+confidence: 4
+---
+
+## Phase 1 complete: plan approved, 2 teammates dispatched for call_path + rewrite_symbol hardening
+
+Dogfood session surfaced two real bugs in Julie's v1 tools. Plan written, Codex-reviewed, revised to drop scope creep, approved by user.
+
+### What surfaced
+
+**rewrite_symbol**:
+- `replace_signature` silently clobbers the whole symbol when the grammar's `body` field is missing (rewrite_symbol.rs:321 falls back to full_range). Direct violation of the v1 acceptance criterion "unsupported operations fail with narrow, specific errors."
+- `replace_body` produces broken code when caller passes content without the brace-inclusive block (span is tree-sitter `body` field = `{...}` in brace-delimited grammars).
+- No-op detection at `format_unified_diff` is shared across all rewrite ops but returns a header-only empty diff with no "no change" message.
+
+**call_path**:
+- No disambiguation param when `from` or `to` resolves to multiple symbols (unlike `deep_dive`'s `context_file`). And a single `context_file` wouldn't work anyway since endpoints can be in different files.
+- `edge_label` has unreachable branches (Extends/Implements and `_ => "reference"`); BFS only traverses Calls/Instantiates/Overrides.
+- Qualified names (e.g. `JulieServerHandler::call_tool`) fail for methods defined in trait impls because extractor doesn't link `parent_id` to the struct name.
+
+### Revised plan (after Codex review)
+
+Deliberately **did NOT add** post-edit tree-sitter round-trip validation — that's feature creep beyond the original "narrow tool, one job" design. Instead, close the "caller blind to span" gap by showing the replaced span's old content in dry-run output (Task 3).
+
+### Execution
+
+- Branch: `feature/call-path-rewrite-symbol-hardening` off main
+- Team: `call-path-rewrite-symbol-team`
+- Teammate A (`rewrite-symbol-impl`, Sonnet): Tasks 1-4, 7 → rewrite_symbol.rs and tests
+- Teammate B (`call-path-impl`, Sonnet): Tasks 5, 6, 8 → call_path.rs, resolution.rs helper, tests
+- Pre-merge review: Codex (per user's approval message)
+- Test command: `cargo xtask test dev` (lead only — subagents run narrow tests)
+
+### Key plan docs
+
+- Current plan: `docs/plans/2026-04-19-call-path-and-rewrite-symbol-hardening.md`
+- Original v1 design: `docs/plans/2026-04-17-agent-tool-surface-design.md` (cited to prevent scope creep)
+- Original v1 implementation: `docs/plans/2026-04-17-agent-tool-surface-implementation.md`

--- a/.memories/autonomous-run-2026-04-19-call-path-rewrite-symbol-hardening.md
+++ b/.memories/autonomous-run-2026-04-19-call-path-rewrite-symbol-hardening.md
@@ -1,0 +1,82 @@
+# Autonomous Execution Report — call_path and rewrite_symbol hardening
+
+**Status:** Complete
+**Plan:** docs/plans/2026-04-19-call-path-and-rewrite-symbol-hardening.md
+**Branch:** feature/call-path-rewrite-symbol-hardening
+**PR:** (filled by Step 7 terminal pointer after gh pr create)
+**Duration:** ~3h (dogfood → plan → approval → team dispatch → review → fix → push)
+**Phases:** 1/1 complete (single team-driven execution phase)
+**Tasks:** 8/8 complete (all plan tasks; plus 2 on-the-path fixes)
+
+## What shipped
+
+- **Task 1** (`rewrite_symbol`): `replace_signature` and `replace_body` now return explicit errors when the grammar's `body` field is missing (kills the silent full-symbol clobber for Rust trait methods, Java interface methods, and any declaration-without-body across all 34 languages). Field-listing in `replace_body` error gives the caller the node's actual tree-sitter field names. Commit `f0e84a39`.
+- **Task 2** (`rewrite_symbol`): centralized no-op detection. If `modified_content == original_content`, return an informational "No changes" message instead of an empty diff. Applies to all 6 operations. Skips `EditingTransaction` begin on no-op. Commit `f0e84a39`.
+- **Task 3** (`rewrite_symbol`): dry-run output now includes the replaced span's byte range, line range, and old content (with 15-head/5-tail elision for spans over 30 lines). Closes the "caller blind to the span" footgun that led to the original `replace_body`-without-braces corruption. Commit `f0e84a39`.
+- **Task 4** (`rewrite_symbol`): per-operation docstring rewritten to spell out grammar dependence — brace-delimited vs indent-delimited, declarations-without-body error condition. Commit `f0e84a39`.
+- **Task 5** (`call_path`): added `from_file_path` and `to_file_path` optional params. New `file_path_matches_suffix` helper in `resolution.rs` (pub fn, reusable). Replaces `.contains()` with segment-aware suffix matching. Commit `2f976f4b`.
+- **Task 6** (`call_path`): `edge_label` and `relationship_priority` now exhaustive over the three BFS-traversed kinds (`Calls`, `Instantiates`, `Overrides`) with `unreachable!` for filtered-out variants. Removed dead `Extends | Implements` and `_ => "reference"` branches. Commit `2f976f4b`.
+- **Task 7** (tests): 11 cross-language tests for `rewrite_symbol` across Python, Java, Ruby, Go, Rust. Includes a byte-for-byte file-unchanged regression test for the Rust trait method `replace_signature` case — the primary bug this hardening pass was designed to prevent. Commit `cd4ebcf3`.
+- **Task 8** (tests): 6 active + 1 `#[ignore]`d tests for `call_path` disambiguation, covering all 5 plan acceptance cases plus the qualified-name pass case plus the trait-impl-limitation documentation case. Commits `f90db57e`, `4d3e707c`.
+- **On-the-path fix** (xtask): added new `call_path_*` test modules to the `tools-misc` bucket in `test_tiers.toml` (they weren't in any bucket — would have silently missed regression). Bumped `tools-misc` timeout from 120s to 210s (14 sequential nextest invocations blew past old timeout). Updated matching manifest contract test. Commits `6e218b37`, `a7eb3c46`.
+- **On-the-path fix** (dashboard): updated `test_projects_page_shows_workspace_controls_and_cleanup_log` and `test_projects_page_keeps_row_actions_compact` to match the Open→Refresh UI change from commit `5bb843ed` on main. Pre-existing regression on main that was blocking `cargo xtask test dev`. Commit `295894ab`.
+- **Codex-review follow-up** (`rewrite_symbol`): replaced `.contains()` substring filter at `rewrite_symbol.rs:493` with `file_path_matches_suffix`, and bypassed `find_symbol`'s inner substring filter by passing `None`. Added two regression tests covering suffix-vs-substring and bogus-filter-not-found. Commit `6f86b1c7`.
+
+## Judgment calls (non-blocking decisions made)
+
+- `docs/plans/2026-04-19-call-path-and-rewrite-symbol-hardening.md:Task 3` — Chose visibility (show old span in dry-run) over validation (round-trip tree-sitter re-parse) because the original v1 design says "narrow tool, one job" and the validation was feature creep beyond what the plan was meant to cover. The silent-corruption class of bug is caught by letting the caller see the braces in the old content.
+- `src/tools/navigation/resolution.rs:194` — Made `file_path_matches_suffix` `pub fn` rather than `pub(crate)` because it's a pure utility with no sensitive internals; max visibility for cross-module reuse.
+- `src/tools/navigation/call_path.rs:resolve_unique_symbol` — Passed `None` to `find_symbol` (not the file_path filter) to apply a strict suffix filter afterward instead of `find_symbol`'s preferential-with-fallback semantics. Strict matching is correct for disambiguation; preferential was wrong semantics for `call_path`.
+- `src/tools/editing/rewrite_symbol.rs:488` (Codex fix) — Same choice: passed `None` to `find_symbol` to bypass its internal `.contains()` filter, then applied `file_path_matches_suffix` as the only filter. Mirrors `call_path`'s pattern.
+- `src/tests/tools/call_path_disambiguation_tests.rs:test_trait_impl_qualified_name_limitation` — Marked `#[ignore]` rather than flipping the assertion to pass. Reason: the expected long-term state is that trait-impl qualified names resolve correctly once the extractor is fixed; `#[ignore]` preserves that intent clearly and lets the test auto-pass when the underlying fix lands.
+- `xtask/test_tiers.toml:tools-misc.timeout_seconds` — Bumped to 210s (expected 60s) rather than splitting the bucket. Splitting would restructure the xtask config in ways unrelated to this plan; a timeout bump is the minimal change.
+- `src/tests/dashboard/projects_actions.rs:140-147` — Fixed two failing dashboard tests on-the-path even though they were pre-existing on main. Reason: they were blocking `cargo xtask test dev` from going green, which blocks the pre-merge review gate. Small, localized, obvious (invert Open→Refresh in assertions).
+
+## External review (codex, adversarial)
+
+- **Findings:** 2 (both high severity)
+- **Verified real, fixed:** 1 (commit: `6f86b1c7`)
+  - `rewrite_symbol` substring-match file filter could mutate wrong file — fixed by using `file_path_matches_suffix` (the helper we already shipped for `call_path`) and bypassing `find_symbol`'s inner substring filter. Two regression tests added covering suffix-vs-substring and bogus-filter-not-found cases.
+- **Dismissed:** 1
+  - `rewrite_symbol` TOCTOU race between file read (line 557) and commit-via-rename — dismissed as **out-of-scope**. Reason: the plan scope was grammar-dependent silent clobbers and per-endpoint disambiguation UX, not concurrent-write safety. Race pre-dates this plan, affects all editing paths (not just `rewrite_symbol`), and fixing properly needs a separate design decision (digest vs mtime vs hash-of-snapshot; user-facing stale-file error semantics). Filed as follow-up.
+- **Flagged for your review:** 0
+
+(codex-cli does not surface per-request token counts in its JSON output; cost line omitted by design.)
+
+## Tests
+
+All 10 xtask dev-tier buckets pass (265.6s total): cli, core-database, core-embeddings, tools-get-context, tools-search, tools-workspace, tools-misc, core-fast, daemon, dashboard. Narrow tests for this plan's work: 95 passing (feature work) + 2 passing (Codex-fix regression tests). No failures, no flakes.
+
+## Blockers hit
+
+None. Two issues surfaced during execution were resolved in-band:
+
+1. Brief compile blocker when `rewrite-symbol-impl` ran tests before `call-path-impl`'s `pub(crate) fn edge_label` commit landed — self-resolved within the same commit batch.
+2. `cargo xtask test dev` failed on pre-existing dashboard tests on main (Open→Refresh UI drift); fixed on-the-path with a two-line test update.
+
+## Files changed
+
+```
+ .memories/2026-04-19/155211_c0b2.md                |  59 +++
+ docs/plans/2026-04-19-call-path-and-rewrite-symbol-hardening.md | 284 +++++
+ src/tests/dashboard/projects_actions.rs            |  13 +-
+ src/tests/mod.rs                                   |   5 +-
+ src/tests/tools/call_path_disambiguation_tests.rs  | 391 ++++++
+ src/tests/tools/call_path_tests.rs                 |  20 +-
+ src/tests/tools/editing/mod.rs                     |   1 +
+ src/tests/tools/editing/rewrite_symbol_cross_language_tests.rs | 421 ++++++
+ src/tests/tools/editing/rewrite_symbol_tests.rs    | 325 ++++
+ src/tools/editing/rewrite_symbol.rs                | 217 ++-
+ src/tools/navigation/call_path.rs                  |  55 ++-
+ src/tools/navigation/resolution.rs                 |   8 +
+ xtask/test_tiers.toml                              |   6 +-
+ xtask/tests/manifest_contract_tests.rs             |   6 +-
+ 14 files changed, 1744 insertions(+), 67 deletions(-)
+```
+
+## Next steps
+
+- Review the PR (link in terminal pointer)
+- **Follow-up: trait-impl parent_id extractor work.** The `#[ignore]`d test `test_trait_impl_qualified_name_limitation` documents that `Receiver::method` qualified names fail for methods defined in `impl Trait for Struct`. Fix is at the extractor level and needs to be done per-language for all 34 grammars (or at a shared layer that normalizes parent_id across trait impls).
+- **Follow-up: TOCTOU concurrent-write safety for `rewrite_symbol` (and `edit_file`).** Codex Finding #2. Needs a separate plan with design decisions: what's the expected digest (hash of snapshot vs mtime), what's the user-facing "stale file" error, does `EditingTransaction` take the check or does the caller?
+- **Follow-up: `rewrite_symbol.rs` file size.** 680 lines vs the 500-line CLAUDE.md limit. This hardening pass added 142 lines on top of an already-violating baseline. Refactor opportunistically on next touch — likely extract `span_for_operation` and helpers into a sibling module.

--- a/docs/plans/2026-04-19-call-path-and-rewrite-symbol-hardening.md
+++ b/docs/plans/2026-04-19-call-path-and-rewrite-symbol-hardening.md
@@ -1,0 +1,284 @@
+# call_path and rewrite_symbol Hardening Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use razorback:team-driven-development (on Claude Code) or razorback:subagent-driven-development (elsewhere) to implement this plan. Fall back to razorback:executing-plans for single-task or tightly-sequential plans.
+
+**Goal:** Fix the real bugs surfaced by dogfooding `call_path` and `rewrite_symbol`, close the cross-language gaps, and make both tools safe to use across Julie's 34 supported languages — not just Rust.
+
+**Architecture:** Close the gaps in the v1 "AST-backed rewrite" design (see `docs/plans/2026-04-17-agent-tool-surface-design.md`) without adding new guardrail axes. For `rewrite_symbol`: reject unsupported operations explicitly instead of silently clobbering (completes the original Task 2 acceptance criterion "unsupported operations fail with narrow, specific errors"), centralize no-op detection, surface the replaced span in dry-run so callers can see what they're about to overwrite, and document the per-operation grammar contract. For `call_path`: split disambiguation into per-endpoint file-path params with suffix-aware matching, and clean up the edge-label code to match what BFS actually traverses.
+
+**Tech Stack:** Rust, tree-sitter, tokio, anyhow, serde, rmcp. Existing helpers: `find_symbol`, `ExtractorManager`, `format_unified_diff`, `compare_symbols_by_priority_and_context`.
+
+---
+
+## Scope Note
+
+All the issues below were validated by (a) dogfood testing in a live MCP session, (b) reading the source, (c) a Codex second opinion, and (d) cross-checking against the original design at `docs/plans/2026-04-17-agent-tool-surface-design.md`. Several findings were caught by Codex and missed in the initial dogfood pass — in particular, the `replace_signature` full-symbol clobber and the no-op detection being shared across all rewrite operations, not just `replace_signature`. The plan deliberately does NOT add post-edit tree-sitter round-trip validation; that would be feature creep beyond the original "narrow tool, one job" design. The `replace_signature` clobber fix completes an acceptance criterion that was already in the original plan ("unsupported operations fail with narrow, specific errors") but wasn't honored in the v1 implementation.
+
+## File Structure
+
+**Modified:**
+- `src/tools/editing/rewrite_symbol.rs` — span_for_operation, call_tool, RewriteSymbolTool docstrings, dry-run output format
+- `src/tools/editing/validation.rs` — add `is_no_op(before, after)` helper (or similar) if needed; maybe expose to rewrite_symbol
+- `src/tools/navigation/call_path.rs` — CallPathTool schema, resolve_unique_symbol, resolve_endpoints, edge_label
+
+**Created (tests):**
+- `src/tests/tools/editing/rewrite_symbol_cross_language_tests.rs` — Python/Java/Ruby/Go coverage for the three body-affecting ops
+- `src/tests/tools/call_path_disambiguation_tests.rs` — from_file_path / to_file_path, duplicate names, trait-impl qualified names
+
+**Modified (tests):**
+- `src/tests/tools/editing/rewrite_symbol_tests.rs` — add replace_signature-clobber guard test, no-op detection test, dry-run span-preview test
+- `src/tests/tools/call_path_tests.rs` — add edge-label exhaustiveness test, multi-segment qualified name test
+
+---
+
+## Task 1: rewrite_symbol — explicit errors for unsupported ops
+
+**Files:**
+- Modify: `src/tools/editing/rewrite_symbol.rs:263-328` (span_for_operation)
+- Test: `src/tests/tools/editing/rewrite_symbol_tests.rs` (add new tests)
+
+**What to build:** Two safety fixes in `span_for_operation`:
+1. `replace_signature` currently falls back to `Ok(Some(full_range))` when the node has no `body` field (line 321-323). Silent full-symbol clobber. Replace with an explicit error: `"replace_signature is not supported for symbol '{name}' (kind: {kind}); it has no body-delimited signature in the {language} grammar."`
+2. `replace_body` error when `body` field is missing (line 288-294) should list the **node's actual field names** via `cursor_for_fields` / manual iteration over tree-sitter node fields, not the grammar-wide catalog. Message: `"Operation 'replace_body' is not supported for '{name}' ({kind}); node has fields: [{actual_fields}] but no 'body' field."`
+
+**Approach:**
+- For (1), keep the `node.child_by_field_name("body")` check but change the `else` branch to return an `Err` instead of `Ok(Some(full_range))`.
+- For (2), use `node.walk()` and iterate `TreeCursor::field_name()` across children to collect the set of field names the node actually has. If no fields, report `"no named fields"`.
+
+**Acceptance criteria:**
+- [ ] `replace_signature` on a Rust `trait` method declaration (no body) returns an explicit error, not a full-symbol replacement. Regression test asserts the file is unchanged.
+- [ ] `replace_body` on a Rust trait method declaration returns an error that lists the available field names on that node.
+- [ ] All existing rewrite_symbol tests still pass.
+- [ ] Cargo fmt + clippy clean.
+- [ ] Tests committed together with the implementation.
+
+---
+
+## Task 2: rewrite_symbol — centralized no-op detection
+
+**Files:**
+- Modify: `src/tools/editing/rewrite_symbol.rs:460-519` (call_tool main body)
+- Modify or create helper in `src/tools/editing/validation.rs` if useful
+- Test: `src/tests/tools/editing/rewrite_symbol_tests.rs`
+
+**What to build:** After `modified_content` is computed and before the dry-run/commit branch, detect `modified_content == original_content` and return an informational result instead of an empty diff. Apply to all rewrite operations, not just `replace_signature`. Messaging: `"No changes: {operation} with supplied content would not modify the file. Symbol '{name}' at {path}:{start_line}-{end_line} is already in the requested state."`
+
+**Approach:**
+- Insert a single check right after the `match self.operation.as_str() { ... }` block produces `modified_content`.
+- Skip the balance warning, diff formatting, and transaction commit on no-op.
+- Return the informational message in both dry_run and non-dry_run modes.
+
+**Acceptance criteria:**
+- [ ] `replace_signature` with identical content → no-op message, not empty diff.
+- [ ] `replace_body`, `replace_full`, `add_doc`, `insert_before`, `insert_after` with content that would produce no change → no-op message.
+- [ ] Non-dry-run no-op does not begin an `EditingTransaction` (no filesystem writes, no mtime change).
+- [ ] Tests cover at least two operations for no-op detection.
+- [ ] Tests committed together.
+
+---
+
+## Task 3: rewrite_symbol — show replaced span in dry-run output
+
+**Files:**
+- Modify: `src/tools/editing/rewrite_symbol.rs` — augment dry-run output to include the span being replaced
+- Test: `src/tests/tools/editing/rewrite_symbol_tests.rs`
+
+**What to build:** Close the "caller is blind to the span" footgun that led to the `replace_body`-without-braces silent corruption. Before the diff, show the caller what's about to be replaced: byte range, line range, and the old content itself (truncated if long).
+
+This keeps the tool's job narrow (per original design: "each tool has one job") and matches the "compact diff preview" shape already in place. No new validation axis, no parse-after-edit step — just give the caller the information they need to realize "oh, the braces are part of the span I'm replacing."
+
+**Approach:**
+- For operations that replace a span (`replace_full`, `replace_body`, `replace_signature`): once `span_for_operation` returns the `ByteRange`, capture `original_content[range.start..range.end]` and the corresponding line range.
+- For insert operations (`insert_before`, `insert_after`, `add_doc`): report the anchor byte/line where the insert happens. No "old content" to show.
+- In dry-run output, prepend a short header before the diff:
+  ```
+  Replacing 142 chars at bytes 1234..1376 (lines 76-83) in src/foo.rs
+  --- Old content ---
+  fn relationship_priority(kind: &RelationshipKind) -> u8 {
+      match kind {
+          RelationshipKind::Calls => 0,
+          ...
+      }
+  }
+  --- Diff ---
+  @@ -76,8 +76,8 @@
+   ...
+  ```
+- If old content is longer than ~30 lines, show the first 15 and last 5 with a `... N lines elided ...` marker. This keeps the preview compact.
+- Non-dry-run (apply) output keeps the existing compact summary — no behavior change there.
+
+**Acceptance criteria:**
+- [ ] Dry-run output for `replace_body`, `replace_full`, `replace_signature` includes the byte range, line range, and old content (or an elided form for long bodies).
+- [ ] Dry-run output for `insert_before`, `insert_after`, `add_doc` reports the anchor position without an "old content" section.
+- [ ] Non-dry-run output is unchanged.
+- [ ] Tests: (a) dry-run preview for `replace_body` on a Rust function shows the braces in the old content, (b) dry-run preview for `add_doc` shows the anchor line but no old content, (c) long-body elision works as spec'd.
+- [ ] Tests committed together.
+
+---
+
+## Task 4: rewrite_symbol — operation docstring clarity
+
+**Files:**
+- Modify: `src/tools/editing/rewrite_symbol.rs:32-58` (RewriteSymbolTool struct and its fields' docstrings)
+
+**What to build:** Replace the single-line `operation` docstring with per-operation semantics that are honest about grammar dependence. New docstring:
+
+```
+/// Operation to perform. All operations target the symbol's span as extracted from the
+/// language's tree-sitter grammar.
+///
+/// - replace_full: Replace the entire symbol span (signature + body if any).
+/// - replace_body: Replace the grammar's `body` field. For brace-delimited languages
+///   (Rust, C, Java, Go, JS/TS, C#, Swift, Kotlin, Scala, PHP, etc.) the replaced
+///   span INCLUDES the enclosing braces, so your `content` must supply the full
+///   `{ ... }` block. For indentation-delimited languages (Python) the replaced
+///   span is the indented suite. For declarations without a body (trait methods,
+///   interface methods, forward declarations) this operation returns an error.
+/// - replace_signature: Replace the text up to the start of the body field. Returns
+///   an error if the symbol has no body field.
+/// - insert_after / insert_before: Insert content on the line after/before the symbol.
+/// - add_doc: Insert a documentation comment before the symbol. Errors if the symbol
+///   already has documentation.
+```
+
+**Acceptance criteria:**
+- [ ] Struct docstrings accurately describe observable behavior for both brace-delimited and indent-delimited languages.
+- [ ] Docstring changes are reflected in the JSON schema produced by `schemars` (verify by building and inspecting the tool's schema output).
+
+---
+
+## Task 5: call_path — per-endpoint file-path disambiguation
+
+**Files:**
+- Modify: `src/tools/navigation/call_path.rs:27-135` (CallPathTool struct, resolve_unique_symbol, resolve_endpoints)
+- Test: `src/tests/tools/call_path_disambiguation_tests.rs` (create)
+
+**What to build:** Add two optional params to `CallPathTool`:
+```rust
+pub from_file_path: Option<String>,
+pub to_file_path: Option<String>,
+```
+Plumb each through `resolve_endpoints` → `resolve_unique_symbol(db, name, role, file_path: Option<&str>)`. Inside `resolve_unique_symbol`:
+1. Pass the `file_path` into `find_symbol` (it already accepts one).
+2. After retrieving matches, if the filter was provided, apply a **suffix-aware** filter: `match.file_path == filter || match.file_path.ends_with(&format!("/{}", filter))`. Do NOT use `.contains()` — that produces false positives (`handler.rs` would match `tools/handler.rs`).
+
+Update the ambiguity error to mention which param to set (`from_file_path` or `to_file_path` depending on role).
+
+**Approach:**
+- Look at `compare_symbols_by_priority_and_context` at `src/tools/navigation/resolution.rs:175-184` for the suffix-aware matching pattern; extract into a reusable helper: `fn file_path_matches_suffix(path: &str, query: &str) -> bool`.
+- Also consider using this helper inside `rewrite_symbol.rs:383-390`, which today uses `.contains()` — fix that while here.
+
+**Acceptance criteria:**
+- [ ] `call_path(from=..., to=..., from_file_path="src/handler.rs")` resolves ambiguous `from` name to the handler.rs match.
+- [ ] Suffix filter rejects `"handler.rs"` matching `"tools/something/handler.rs"` only when the full segment doesn't match — i.e. `src/tools/handler.rs` ends with `/handler.rs` ✓, but `src/foohandler.rs` does not ✓.
+- [ ] Ambiguity error message names the correct param (`from_file_path` vs `to_file_path`) per role.
+- [ ] Tests cover: (a) successful disambiguation with from_file_path, (b) successful disambiguation with to_file_path, (c) both simultaneously, (d) substring false-positive rejection, (e) still-ambiguous-after-filter case.
+- [ ] rewrite_symbol's `.contains()` filter at line 383-390 updated to suffix-aware matching via the shared helper.
+- [ ] Tests committed together.
+
+---
+
+## Task 6: call_path — edge_label cleanup
+
+**Files:**
+- Modify: `src/tools/navigation/call_path.rs:85-94` (edge_label) and `76-83` (relationship_priority)
+- Test: `src/tests/tools/call_path_tests.rs`
+
+**What to build:** Clean up two functions that contain dead code given the BFS filter at line 161-168 (which keeps only `Calls`, `Instantiates`, `Overrides`).
+
+1. `edge_label`: Remove `Extends | Implements` branch (never reached — BFS filters them out). Remove `_ => "reference"` fallback (never reached). Make the match exhaustive over the three traversed kinds, with `debug_assert!(unreachable)` or `panic!` for the fallthrough.
+2. `relationship_priority`: Same treatment — the `_ => u8::MAX` arm is dead. Make exhaustive or panic-on-unreachable.
+3. Add a docstring to the module or to `CallPathTool` clarifying: `"BFS traverses Calls, Instantiates, and Overrides relationships only. Extends/Implements/TypeUsage/Reference edges are not followed."` — this matches the existing tool description but makes it internally consistent.
+
+**Acceptance criteria:**
+- [ ] Match statements are exhaustive over traversed kinds (or explicit `unreachable!` for the filtered-out kinds).
+- [ ] New test: `test_edge_label_exhaustive_over_traversed_kinds` asserts the labels for Calls → "call", Instantiates → "construct", Overrides → "dispatch".
+- [ ] Existing call_path tests still pass.
+- [ ] Tests committed together.
+
+---
+
+## Task 7: Cross-language tests for rewrite_symbol
+
+**Files:**
+- Create: `src/tests/tools/editing/rewrite_symbol_cross_language_tests.rs`
+- Register test module: `src/tests/tools/editing/mod.rs`
+
+**What to build:** End-to-end tests for rewrite_symbol on multiple grammar families. Each test runs the tool against a synthetic in-workspace file and verifies the post-edit buffer. Cover at minimum:
+
+| Language | Test cases |
+|---|---|
+| Python | `replace_body` on a `def` with indented suite (pass); `replace_signature` on a `def` (pass). |
+| Java | `replace_body` on a method (brace-delimited, pass); `replace_signature` on an interface method declaration (no body) → expects explicit error from Task 1. |
+| Ruby | `replace_body` on a `def ... end` method (pass); `replace_signature` on a `def` (pass). |
+| Go | `replace_signature` on a func declaration (pass); `replace_body` on a method (pass). |
+| Rust | `replace_signature` on a trait method declaration (no body) → expects explicit error from Task 1; regression test asserts the file is unchanged on that error. |
+
+**Approach:**
+- Use the existing test fixture setup in `rewrite_symbol_tests.rs` (likely a temp workspace builder, see line 83 onward for pattern). Extend it to accept different source files per test.
+- Each test creates a small source file in the target language, runs `manage_workspace(operation="index")` on the temp workspace, then invokes the tool.
+- Assert on both: the returned `CallToolResult` content (error or success message) and the resulting file content (unchanged on error, correctly mutated on success).
+- Integrate with Task 3: for at least one brace-delimited `replace_body` case, assert that the dry-run preview includes the old-content section showing the enclosing braces.
+
+**Acceptance criteria:**
+- [ ] Five languages covered (Python, Java, Ruby, Go, Rust) with the cases above.
+- [ ] Tests that exercise Task 1's explicit-error behavior (declaration-without-body cases in Java and Rust) assert the file is unchanged and the error message names the operation and symbol.
+- [ ] At least one test asserts the dry-run preview shows the replaced span's old content (Task 3 integration).
+- [ ] Tests run with `cargo nextest run --lib rewrite_symbol_cross_language`.
+- [ ] Tests run fast (< 5s combined).
+- [ ] Tests committed together.
+
+---
+
+## Task 8: Cross-language tests for call_path
+
+**Files:**
+- Create: `src/tests/tools/call_path_disambiguation_tests.rs`
+- Register test module: `src/tests/tools/mod.rs`
+
+**What to build:** Tests covering the per-endpoint disambiguation params and the qualified-name trait-impl case.
+
+Cases:
+1. Duplicate symbol name in two files (e.g., two `process` functions in `src/a.rs` and `src/b.rs`), path from one specific file resolves correctly via `from_file_path`.
+2. Cross-file path: `from` in `a.rs`, `to` in `b.rs`, both disambiguated by their respective file-path params.
+3. Substring false-positive: `from_file_path="handler.rs"` when only `tools/foohandler.rs` exists → resolution fails with a clear error (not a false match).
+4. Multi-segment qualified name that Julie currently supports (e.g., `MyStruct::my_method` where both parent and child are indexed). Pass case.
+5. Trait-impl qualified name (currently broken case surfaced in dogfood): `JulieServerHandler::call_tool` where `call_tool` is defined in `impl Trait for Struct`. Expected behavior: document current limitation with a test that either (a) passes if extractor already links parent_id correctly, or (b) fails with a clear error message rather than silently "not found". If this turns out to be an extractor fix, file a follow-up issue and keep the test as `#[ignore]` with a clear reason.
+
+**Acceptance criteria:**
+- [ ] All five cases covered.
+- [ ] For case 5 specifically: the tool returns a helpful error, not a bare "not found", OR the extractor is updated to populate parent_id from trait impls (scope the extractor change to this task only if it is a one-line change; otherwise file a follow-up and `#[ignore]` the test).
+- [ ] Tests committed together.
+
+---
+
+## Sequencing and Dependencies
+
+- **Parallel bucket A** (rewrite_symbol, all same file — sequential per-teammate within the bucket):
+  - Task 1 → Task 2 → Task 3 → Task 4 → Task 7
+- **Parallel bucket B** (call_path, all same file — sequential per-teammate within the bucket):
+  - Task 5 → Task 6 → Task 8
+
+Bucket A and bucket B are independent (different files). Assign each bucket to a separate teammate. Do NOT split a bucket across teammates (Tasks 1, 2, 3 all edit the same function in `rewrite_symbol.rs`; Tasks 5 and 6 both edit `call_path.rs`).
+
+If a third teammate is available, they can pick up Task 7 and Task 8 once the corresponding implementation tasks land.
+
+## Test Strategy
+
+- During RED/GREEN loops: `cargo nextest run --lib <specific_test_name>`.
+- After each task batch completes in a teammate: the teammate runs only the narrow test(s) they wrote (subagent rule).
+- Lead runs `cargo xtask test changed` once the batch lands, escalating to `cargo xtask test dev` if `changed` falls back to `dev`.
+- Final pre-merge: `cargo xtask test full` (covers dev + system + dogfood).
+
+## Non-goals
+
+- No changes to the tree-sitter grammars themselves.
+- No new rewrite operations (e.g., `replace_body_contents` as a separate op). Keep v1 scoped to fixing the current operations' contracts. If we later want body-interior semantics, that is a new plan.
+- No changes to `find_symbol` semantics. The trait-impl limitation for qualified names is an extractor-level question, in scope only if it turns out to be trivial; otherwise it's a follow-up.
+- No changes to how `call_path` BFS filters relationships. The filter set stays `Calls | Instantiates | Overrides`.
+
+## Risks
+
+- **Old-content preview (Task 3) adds output size.** A 500-line `replace_full` on a 500-line symbol produces a big dry-run. Mitigation: the elision rule (first 15 + last 5 lines for content over ~30 lines) caps the output. Verify in test.
+- **Per-endpoint file_path params in `call_path` (Task 5)** change the tool schema. Existing MCP clients use named args, so this should be backward-compatible, but a schema dump comparison before/after would confirm.
+- **The `replace_signature` explicit-error change (Task 1)** is technically a behavior change for any caller that was relying on the full-symbol fallback. The fallback was never documented and produced data loss, so strictly an improvement, but worth calling out in release notes.

--- a/src/tests/dashboard/projects_actions.rs
+++ b/src/tests/dashboard/projects_actions.rs
@@ -137,13 +137,12 @@ async fn test_projects_page_shows_workspace_controls_and_cleanup_log() {
     assert!(html.contains("auto prune"));
     assert!(html.contains("missing path"));
     assert!(html.contains("projects-table-shell"));
-    assert!(html.contains("/projects/current_ws/open"));
+    assert!(html.contains("/projects/current_ws/refresh"));
     assert!(html.contains("/projects/stale_ws/open"));
     assert!(
         !html.contains("/projects/blocked_ws/open"),
         "blocked missing workspaces should not offer an inline prune/open action"
     );
-    assert!(!html.contains("/projects/current_ws/refresh"));
     assert!(!html.contains("/projects/current_ws/delete"));
     assert!(
         !html.contains("Reference Workspaces"),
@@ -180,16 +179,12 @@ async fn test_projects_page_keeps_row_actions_compact() {
         "projects table should render inside the responsive shell"
     );
     assert!(
-        html.contains(&format!("action=\"/projects/{workspace_id}/open\"")),
-        "row should keep the quick open action inline"
-    );
-    assert!(
-        !html.contains(&format!("action=\"/projects/{workspace_id}/refresh\"")),
-        "refresh should move out of the compact table row"
+        html.contains(&format!("action=\"/projects/{workspace_id}/refresh\"")),
+        "healthy row should keep the quick refresh action inline"
     );
     assert!(
         !html.contains(&format!("action=\"/projects/{workspace_id}/delete\"")),
-        "delete should move out of the compact table row"
+        "delete should stay out of the compact table row"
     );
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -100,8 +100,9 @@ pub mod tools {
 
     pub mod phase4_token_savings; // Phase 4: Data structure optimization token savings tests (skip_serializing_if)
 
-    pub mod call_path_tests;
-    pub mod filtering_tests; // Symbol filter pipeline tests (index-based refactor TDD) // call_path shortest-path navigation tests
+    pub mod call_path_tests; // call_path shortest-path navigation tests
+    pub mod call_path_disambiguation_tests; // call_path per-endpoint file-path disambiguation tests
+    pub mod filtering_tests; // Symbol filter pipeline tests (index-based refactor TDD)
 
     pub mod get_context_allocation_tests; // get_context token allocation tests
     pub mod get_context_formatting_tests; // get_context output formatting tests

--- a/src/tests/tools/call_path_disambiguation_tests.rs
+++ b/src/tests/tools/call_path_disambiguation_tests.rs
@@ -171,6 +171,96 @@ async fn test_disambiguation_both_file_paths() -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
+// Case 2b: to_file_path alone disambiguates an ambiguous `to` symbol
+// ---------------------------------------------------------------------------
+//
+// Two files each define a `result` function. `from` is unambiguous (only in
+// src/a.rs), but `to` has two candidates. to_file_path pins it to src/a.rs.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_disambiguation_to_file_path() -> Result<()> {
+    let files = &[
+        (
+            "src/a.rs",
+            "pub fn runner() { result(); }\npub fn result() {}\n",
+        ),
+        ("src/b.rs", "pub fn result() {}\n"),
+    ];
+    let (_temp_dir, handler) = setup_multi_file_workspace(files).await?;
+
+    // Without hint: `to` is ambiguous
+    let ambiguous_tool = CallPathTool {
+        from: "runner".to_string(),
+        to: "result".to_string(),
+        max_hops: 2,
+        workspace: Some("primary".to_string()),
+        from_file_path: None,
+        to_file_path: None,
+    };
+    let text = extract_text(&ambiguous_tool.call_tool(&handler).await?);
+    assert!(
+        text.contains("ambiguous"),
+        "expected ambiguity error for `to` without hint, got: {text}"
+    );
+
+    // With to_file_path: should resolve and find the 1-hop path
+    let tool = CallPathTool {
+        from: "runner".to_string(),
+        to: "result".to_string(),
+        max_hops: 2,
+        workspace: Some("primary".to_string()),
+        from_file_path: None,
+        to_file_path: Some("src/a.rs".to_string()),
+    };
+    let text = extract_text(&tool.call_tool(&handler).await?);
+    let response = try_parse_response(&text)
+        .unwrap_or_else(|| panic!("expected JSON response, got: {text}"));
+
+    assert!(
+        response.found,
+        "path should be found via to_file_path disambiguation: {response:?}"
+    );
+    assert_eq!(response.hops, 1);
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Case 2e: still-ambiguous after filter (filter matches multiple files)
+// ---------------------------------------------------------------------------
+//
+// Two files both named handler.rs in different directories each define
+// `process`. The filter "handler.rs" matches both (each path ends with
+// /handler.rs), so the error should still report "ambiguous" rather than
+// silently picking one.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_disambiguation_still_ambiguous_after_filter() -> Result<()> {
+    let files = &[
+        ("src/a/handler.rs", "pub fn process() { step(); }\npub fn step() {}\n"),
+        ("src/b/handler.rs", "pub fn process() {}\n"),
+    ];
+    let (_temp_dir, handler) = setup_multi_file_workspace(files).await?;
+
+    // "handler.rs" matches both src/a/handler.rs and src/b/handler.rs — still ambiguous
+    let tool = CallPathTool {
+        from: "process".to_string(),
+        to: "step".to_string(),
+        max_hops: 2,
+        workspace: Some("primary".to_string()),
+        from_file_path: Some("handler.rs".to_string()),
+        to_file_path: None,
+    };
+    let text = extract_text(&tool.call_tool(&handler).await?);
+    assert!(
+        text.contains("ambiguous"),
+        "filter matching two files should still report ambiguous, got: {text}"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Case 3: substring false-positive rejection
 // ---------------------------------------------------------------------------
 //

--- a/src/tests/tools/call_path_disambiguation_tests.rs
+++ b/src/tests/tools/call_path_disambiguation_tests.rs
@@ -1,0 +1,301 @@
+use anyhow::Result;
+use std::fs;
+
+use crate::handler::JulieServerHandler;
+use crate::tools::navigation::call_path::{CallPathResponse, CallPathTool};
+use crate::tools::workspace::ManageWorkspaceTool;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async fn setup_multi_file_workspace(
+    files: &[(&str, &str)],
+) -> Result<(TempDir, JulieServerHandler)> {
+    let temp_dir = TempDir::new()?;
+    let workspace_path = temp_dir.path().to_path_buf();
+
+    for (relative_path, content) in files {
+        let full_path = workspace_path.join(relative_path);
+        if let Some(parent) = full_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&full_path, content)?;
+    }
+
+    let handler = JulieServerHandler::new(workspace_path.clone()).await?;
+    let index_tool = ManageWorkspaceTool {
+        operation: "index".to_string(),
+        workspace_id: None,
+        path: Some(workspace_path.to_string_lossy().to_string()),
+        name: None,
+        force: Some(false),
+        detailed: None,
+    };
+    index_tool.call_tool(&handler).await?;
+
+    Ok((temp_dir, handler))
+}
+
+fn extract_text(result: &crate::mcp_compat::CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|block| {
+            serde_json::to_value(block).ok().and_then(|json| {
+                json.get("text")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            })
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn try_parse_response(text: &str) -> Option<CallPathResponse> {
+    serde_json::from_str(text).ok()
+}
+
+// ---------------------------------------------------------------------------
+// Case 1: from_file_path disambiguates an ambiguous `from` symbol
+// ---------------------------------------------------------------------------
+//
+// Two files each define a `process` function. Without a hint both are
+// returned and call_path errors with "ambiguous". With from_file_path
+// pointing at src/a.rs the correct symbol is selected and the path is found.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_disambiguation_from_file_path() -> Result<()> {
+    let files = &[
+        (
+            "src/a.rs",
+            "pub fn process() { helper(); }\npub fn helper() {}\n",
+        ),
+        ("src/b.rs", "pub fn process() {}\n"),
+    ];
+    let (_temp_dir, handler) = setup_multi_file_workspace(files).await?;
+
+    // Without hint: should error with "ambiguous"
+    let ambiguous_tool = CallPathTool {
+        from: "process".to_string(),
+        to: "helper".to_string(),
+        max_hops: 2,
+        workspace: Some("primary".to_string()),
+        from_file_path: None,
+        to_file_path: None,
+    };
+    let text = extract_text(&ambiguous_tool.call_tool(&handler).await?);
+    assert!(
+        text.contains("ambiguous"),
+        "expected ambiguity error without hint, got: {text}"
+    );
+
+    // With from_file_path: should resolve and find the 1-hop path
+    let tool = CallPathTool {
+        from: "process".to_string(),
+        to: "helper".to_string(),
+        max_hops: 2,
+        workspace: Some("primary".to_string()),
+        from_file_path: Some("src/a.rs".to_string()),
+        to_file_path: None,
+    };
+    let text = extract_text(&tool.call_tool(&handler).await?);
+    let response = try_parse_response(&text)
+        .unwrap_or_else(|| panic!("expected JSON response, got: {text}"));
+
+    assert!(
+        response.found,
+        "path should be found via from_file_path disambiguation: {response:?}"
+    );
+    assert_eq!(response.hops, 1);
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Case 2: both from_file_path and to_file_path disambiguate simultaneously
+// ---------------------------------------------------------------------------
+//
+// Two files each define `entry` and `target`. Without hints both endpoints
+// are ambiguous. With both file-path params the path is found.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_disambiguation_both_file_paths() -> Result<()> {
+    let files = &[
+        (
+            "src/a.rs",
+            "pub fn entry() { target(); }\npub fn target() {}\n",
+        ),
+        (
+            "src/b.rs",
+            "pub fn entry() { target(); }\npub fn target() {}\n",
+        ),
+    ];
+    let (_temp_dir, handler) = setup_multi_file_workspace(files).await?;
+
+    // Without hints: from is ambiguous
+    let ambiguous_tool = CallPathTool {
+        from: "entry".to_string(),
+        to: "target".to_string(),
+        max_hops: 2,
+        workspace: Some("primary".to_string()),
+        from_file_path: None,
+        to_file_path: None,
+    };
+    let text = extract_text(&ambiguous_tool.call_tool(&handler).await?);
+    assert!(
+        text.contains("ambiguous"),
+        "expected ambiguity error without hints, got: {text}"
+    );
+
+    // With both file paths: should resolve and find path
+    let tool = CallPathTool {
+        from: "entry".to_string(),
+        to: "target".to_string(),
+        max_hops: 2,
+        workspace: Some("primary".to_string()),
+        from_file_path: Some("src/a.rs".to_string()),
+        to_file_path: Some("src/a.rs".to_string()),
+    };
+    let text = extract_text(&tool.call_tool(&handler).await?);
+    let response = try_parse_response(&text)
+        .unwrap_or_else(|| panic!("expected JSON response, got: {text}"));
+
+    assert!(
+        response.found,
+        "path should be found with both file-path params disambiguating: {response:?}"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Case 3: substring false-positive rejection
+// ---------------------------------------------------------------------------
+//
+// Only src/tools/foohandler.rs exists. from_file_path="handler.rs" must NOT
+// match "foohandler.rs" via substring (the slash-boundary rule rejects it).
+// The resolver should return "not found" rather than a false match.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_disambiguation_no_substring_false_positive() -> Result<()> {
+    let files = &[(
+        "src/tools/foohandler.rs",
+        "pub fn process() { end_step(); }\npub fn end_step() {}\n",
+    )];
+    let (_temp_dir, handler) = setup_multi_file_workspace(files).await?;
+
+    // "handler.rs" ends_with of "foohandler.rs" would match via bare ends_with,
+    // but must NOT match with the slash-boundary rule.
+    let tool = CallPathTool {
+        from: "process".to_string(),
+        to: "end_step".to_string(),
+        max_hops: 2,
+        workspace: Some("primary".to_string()),
+        from_file_path: Some("handler.rs".to_string()),
+        to_file_path: None,
+    };
+    let text = extract_text(&tool.call_tool(&handler).await?);
+
+    // Should not produce a valid found=true response
+    let found_false_positive = try_parse_response(&text)
+        .map(|r| r.found)
+        .unwrap_or(false);
+    assert!(
+        !found_false_positive,
+        "handler.rs must not match foohandler.rs via substring: {text}"
+    );
+    // The error should mention "not found" (filter reduced matches to zero)
+    assert!(
+        text.contains("not found") || text.contains("Error"),
+        "expected not-found error for mismatched filter, got: {text}"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Case 4: multi-segment qualified name (MyStruct::my_method)
+// ---------------------------------------------------------------------------
+//
+// Qualified name resolution via "Parent::child" notation is supported by
+// find_symbol's Step 2 path. Verify that a method on a struct can be used as
+// the `from` endpoint of a call_path query.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_qualified_name_struct_method() -> Result<()> {
+    let source = "pub struct Processor;\n\
+                  impl Processor {\n\
+                      pub fn run(&self) { do_work(); }\n\
+                  }\n\
+                  pub fn do_work() {}\n";
+    let files = &[("src/lib.rs", source)];
+    let (_temp_dir, handler) = setup_multi_file_workspace(files).await?;
+
+    let tool = CallPathTool {
+        from: "Processor::run".to_string(),
+        to: "do_work".to_string(),
+        max_hops: 2,
+        workspace: Some("primary".to_string()),
+        from_file_path: None,
+        to_file_path: None,
+    };
+    let text = extract_text(&tool.call_tool(&handler).await?);
+    let response = try_parse_response(&text)
+        .unwrap_or_else(|| panic!("expected JSON response for qualified name, got: {text}"));
+
+    assert!(
+        response.found,
+        "qualified name Processor::run should resolve and find path to do_work: {response:?}"
+    );
+    assert_eq!(response.hops, 1);
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Case 5: trait-impl qualified name (known limitation)
+// ---------------------------------------------------------------------------
+//
+// Methods defined inside `impl Trait for Struct` blocks are not linked to the
+// implementing struct by parent_id in the Rust extractor — the method's
+// parent_id points to the trait, not the struct. As a result,
+// "ImplStruct::method" qualified lookup falls through to a literal name search
+// which finds nothing, and call_path returns a clear "not found" error.
+//
+// If this test starts passing without the #[ignore] it means the extractor
+// was fixed to populate parent_id from trait impls — remove the ignore then.
+#[ignore = "Trait-impl methods are not linked to the implementing struct by parent_id; \
+            SomeHandler::handle qualified lookup fails. Fix requires updating the Rust \
+            extractor's trait-impl resolution to set parent_id = impl struct, not trait."]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_trait_impl_qualified_name_limitation() -> Result<()> {
+    let source = "pub trait Runnable { fn run(&self); }\n\
+                  pub struct Worker;\n\
+                  impl Runnable for Worker {\n\
+                      fn run(&self) { inner(); }\n\
+                  }\n\
+                  pub fn inner() {}\n";
+    let files = &[("src/lib.rs", source)];
+    let (_temp_dir, handler) = setup_multi_file_workspace(files).await?;
+
+    let tool = CallPathTool {
+        from: "Worker::run".to_string(),
+        to: "inner".to_string(),
+        max_hops: 2,
+        workspace: Some("primary".to_string()),
+        from_file_path: None,
+        to_file_path: None,
+    };
+    let text = extract_text(&tool.call_tool(&handler).await?);
+    let response = try_parse_response(&text)
+        .unwrap_or_else(|| panic!("expected JSON response, got: {text}"));
+
+    assert!(
+        response.found,
+        "Worker::run should resolve via trait-impl qualified lookup: {response:?}"
+    );
+
+    Ok(())
+}

--- a/src/tests/tools/call_path_tests.rs
+++ b/src/tests/tools/call_path_tests.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use std::fs;
 
+use crate::extractors::RelationshipKind;
 use crate::handler::JulieServerHandler;
-use crate::tools::navigation::call_path::{CallPathHop, CallPathResponse, CallPathTool};
+use crate::tools::navigation::call_path::{CallPathHop, CallPathResponse, CallPathTool, edge_label};
 use crate::tools::workspace::ManageWorkspaceTool;
 use tempfile::TempDir;
 
@@ -55,6 +56,8 @@ async fn test_call_path_finds_shortest_call_chain() -> Result<()> {
         to: "leaf".to_string(),
         max_hops: 4,
         workspace: Some("primary".to_string()),
+        from_file_path: None,
+        to_file_path: None,
     };
 
     let result = tool.call_tool(&handler).await?;
@@ -93,6 +96,8 @@ async fn test_call_path_returns_found_false_when_no_path_exists() -> Result<()> 
         to: "leaf".to_string(),
         max_hops: 4,
         workspace: Some("primary".to_string()),
+        from_file_path: None,
+        to_file_path: None,
     };
 
     let result = tool.call_tool(&handler).await?;
@@ -123,6 +128,8 @@ async fn test_call_path_respects_max_hops() -> Result<()> {
         to: "leaf".to_string(),
         max_hops: 1,
         workspace: Some("primary".to_string()),
+        from_file_path: None,
+        to_file_path: None,
     };
 
     let result = tool.call_tool(&handler).await?;
@@ -162,6 +169,8 @@ async fn test_non_call_edge_not_traversed() -> Result<()> {
         to: "Doer".to_string(),
         max_hops: 4,
         workspace: Some("primary".to_string()),
+        from_file_path: None,
+        to_file_path: None,
     };
 
     let result = tool.call_tool(&handler).await?;
@@ -190,6 +199,8 @@ async fn test_call_path_workspace_isolation() -> Result<()> {
         to: "beta".to_string(),
         max_hops: 4,
         workspace: Some("nonexistent-workspace-id".to_string()),
+        from_file_path: None,
+        to_file_path: None,
     };
 
     // call_tool may propagate Err when workspace resolution fails outright,
@@ -212,4 +223,11 @@ async fn test_call_path_workspace_isolation() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[test]
+fn test_edge_label_exhaustive_over_traversed_kinds() {
+    assert_eq!(edge_label(&RelationshipKind::Calls), "call");
+    assert_eq!(edge_label(&RelationshipKind::Instantiates), "construct");
+    assert_eq!(edge_label(&RelationshipKind::Overrides), "dispatch");
 }

--- a/src/tests/tools/editing/mod.rs
+++ b/src/tests/tools/editing/mod.rs
@@ -4,6 +4,7 @@
 
 mod edit_file_tests;
 mod markdown_section_tests;
+mod rewrite_symbol_cross_language_tests;
 mod rewrite_symbol_tests;
 mod security_tests;
 pub mod transactional_editing_tests; // EditingTransaction and MultiFileTransaction tests

--- a/src/tests/tools/editing/rewrite_symbol_cross_language_tests.rs
+++ b/src/tests/tools/editing/rewrite_symbol_cross_language_tests.rs
@@ -1,0 +1,421 @@
+use anyhow::Result;
+use std::fs;
+use tempfile::TempDir;
+
+use crate::handler::JulieServerHandler;
+use crate::mcp_compat::CallToolResult;
+use crate::tools::workspace::ManageWorkspaceTool;
+
+fn extract_text(result: &CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|c| c.as_text())
+        .map(|t| t.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+async fn setup_workspace(files: &[(&str, &str)]) -> Result<(TempDir, JulieServerHandler)> {
+    let temp_dir = TempDir::new()?;
+    let workspace_path = temp_dir.path().to_path_buf();
+
+    for (relative_path, content) in files {
+        let absolute_path = workspace_path.join(relative_path);
+        if let Some(parent) = absolute_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&absolute_path, content)?;
+    }
+
+    let handler = JulieServerHandler::new(workspace_path.clone()).await?;
+    let index_tool = ManageWorkspaceTool {
+        operation: "index".to_string(),
+        workspace_id: None,
+        path: Some(workspace_path.to_string_lossy().to_string()),
+        name: None,
+        force: Some(false),
+        detailed: None,
+    };
+    index_tool.call_tool(&handler).await?;
+
+    Ok((temp_dir, handler))
+}
+
+// ── Python ───────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_python_replace_body_indented_suite() -> Result<()> {
+    let source = "def greet(name: str) -> str:\n    return f\"Hello, {name}\"\n";
+    let (temp_dir, handler) = setup_workspace(&[("greet.py", source)]).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_body".to_string(),
+        content: "    return \"Fixed\"\n".to_string(),
+        file_path: Some("greet.py".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        !text.contains("Error:"),
+        "Python replace_body should succeed, got: {text}"
+    );
+
+    let on_disk = fs::read_to_string(temp_dir.path().join("greet.py"))?;
+    assert!(
+        on_disk.contains("Fixed"),
+        "Python body should be updated, got: {on_disk}"
+    );
+    assert!(
+        on_disk.contains("def greet"),
+        "Python signature should be preserved, got: {on_disk}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_python_replace_signature() -> Result<()> {
+    let source = "def greet(name: str) -> str:\n    return f\"Hello, {name}\"\n";
+    let (temp_dir, handler) = setup_workspace(&[("greet.py", source)]).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_signature".to_string(),
+        content: "def greet(name: str, greeting: str = \"Hello\") -> str:".to_string(),
+        file_path: Some("greet.py".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        !text.contains("Error:"),
+        "Python replace_signature should succeed, got: {text}"
+    );
+
+    let on_disk = fs::read_to_string(temp_dir.path().join("greet.py"))?;
+    assert!(
+        on_disk.contains("greeting"),
+        "Python signature should be updated, got: {on_disk}"
+    );
+    assert!(
+        on_disk.contains("return"),
+        "Python body should be preserved, got: {on_disk}"
+    );
+
+    Ok(())
+}
+
+// ── Java ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_java_replace_body_brace_delimited() -> Result<()> {
+    let source = "public class Greeter {\n    public String greet(String name) {\n        return \"Hello, \" + name;\n    }\n}\n";
+    let (temp_dir, handler) = setup_workspace(&[("Greeter.java", source)]).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_body".to_string(),
+        content: "{\n        return \"Fixed\";\n    }".to_string(),
+        file_path: Some("Greeter.java".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        !text.contains("Error:"),
+        "Java replace_body should succeed, got: {text}"
+    );
+
+    let on_disk = fs::read_to_string(temp_dir.path().join("Greeter.java"))?;
+    assert!(
+        on_disk.contains("Fixed"),
+        "Java method body should be updated, got: {on_disk}"
+    );
+    assert!(
+        on_disk.contains("greet"),
+        "Java method name should be preserved, got: {on_disk}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_java_replace_body_dry_run_shows_braces_in_old_content() -> Result<()> {
+    // Verifies Task 3 integration: dry-run preview shows brace-inclusive old content.
+    let source = "public class Greeter {\n    public String greet(String name) {\n        return \"Hello, \" + name;\n    }\n}\n";
+    let (_temp_dir, handler) = setup_workspace(&[("Greeter.java", source)]).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_body".to_string(),
+        content: "{\n        return \"Fixed\";\n    }".to_string(),
+        file_path: Some("Greeter.java".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: true,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        text.contains("--- Old content ---"),
+        "Java dry-run should show old content section, got: {text}"
+    );
+    assert!(
+        text.contains('{') && text.contains('}'),
+        "Java dry-run old content should include enclosing braces, got: {text}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_java_interface_method_replace_signature_explicit_error() -> Result<()> {
+    // Java interface method declarations have no body. replace_signature must error.
+    let source = "public interface Greetable {\n    String greet(String name);\n}\n";
+    let (temp_dir, handler) = setup_workspace(&[("Greetable.java", source)]).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_signature".to_string(),
+        content: "String greet(String name, String greeting)".to_string(),
+        file_path: Some("Greetable.java".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        text.contains("Error:"),
+        "Java interface method replace_signature should return an error, got: {text}"
+    );
+
+    let on_disk = fs::read_to_string(temp_dir.path().join("Greetable.java"))?;
+    assert_eq!(
+        on_disk, source,
+        "Java interface file must be unchanged after error"
+    );
+
+    Ok(())
+}
+
+// ── Ruby ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ruby_replace_body_def_end() -> Result<()> {
+    let source = "def greet(name)\n  \"Hello, #{name}\"\nend\n";
+    let (temp_dir, handler) = setup_workspace(&[("greet.rb", source)]).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_body".to_string(),
+        content: "  \"Fixed\"\n".to_string(),
+        file_path: Some("greet.rb".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        !text.contains("Error:"),
+        "Ruby replace_body should succeed, got: {text}"
+    );
+
+    let on_disk = fs::read_to_string(temp_dir.path().join("greet.rb"))?;
+    assert!(
+        on_disk.contains("Fixed"),
+        "Ruby method body should be updated, got: {on_disk}"
+    );
+    assert!(
+        on_disk.contains("def greet"),
+        "Ruby method signature should be preserved, got: {on_disk}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ruby_replace_signature() -> Result<()> {
+    let source = "def greet(name)\n  \"Hello, #{name}\"\nend\n";
+    let (temp_dir, handler) = setup_workspace(&[("greet.rb", source)]).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_signature".to_string(),
+        content: "def greet(name, greeting = \"Hello\")".to_string(),
+        file_path: Some("greet.rb".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        !text.contains("Error:"),
+        "Ruby replace_signature should succeed, got: {text}"
+    );
+
+    let on_disk = fs::read_to_string(temp_dir.path().join("greet.rb"))?;
+    assert!(
+        on_disk.contains("greeting"),
+        "Ruby signature should be updated, got: {on_disk}"
+    );
+
+    Ok(())
+}
+
+// ── Go ───────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_go_replace_signature() -> Result<()> {
+    let source =
+        "package main\n\nfunc greet(name string) string {\n\treturn \"Hello, \" + name\n}\n";
+    let (temp_dir, handler) = setup_workspace(&[("greet.go", source)]).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_signature".to_string(),
+        content: "func greet(name string, greeting string) string".to_string(),
+        file_path: Some("greet.go".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        !text.contains("Error:"),
+        "Go replace_signature should succeed, got: {text}"
+    );
+
+    let on_disk = fs::read_to_string(temp_dir.path().join("greet.go"))?;
+    assert!(
+        on_disk.contains("greeting"),
+        "Go signature should be updated, got: {on_disk}"
+    );
+    assert!(
+        on_disk.contains("return"),
+        "Go body should be preserved, got: {on_disk}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_go_replace_body() -> Result<()> {
+    let source =
+        "package main\n\nfunc greet(name string) string {\n\treturn \"Hello, \" + name\n}\n";
+    let (temp_dir, handler) = setup_workspace(&[("greet.go", source)]).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_body".to_string(),
+        content: "{\n\treturn \"Fixed\"\n}".to_string(),
+        file_path: Some("greet.go".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        !text.contains("Error:"),
+        "Go replace_body should succeed, got: {text}"
+    );
+
+    let on_disk = fs::read_to_string(temp_dir.path().join("greet.go"))?;
+    assert!(
+        on_disk.contains("Fixed"),
+        "Go body should be updated, got: {on_disk}"
+    );
+    assert!(
+        on_disk.contains("func greet"),
+        "Go signature should be preserved, got: {on_disk}"
+    );
+
+    Ok(())
+}
+
+// ── Rust trait (regression from the dogfood incident) ────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rust_trait_method_replace_signature_explicit_error_and_file_unchanged() -> Result<()>
+{
+    // This is the primary regression test for the silent-clobber bug.
+    // Before the fix, replace_signature on a trait method would silently
+    // overwrite the entire symbol span. After the fix it must error.
+    let source = "pub trait Greetable {\n    fn greet(&self) -> String;\n}\n";
+    let (temp_dir, handler) = setup_workspace(&[("src/greet.rs", source)]).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_signature".to_string(),
+        content: "fn greet(&self, name: &str) -> String".to_string(),
+        file_path: Some("src/greet.rs".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        text.contains("replace_signature is not supported"),
+        "Must return explicit error for Rust trait method with no body, got: {text}"
+    );
+    assert!(
+        text.contains("greet"),
+        "Error should name the offending symbol, got: {text}"
+    );
+
+    let on_disk = fs::read_to_string(temp_dir.path().join("src/greet.rs"))?;
+    assert_eq!(
+        on_disk, source,
+        "File must be byte-for-byte identical after failed replace_signature"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rust_trait_method_replace_body_error_with_field_names() -> Result<()> {
+    let source = "pub trait Greetable {\n    fn greet(&self) -> String;\n}\n";
+    let (temp_dir, handler) = setup_workspace(&[("src/greet.rs", source)]).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_body".to_string(),
+        content: "{ String::from(\"hello\") }".to_string(),
+        file_path: Some("src/greet.rs".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        text.contains("node has fields:"),
+        "Error should list actual node field names, got: {text}"
+    );
+    assert!(
+        text.contains("no 'body' field"),
+        "Error should identify the missing body field, got: {text}"
+    );
+
+    let on_disk = fs::read_to_string(temp_dir.path().join("src/greet.rs"))?;
+    assert_eq!(
+        on_disk, source,
+        "File must be unchanged after failed replace_body"
+    );
+
+    Ok(())
+}

--- a/src/tests/tools/editing/rewrite_symbol_tests.rs
+++ b/src/tests/tools/editing/rewrite_symbol_tests.rs
@@ -948,3 +948,80 @@ async fn test_dry_run_long_body_elision() -> Result<()> {
 
     Ok(())
 }
+
+/// Regression test: file_path filter must use suffix semantics, not substring.
+/// `handler.rs` must match `src/tools/handler.rs` but NOT `src/tools/foohandler.rs`.
+#[tokio::test]
+async fn test_rewrite_symbol_file_path_filter_uses_suffix_not_substring() -> Result<()> {
+    let files = [
+        (
+            "src/tools/handler.rs",
+            "pub fn process() {\n    println!(\"handler\");\n}\n",
+        ),
+        (
+            "src/tools/foohandler.rs",
+            "pub fn process() {\n    println!(\"foohandler\");\n}\n",
+        ),
+    ];
+    let (_temp_dir, handler) = setup_indexed_workspace_with_files(&files).await?;
+
+    // With file_path="handler.rs", only src/tools/handler.rs should match.
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "process".to_string(),
+        operation: "replace_full".to_string(),
+        content: "pub fn process() { println!(\"updated\"); }".to_string(),
+        file_path: Some("handler.rs".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: true,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+
+    // Must resolve to the exact-suffix file, not produce an ambiguity error or wrong-file match.
+    assert!(
+        !text.starts_with("Error:"),
+        "Expected successful resolution to handler.rs, got: {text}"
+    );
+    assert!(
+        text.contains("src/tools/handler.rs"),
+        "Diff must reference src/tools/handler.rs, got: {text}"
+    );
+    assert!(
+        !text.contains("foohandler.rs"),
+        "foohandler.rs must not appear in the result, got: {text}"
+    );
+
+    Ok(())
+}
+
+/// Regression test: a bogus file_path filter that is not a valid suffix of any indexed path
+/// must return a not-found error, not a false positive from substring matching.
+#[tokio::test]
+async fn test_rewrite_symbol_file_path_bogus_filter_returns_not_found() -> Result<()> {
+    let files = [(
+        "src/tools/handler.rs",
+        "pub fn process() {\n    println!(\"handler\");\n}\n",
+    )];
+    let (_temp_dir, handler) = setup_indexed_workspace_with_files(&files).await?;
+
+    // "andler.rs" is a substring of "handler.rs" but NOT a valid path suffix (no leading `/`).
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "process".to_string(),
+        operation: "replace_full".to_string(),
+        content: "pub fn process() {}".to_string(),
+        file_path: Some("andler.rs".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: true,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+
+    assert!(
+        text.contains("Error:") && text.contains("not found"),
+        "Expected not-found error for bogus suffix filter, got: {text}"
+    );
+
+    Ok(())
+}

--- a/src/tests/tools/editing/rewrite_symbol_tests.rs
+++ b/src/tests/tools/editing/rewrite_symbol_tests.rs
@@ -700,3 +700,251 @@ async fn test_rewrite_symbol_keeps_primary_binding_snapshot_across_swap_window()
 
     Ok(())
 }
+
+// Task 1: explicit errors for unsupported ops
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_replace_signature_no_body_returns_explicit_error() -> Result<()> {
+    // Rust trait method declarations parse as function_signature_item (no body field).
+    // replace_signature must return an explicit error, not silently clobber the whole symbol.
+    let source = "pub trait Greetable {\n    fn greet(&self) -> String;\n}\n";
+    let (temp_dir, handler, _) = setup_indexed_workspace(source).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_signature".to_string(),
+        content: "fn greet(&self, name: &str) -> String".to_string(),
+        file_path: Some("src/test.rs".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        text.contains("replace_signature is not supported"),
+        "Expected explicit error for trait method with no body, got: {text}"
+    );
+    assert!(
+        text.contains("greet"),
+        "Error should name the symbol, got: {text}"
+    );
+
+    let on_disk = fs::read_to_string(temp_dir.path().join("src").join("test.rs"))?;
+    assert_eq!(
+        on_disk, source,
+        "File must be unchanged after replace_signature error"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_replace_body_error_lists_actual_field_names() -> Result<()> {
+    // replace_body on a trait method declaration should error and list the actual
+    // field names the node has (e.g., name, parameters, return_type) — not 'body'.
+    let source = "pub trait Greetable {\n    fn greet(&self) -> String;\n}\n";
+    let (temp_dir, handler, _) = setup_indexed_workspace(source).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_body".to_string(),
+        content: "{ String::from(\"hello\") }".to_string(),
+        file_path: Some("src/test.rs".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        text.contains("node has fields:"),
+        "Error should list actual node field names, got: {text}"
+    );
+    assert!(
+        text.contains("no 'body' field"),
+        "Error should mention the missing 'body' field, got: {text}"
+    );
+
+    let on_disk = fs::read_to_string(temp_dir.path().join("src").join("test.rs"))?;
+    assert_eq!(
+        on_disk, source,
+        "File must be unchanged after replace_body error"
+    );
+
+    Ok(())
+}
+
+// Task 2: no-op detection
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_replace_signature_noop_returns_info_message() -> Result<()> {
+    let source = "pub fn greet(name: &str) -> String {\n    format!(\"hello {name}\")\n}\n";
+    let (_temp_dir, handler, _) = setup_indexed_workspace(source).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_signature".to_string(),
+        content: "pub fn greet(name: &str) -> String".to_string(),
+        file_path: Some("src/test.rs".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        text.contains("No changes:"),
+        "Expected no-op info message, got: {text}"
+    );
+    assert!(
+        text.contains("greet"),
+        "No-op message should name the symbol, got: {text}"
+    );
+    assert!(
+        !text.contains("Applied"),
+        "No-op should not claim to have applied anything, got: {text}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_replace_body_noop_returns_info_message() -> Result<()> {
+    let source = "pub fn greet() {\n    println!(\"hello\");\n}\n";
+    let (_temp_dir, handler, _) = setup_indexed_workspace(source).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_body".to_string(),
+        content: "{\n    println!(\"hello\");\n}".to_string(),
+        file_path: Some("src/test.rs".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: false,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        text.contains("No changes:"),
+        "Expected no-op info message for replace_body with identical body, got: {text}"
+    );
+
+    Ok(())
+}
+
+// Task 3: dry-run span header
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dry_run_replace_body_shows_old_content_with_braces() -> Result<()> {
+    // The span header must show the old content so callers can see the braces
+    // are part of the replaced span and must be included in their 'content'.
+    let source = "pub fn greet() {\n    println!(\"hello\");\n}\n";
+    let (_temp_dir, handler, _) = setup_indexed_workspace(source).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "replace_body".to_string(),
+        content: "{\n    println!(\"hi there\");\n}".to_string(),
+        file_path: Some("src/test.rs".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: true,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        text.contains("--- Old content ---"),
+        "Dry-run preview should include old content header, got: {text}"
+    );
+    assert!(
+        text.contains('{') && text.contains('}'),
+        "Old content section should show enclosing braces, got: {text}"
+    );
+    assert!(
+        text.contains("Replacing"),
+        "Dry-run should show span replacement header, got: {text}"
+    );
+    assert!(
+        text.contains("bytes"),
+        "Replacement header should show byte range, got: {text}"
+    );
+    assert!(
+        text.contains("lines"),
+        "Replacement header should show line range, got: {text}"
+    );
+    assert!(
+        text.contains("--- Diff ---"),
+        "Dry-run should include diff section header, got: {text}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dry_run_add_doc_shows_anchor_no_old_content() -> Result<()> {
+    let source = "pub fn greet() {\n    println!(\"hello\");\n}\n";
+    let (_temp_dir, handler, _) = setup_indexed_workspace(source).await?;
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "greet".to_string(),
+        operation: "add_doc".to_string(),
+        content: "/// Greets the user.".to_string(),
+        file_path: Some("src/test.rs".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: true,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        text.contains("Inserting at byte"),
+        "Insert dry-run should report anchor byte position, got: {text}"
+    );
+    assert!(
+        !text.contains("--- Old content ---"),
+        "Insert dry-run must not include old content section, got: {text}"
+    );
+    assert!(
+        text.contains("--- Diff ---"),
+        "Insert dry-run should include diff section header, got: {text}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dry_run_long_body_elision() -> Result<()> {
+    // A body longer than 30 lines should show first 15 + last 5, rest elided.
+    let mut lines = vec!["pub fn long_fn() {".to_string()];
+    for i in 0..35u32 {
+        lines.push(format!("    let _x{i} = {i};"));
+    }
+    lines.push("}".to_string());
+    let source = lines.join("\n") + "\n";
+
+    let (_temp_dir, handler, _) = setup_indexed_workspace(&source).await?;
+
+    let new_body_lines: Vec<String> = (0..35u32)
+        .map(|i| format!("    let _x{i} = {};", i + 100))
+        .collect();
+    let new_body = format!("{{\n{}\n}}", new_body_lines.join("\n"));
+
+    let tool = crate::tools::editing::rewrite_symbol::RewriteSymbolTool {
+        symbol: "long_fn".to_string(),
+        operation: "replace_body".to_string(),
+        content: new_body,
+        file_path: Some("src/test.rs".to_string()),
+        workspace: Some("primary".to_string()),
+        dry_run: true,
+    };
+
+    let result = tool.call_tool(&handler).await?;
+    let text = extract_text(&result);
+    assert!(
+        text.contains("lines elided"),
+        "Long body should be elided in dry-run preview, got: {text}"
+    );
+
+    Ok(())
+}

--- a/src/tools/editing/rewrite_symbol.rs
+++ b/src/tools/editing/rewrite_symbol.rs
@@ -35,7 +35,21 @@ pub struct RewriteSymbolTool {
     /// Symbol name to edit (supports qualified names like `MyClass::method`)
     pub symbol: String,
 
-    /// Operation: replace_full, replace_body, replace_signature, insert_after, insert_before, add_doc
+    /// Operation to perform. All operations target the symbol's span as extracted from the
+    /// language's tree-sitter grammar.
+    ///
+    /// - replace_full: Replace the entire symbol span (signature + body if any).
+    /// - replace_body: Replace the grammar's `body` field. For brace-delimited languages
+    ///   (Rust, C, Java, Go, JS/TS, C#, Swift, Kotlin, Scala, PHP, etc.) the replaced
+    ///   span INCLUDES the enclosing braces, so your `content` must supply the full
+    ///   `{ ... }` block. For indentation-delimited languages (Python) the replaced
+    ///   span is the indented suite. For declarations without a body (trait methods,
+    ///   interface methods, forward declarations) this operation returns an error.
+    /// - replace_signature: Replace the text up to the start of the body field. Returns
+    ///   an error if the symbol has no body field.
+    /// - insert_after / insert_before: Insert content on the line after/before the symbol.
+    /// - add_doc: Insert a documentation comment before the symbol. Errors if the symbol
+    ///   already has documentation.
     pub operation: String,
 
     /// New code/text content for the operation
@@ -260,6 +274,46 @@ fn live_symbol_context(
     Ok(LiveSymbolContext { live_symbol, tree })
 }
 
+fn collect_node_field_names(node: Node<'_>) -> String {
+    let mut cursor = node.walk();
+    let mut field_names = std::collections::BTreeSet::new();
+    if cursor.goto_first_child() {
+        loop {
+            if let Some(name) = cursor.field_name() {
+                field_names.insert(name.to_string());
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    if field_names.is_empty() {
+        "no named fields".to_string()
+    } else {
+        field_names.into_iter().collect::<Vec<_>>().join(", ")
+    }
+}
+
+fn detect_language_name(file_path: &str) -> String {
+    crate::utils::language::detect_language(std::path::Path::new(file_path))
+        .map(|l| format!("{l:?}"))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+enum SpanContext {
+    Replace {
+        byte_start: usize,
+        byte_end: usize,
+        start_line: usize,
+        end_line: usize,
+        old_content: String,
+    },
+    Anchor {
+        byte: usize,
+        line: usize,
+    },
+}
+
 fn span_for_operation(
     operation: &str,
     original_content: &str,
@@ -285,17 +339,21 @@ fn span_for_operation(
                     live_symbol.name
                 )
             })?;
-            let body = node.child_by_field_name("body").ok_or_else(|| {
-                anyhow!(
-                    "Operation 'replace_body' is not supported for symbol '{}' ({:?})",
-                    live_symbol.name,
-                    live_symbol.kind
-                )
-            })?;
-            Ok(Some(ByteRange {
-                start: body.start_byte(),
-                end: body.end_byte(),
-            }))
+            match node.child_by_field_name("body") {
+                Some(body) => Ok(Some(ByteRange {
+                    start: body.start_byte(),
+                    end: body.end_byte(),
+                })),
+                None => {
+                    let fields_str = collect_node_field_names(node);
+                    Err(anyhow!(
+                        "Operation 'replace_body' is not supported for '{}' ({:?}); node has fields: [{}] but no 'body' field.",
+                        live_symbol.name,
+                        live_symbol.kind,
+                        fields_str
+                    ))
+                }
+            }
         }
         "replace_signature" => {
             let node = find_exact_span_node(
@@ -319,11 +377,60 @@ fn span_for_operation(
                     ),
                 }))
             } else {
-                Ok(Some(full_range))
+                let language_name = detect_language_name(&live_symbol.file_path);
+                Err(anyhow!(
+                    "replace_signature is not supported for symbol '{}' (kind: {:?}); it has no body-delimited signature in the {} grammar.",
+                    live_symbol.name,
+                    live_symbol.kind,
+                    language_name
+                ))
             }
         }
         "insert_before" | "insert_after" | "add_doc" => Ok(None),
         _ => Err(anyhow!("Unsupported operation '{}'", operation)),
+    }
+}
+
+fn format_span_header(ctx: &SpanContext, file_path: &str) -> String {
+    match ctx {
+        SpanContext::Replace {
+            byte_start,
+            byte_end,
+            start_line,
+            end_line,
+            old_content,
+        } => {
+            let char_count = byte_end - byte_start;
+            let mut header = format!(
+                "Replacing {char_count} chars at bytes {byte_start}..{byte_end} (lines {start_line}-{end_line}) in {file_path}\n--- Old content ---\n"
+            );
+            let lines: Vec<&str> = old_content.lines().collect();
+            const MAX_LINES: usize = 30;
+            const HEAD_LINES: usize = 15;
+            const TAIL_LINES: usize = 5;
+            if lines.len() > MAX_LINES {
+                for line in &lines[..HEAD_LINES] {
+                    header.push_str(line);
+                    header.push('\n');
+                }
+                let elided = lines.len() - HEAD_LINES - TAIL_LINES;
+                header.push_str(&format!("... {elided} lines elided ...\n"));
+                for line in &lines[lines.len() - TAIL_LINES..] {
+                    header.push_str(line);
+                    header.push('\n');
+                }
+            } else {
+                header.push_str(old_content);
+                if !old_content.ends_with('\n') {
+                    header.push('\n');
+                }
+            }
+            header.push_str("--- Diff ---\n");
+            header
+        }
+        SpanContext::Anchor { byte, line } => {
+            format!("Inserting at byte {byte} (line {line}) in {file_path}\n--- Diff ---\n")
+        }
     }
 }
 
@@ -457,21 +564,41 @@ impl RewriteSymbolTool {
             &target.workspace_root,
         )?;
 
-        let modified_content = match self.operation.as_str() {
+        let (modified_content, span_context) = match self.operation.as_str() {
             "replace_full" | "replace_body" | "replace_signature" => {
-                let range = span_for_operation(
+                let range = match span_for_operation(
                     &self.operation,
                     &original_content,
                     &live.live_symbol,
                     &live.tree,
-                )?
-                .ok_or_else(|| {
-                    anyhow!(
-                        "Operation '{}' did not resolve a byte range",
-                        self.operation
-                    )
-                })?;
-                replace_byte_range(&original_content, range, &self.content)?
+                ) {
+                    Ok(Some(r)) => r,
+                    Ok(None) => {
+                        return Err(anyhow!(
+                            "Operation '{}' did not resolve a byte range",
+                            self.operation
+                        ));
+                    }
+                    Err(e) => {
+                        return Ok(CallToolResult::text_content(vec![Content::text(format!(
+                            "Error: {e}"
+                        ))]));
+                    }
+                };
+                let old_content = original_content[range.start..range.end].to_string();
+                let start_line = original_content[..range.start].lines().count() + 1;
+                let end_line = start_line + old_content.lines().count().saturating_sub(1);
+                let modified = replace_byte_range(&original_content, range, &self.content)?;
+                (
+                    modified,
+                    SpanContext::Replace {
+                        byte_start: range.start,
+                        byte_end: range.end,
+                        start_line,
+                        end_line,
+                        old_content,
+                    },
+                )
             }
             "insert_before" | "add_doc" => {
                 if self.operation == "add_doc" && live.live_symbol.doc_comment.is_some() {
@@ -480,19 +607,31 @@ impl RewriteSymbolTool {
                         self.symbol
                     ))]));
                 }
-                insert_before_line(
-                    &original_content,
-                    live.live_symbol.start_byte as usize,
-                    &self.content,
-                )?
+                let byte = live.live_symbol.start_byte as usize;
+                let line = original_content[..byte].lines().count() + 1;
+                let modified = insert_before_line(&original_content, byte, &self.content)?;
+                (modified, SpanContext::Anchor { byte, line })
             }
-            "insert_after" => insert_after_line(
-                &original_content,
-                live.live_symbol.end_byte as usize,
-                &self.content,
-            )?,
+            "insert_after" => {
+                let byte = live.live_symbol.end_byte as usize;
+                let line = original_content[..byte].lines().count();
+                let modified = insert_after_line(&original_content, byte, &self.content)?;
+                (modified, SpanContext::Anchor { byte, line })
+            }
             _ => unreachable!(),
         };
+
+        if modified_content == original_content {
+            let message = format!(
+                "No changes: {} with supplied content would not modify the file. Symbol '{}' at {}:{}-{} is already in the requested state.",
+                self.operation,
+                self.symbol,
+                indexed_symbol.file_path,
+                live.live_symbol.start_line,
+                live.live_symbol.end_line
+            );
+            return Ok(CallToolResult::text_content(vec![Content::text(message)]));
+        }
 
         let balance_warning = if should_check_balance(&indexed_symbol.file_path) {
             check_bracket_balance(&original_content, &modified_content)
@@ -511,7 +650,11 @@ impl RewriteSymbolTool {
                 "rewrite_symbol dry_run for {} in {}",
                 self.symbol, indexed_symbol.file_path
             );
-            let mut message = format!("Dry run preview (set dry_run=false to apply):\n\n{}", diff);
+            let span_header = format_span_header(&span_context, &indexed_symbol.file_path);
+            let mut message = format!(
+                "Dry run preview (set dry_run=false to apply):\n\n{}{}",
+                span_header, diff
+            );
             if let Some(ref warning) = balance_warning {
                 message.push_str(&format!("\n\n{}", warning));
             }

--- a/src/tools/editing/rewrite_symbol.rs
+++ b/src/tools/editing/rewrite_symbol.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 use crate::extractors::{ExtractorManager, Symbol};
 use crate::handler::JulieServerHandler;
 use crate::mcp_compat::CallToolResultExt;
-use crate::tools::navigation::resolution::{WorkspaceTarget, resolve_workspace_filter};
+use crate::tools::navigation::resolution::{WorkspaceTarget, file_path_matches_suffix, resolve_workspace_filter};
 use crate::utils::file_utils::secure_path_resolution;
 use rmcp::model::{CallToolResult, Content};
 use tree_sitter::{Node, Parser, Tree};
@@ -485,12 +485,12 @@ impl RewriteSymbolTool {
             let symbols = crate::tools::deep_dive::data::find_symbol(
                 &db,
                 &symbol_name,
-                file_path_filter.as_deref(),
+                None,
             )?;
             let filtered = if let Some(ref filter) = file_path_filter {
                 symbols
                     .into_iter()
-                    .filter(|symbol| symbol.file_path.contains(filter.as_str()))
+                    .filter(|symbol| file_path_matches_suffix(&symbol.file_path, filter))
                     .collect()
             } else {
                 symbols

--- a/src/tools/navigation/call_path.rs
+++ b/src/tools/navigation/call_path.rs
@@ -14,7 +14,7 @@ use crate::mcp_compat::CallToolResultExt;
 use crate::tools::deep_dive::data::find_symbol;
 
 use super::lock_db;
-use super::resolution::{WorkspaceTarget, resolve_workspace_filter};
+use super::resolution::{WorkspaceTarget, file_path_matches_suffix, resolve_workspace_filter};
 
 fn default_max_hops() -> u32 {
     6
@@ -26,6 +26,8 @@ fn default_workspace() -> Option<String> {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
+/// BFS traverses Calls, Instantiates, and Overrides relationships only.
+/// Extends/Implements/TypeUsage/Reference edges are not followed.
 pub struct CallPathTool {
     pub from: String,
     pub to: String,
@@ -36,6 +38,10 @@ pub struct CallPathTool {
     pub max_hops: u32,
     #[serde(default = "default_workspace")]
     pub workspace: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_file_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_file_path: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -78,23 +84,34 @@ fn relationship_priority(kind: &RelationshipKind) -> u8 {
         RelationshipKind::Calls => 0,
         RelationshipKind::Instantiates => 1,
         RelationshipKind::Overrides => 2,
-        _ => u8::MAX,
+        _ => unreachable!("BFS only traverses Calls, Instantiates, and Overrides"),
     }
 }
 
-fn edge_label(kind: &RelationshipKind) -> &'static str {
+pub(crate) fn edge_label(kind: &RelationshipKind) -> &'static str {
     match kind {
         RelationshipKind::Calls => "call",
         RelationshipKind::Instantiates => "construct",
-        RelationshipKind::Extends | RelationshipKind::Implements | RelationshipKind::Overrides => {
-            "dispatch"
-        }
-        _ => "reference",
+        RelationshipKind::Overrides => "dispatch",
+        _ => unreachable!("BFS only traverses Calls, Instantiates, and Overrides"),
     }
 }
 
-fn resolve_unique_symbol(db: &SymbolDatabase, name: &str, role: &str) -> Result<Symbol> {
-    let matches = find_symbol(db, name, None)?;
+fn resolve_unique_symbol(
+    db: &SymbolDatabase,
+    name: &str,
+    role: &str,
+    file_path: Option<&str>,
+) -> Result<Symbol> {
+    let all_matches = find_symbol(db, name, None)?;
+    let matches: Vec<Symbol> = if let Some(filter) = file_path {
+        all_matches
+            .into_iter()
+            .filter(|s| file_path_matches_suffix(&s.file_path, filter))
+            .collect()
+    } else {
+        all_matches
+    };
     if matches.is_empty() {
         return Err(anyhow!(
             "Symbol '{}' for '{}' was not found. Use fast_search or deep_dive to verify the name.",
@@ -114,8 +131,9 @@ fn resolve_unique_symbol(db: &SymbolDatabase, name: &str, role: &str) -> Result<
             .collect::<Vec<_>>()
             .join("\n");
         return Err(anyhow!(
-            "Symbol '{}' for '{}' is ambiguous. Use a qualified name. Matches:\n{}",
+            "Symbol '{}' for '{}' is ambiguous. Use a qualified name or set '{}_file_path' to disambiguate. Matches:\n{}",
             name,
+            role,
             role,
             locations
         ));
@@ -123,9 +141,15 @@ fn resolve_unique_symbol(db: &SymbolDatabase, name: &str, role: &str) -> Result<
     Ok(matches.into_iter().next().expect("one symbol"))
 }
 
-fn resolve_endpoints(db: &SymbolDatabase, from: &str, to: &str) -> Result<ResolvedEndpoints> {
-    let from_symbol = resolve_unique_symbol(db, from, "from")?;
-    let to_symbol = resolve_unique_symbol(db, to, "to")?;
+fn resolve_endpoints(
+    db: &SymbolDatabase,
+    from: &str,
+    to: &str,
+    from_file_path: Option<&str>,
+    to_file_path: Option<&str>,
+) -> Result<ResolvedEndpoints> {
+    let from_symbol = resolve_unique_symbol(db, from, "from", from_file_path)?;
+    let to_symbol = resolve_unique_symbol(db, to, "to", to_file_path)?;
     let mut targets = HashSet::new();
     targets.insert(to_symbol.id);
     Ok(ResolvedEndpoints {
@@ -296,10 +320,13 @@ impl CallPathTool {
         let from = self.from.clone();
         let to = self.to.clone();
         let max_hops = self.max_hops;
+        let from_file_path = self.from_file_path.clone();
+        let to_file_path = self.to_file_path.clone();
 
         let response = tokio::task::spawn_blocking(move || -> Result<CallPathResponse> {
             let db = lock_db(&target.db, "call_path");
-            let endpoints = resolve_endpoints(&db, &from, &to)?;
+            let endpoints =
+                resolve_endpoints(&db, &from, &to, from_file_path.as_deref(), to_file_path.as_deref())?;
             let search = bfs_shortest_path(&db, &endpoints.from.id, &endpoints.targets, max_hops)?;
 
             if endpoints.targets.contains(&endpoints.from.id) {

--- a/src/tools/navigation/resolution.rs
+++ b/src/tools/navigation/resolution.rs
@@ -186,3 +186,11 @@ pub fn compare_symbols_by_priority_and_context(
     // Return Equal to allow caller to add final tiebreaker
     std::cmp::Ordering::Equal
 }
+
+/// True if `path` equals `filter` or has `filter` as a path-separated suffix.
+///
+/// Prevents false positives from bare `ends_with`: `"handler.rs"` matches
+/// `"src/tools/handler.rs"` (preceded by `/`) but NOT `"foohandler.rs"`.
+pub fn file_path_matches_suffix(path: &str, filter: &str) -> bool {
+    path == filter || path.ends_with(&format!("/{}", filter))
+}

--- a/src/tools/workspace/indexing/embeddings.rs
+++ b/src/tools/workspace/indexing/embeddings.rs
@@ -266,10 +266,4 @@ pub(crate) async fn spawn_workspace_embedding(
     total_symbols
 }
 
-/// Backward-compatible wrapper kept for call sites that are reference-specific.
-pub(crate) async fn spawn_target_workspace_embedding(
-    handler: &JulieServerHandler,
-    workspace_id: String,
-) -> usize {
-    spawn_workspace_embedding(handler, workspace_id).await
-}
+

--- a/xtask/test_tiers.toml
+++ b/xtask/test_tiers.toml
@@ -74,8 +74,8 @@ commands = ["cargo nextest run --lib tests::tools::workspace -- --skip search_qu
 
 [buckets.tools-misc]
 # Remaining tool tests with enough shared setup to keep together for the first pass.
-expected_seconds = 40
-timeout_seconds = 120
+expected_seconds = 60
+timeout_seconds = 210
 commands = [
   "cargo nextest run --lib tests::tools::get_symbols -- --skip search_quality",
   "cargo nextest run --lib tests::tools::get_symbols_target_workspace -- --skip search_quality",
@@ -91,6 +91,8 @@ commands = [
   "cargo nextest run --lib tests::tools::target_workspace_fast_refs_tests -- --skip search_quality",
   "cargo nextest run --lib tools::search::query_preprocessor::tests -- --skip search_quality",
   "cargo nextest run --lib tests::tools::metrics -- --skip search_quality",
+  "cargo nextest run --lib tests::tools::call_path_tests -- --skip search_quality",
+  "cargo nextest run --lib tests::tools::call_path_disambiguation_tests -- --skip search_quality",
 ]
 
 [buckets.core-fast]

--- a/xtask/tests/manifest_contract_tests.rs
+++ b/xtask/tests/manifest_contract_tests.rs
@@ -258,8 +258,8 @@ fn expected_buckets() -> BTreeMap<&'static str, ExpectedBucket> {
         (
             "tools-misc",
             ExpectedBucket {
-                expected_seconds: 40,
-                timeout_seconds: 120,
+                expected_seconds: 60,
+                timeout_seconds: 210,
                 commands: &[
                     "cargo nextest run --lib tests::tools::get_symbols -- --skip search_quality",
                     "cargo nextest run --lib tests::tools::get_symbols_target_workspace -- --skip search_quality",
@@ -275,6 +275,8 @@ fn expected_buckets() -> BTreeMap<&'static str, ExpectedBucket> {
                     "cargo nextest run --lib tests::tools::target_workspace_fast_refs_tests -- --skip search_quality",
                     "cargo nextest run --lib tools::search::query_preprocessor::tests -- --skip search_quality",
                     "cargo nextest run --lib tests::tools::metrics -- --skip search_quality",
+                    "cargo nextest run --lib tests::tools::call_path_tests -- --skip search_quality",
+                    "cargo nextest run --lib tests::tools::call_path_disambiguation_tests -- --skip search_quality",
                 ],
             },
         ),


### PR DESCRIPTION
## Status: Complete

## What shipped

**rewrite_symbol** — closes the silent-clobber class of bugs from the v1 design:
- `replace_signature` and `replace_body` now return explicit errors when the grammar's `body` field is missing (kills silent full-symbol clobber for Rust trait methods, Java interface methods, and any declaration-without-body across all 34 languages)
- Centralized no-op detection (`modified_content == original_content` → informational message, no `EditingTransaction` begun)
- Dry-run output now shows the replaced span's byte range, line range, and old content (with 15-head/5-tail elision >30 lines). Closes the "caller blind to the span" footgun that enabled the original `replace_body`-without-braces corruption
- Per-operation docstring rewritten to spell out grammar dependence
- `file_path` filter now uses suffix-aware matching, not `.contains()` (Codex review finding — could have mutated the wrong file)

**call_path** — closes v1 design gaps:
- Added `from_file_path` and `to_file_path` optional params with suffix-aware matching (new `file_path_matches_suffix` helper in `resolution.rs`)
- `edge_label` and `relationship_priority` now exhaustive over the three BFS-traversed kinds (`Calls`, `Instantiates`, `Overrides`) with `unreachable!` for filtered-out variants. Removed dead branches.

**Tests:**
- 11 new cross-language tests for `rewrite_symbol` (Python, Java, Ruby, Go, Rust), including a byte-for-byte file-unchanged regression test for the Rust trait method case — the primary bug this pass was designed to prevent
- 6 active + 1 `#[ignore]`d tests for `call_path` disambiguation, covering all 5 plan acceptance cases
- 2 regression tests covering Codex's substring-vs-suffix finding

**xtask:**
- Added `call_path_*` test modules to the `tools-misc` bucket (they weren't in any bucket — would have silently missed future regression)
- Bumped `tools-misc` timeout 120s → 210s (16 sequential nextest invocations now)

**On-the-path fixes:**
- Two pre-existing dashboard tests on main broken by the Open→Refresh UI change (commit 5bb843ed); fixed assertions to match current UI

## External review (codex, adversarial)

- 2 findings, both high severity
- **Fixed (1):** `rewrite_symbol` substring file-path matching could mutate wrong file — fixed in commit 6f86b1c7 using the `file_path_matches_suffix` helper we already shipped for `call_path`. Two regression tests added.
- **Dismissed (1, out-of-scope):** TOCTOU race between read and commit-via-rename. Pre-dates this plan; affects all editing paths; needs separate design. Filed as follow-up in the full report.
- **Flagged for human review:** 0

## Blockers hit

None.

## Test plan
- [ ] `cargo xtask test dev` green (verified: 10/10 buckets pass in 265.6s)
- [ ] Live MCP smoke: rebuild release binary, run `rewrite_symbol` with `replace_signature` on a trait method declaration, verify explicit error and file unchanged
- [ ] Live MCP smoke: run `call_path` with ambiguous `from` name and `from_file_path` hint, verify resolution

## Next steps

See the full report at `.memories/autonomous-run-2026-04-19-call-path-rewrite-symbol-hardening.md` (committed in this PR) for:
- Complete judgment calls log
- Detailed Codex review and dismissal reasons
- Three follow-up items (trait-impl extractor work, TOCTOU concurrent-write safety, `rewrite_symbol.rs` file size refactor)