### PR TITLE
feat(dashboard): rework search analysis into diagnostic tool

### DIFF
--- a/.memories/2026-04-20/152304_cc31.md
+++ b/.memories/2026-04-20/152304_cc31.md
@@ -1,0 +1,49 @@
+---
+id: checkpoint_cc31220a
+timestamp: 2026-04-20T15:23:04.644Z
+tags:
+  - docs
+  - plan
+  - search
+  - dashboard
+  - observability
+git:
+  branch: main
+  commit: c1204301
+  files:
+    - docs/plans/2026-04-19-dependency-upgrade-audit-design.md
+    - docs/plans/2026-04-19-dependency-upgrade-audit-implementation-plan.md
+    - docs/plans/2026-04-19-miller-retrieval-port-design.md
+    - docs/plans/2026-04-19-tantivy-0.26-comparison-report.md
+    - docs/plans/2026-04-20-fast-search-observability-and-comparison-implementation-plan.md
+summary: Wrote fast_search observability implementation plan
+briefId: julie-world-class-systems-program
+type: checkpoint
+impact: Gives the search observability project a reviewable execution plan with
+  concrete module boundaries and test gates.
+symbols:
+  - docs/plans/2026-04-20-fast-search-observability-and-comparison-implementation-plan.md
+next: Ask the user to review and approve the implementation plan before starting
+  code changes.
+confidence: 5
+---
+
+## Wrote fast_search observability implementation plan
+
+### WHAT
+- Added `docs/plans/2026-04-20-fast-search-observability-and-comparison-implementation-plan.md`
+- Turned the earlier design spec into an execution plan with task-level file ownership, acceptance criteria, and verification gates
+- Anchored the plan to the current Julie seams: shared search execution, handler telemetry, daemon persistence, dashboard analysis, and compare views
+
+### WHY
+- The design doc answered *what* to build, but not *how* to land it without bloating the wrong files or breaking the hot path
+- This project touches oversized files and two product truths at once: the dashboard playground must stop lying, and search telemetry must stay cheap enough for live sessions
+
+### HOW
+- Broke the work into six tasks: shared execution core, telemetry enrichment, episode analysis, replay comparison, dashboard UX wiring, and verification
+- Called out new extraction points like `src/tools/search/execution.rs`, `src/tools/search/trace.rs`, and dashboard analysis modules so the plan does not feed `src/handler.rs` and `src/daemon/database.rs` more weight than they can carry
+- Included acceptance criteria around episode rules, useful downstream actions, same-symbol or same-file convergence, and compare metrics
+
+### IMPACT
+- The project now has a concrete implementation roadmap instead of a design that still needed translation work
+- Future implementation can proceed with clearer file boundaries, lower risk of dashboard fiction, and explicit search-quality verification gates

--- a/.memories/2026-04-20/162538_3c71.md
+++ b/.memories/2026-04-20/162538_3c71.md
@@ -1,0 +1,93 @@
+---
+id: checkpoint_3c718318
+timestamp: 2026-04-20T16:25:38.623Z
+tags:
+  - search
+  - dashboard
+  - telemetry
+  - comparison
+  - observability
+git:
+  branch: codex/fast-search-observability
+  commit: dc1b3453
+  files:
+    - dashboard/templates/partials/search_compare_results.html
+    - dashboard/templates/partials/search_episode_table.html
+    - dashboard/templates/partials/search_results.html
+    - dashboard/templates/search.html
+    - dashboard/templates/search_analysis.html
+    - dashboard/templates/search_compare.html
+    - src/daemon/database.rs
+    - src/dashboard/mod.rs
+    - src/dashboard/routes/mod.rs
+    - src/dashboard/routes/projects_actions.rs
+    - src/dashboard/routes/search.rs
+    - src/dashboard/routes/search_analysis.rs
+    - src/dashboard/routes/search_compare.rs
+    - src/dashboard/search_analysis.rs
+    - src/dashboard/search_compare.rs
+    - src/handler.rs
+    - src/handler/search_telemetry.rs
+    - src/handler/tool_targets.rs
+    - src/tests/core/handler_telemetry.rs
+    - src/tests/daemon/database.rs
+    - src/tests/dashboard/integration.rs
+    - src/tests/dashboard/mod.rs
+    - src/tests/dashboard/search_analysis.rs
+    - src/tests/mod.rs
+    - src/tests/tools/call_path_tests.rs
+    - src/tools/search/execution.rs
+    - src/tools/search/line_mode.rs
+    - src/tools/search/mod.rs
+    - src/tools/search/trace.rs
+    - src/tools/workspace/indexing/embeddings.rs
+summary: Implemented fast-search observability and comparison bench
+briefId: julie-world-class-systems-program
+type: checkpoint
+impact: Search work can now be evaluated with captured corpus data and dashboard
+  analysis instead of transcript archaeology.
+evidence:
+  - cargo nextest run --lib
+    test_dashboard_content_search_renders_line_match_preview
+  - cargo nextest run --lib test_fast_search_metadata_captures_trace_and_intent
+  - cargo nextest run --lib tests::dashboard::search_analysis
+  - cargo nextest run --lib test_insert_and_list_search_compare_runs_and_cases
+  - cargo nextest run --lib test_all_dashboard_pages_return_200
+  - cargo xtask test dogfood
+  - cargo xtask test dev
+symbols:
+  - FastSearchTool::execute_with_trace
+  - search_telemetry::fast_search_metadata
+  - tool_targets::get_symbols_metadata
+  - dashboard::search_analysis::analyze_tool_calls
+  - dashboard::search_compare::run_compare
+  - DaemonDatabase::list_tool_calls_for_search_analysis
+next: Review the compare metrics and decide whether the fixed strategy set
+  should grow into configurable ranking variants.
+confidence: 5
+---
+
+## Implemented fast-search observability and comparison bench
+
+### WHAT
+Added a shared search execution core that powers both `fast_search` and the dashboard playground, then layered structured telemetry, episode analysis, and a replay-style comparison bench on top.
+
+- Added structured search trace types and shared execution helpers in `src/tools/search/trace.rs` and `src/tools/search/execution.rs`
+- Refactored `FastSearchTool` and line-mode search so `fast_search` and dashboard search use the same execution path
+- Added fast-search metadata capture and downstream tool target metadata in `src/handler/search_telemetry.rs` and `src/handler/tool_targets.rs`
+- Added dashboard analysis and compare views plus daemon DB persistence for compare runs and cases
+- Added tests for telemetry extraction, episode grouping, compare-run persistence, and dashboard route coverage
+
+### WHY
+The harness transcript stopped being a reliable source of truth for search quality, which made first-hit tuning into guesswork. Julie needed its own visibility into what searches returned, how agents chained them, and whether alternate ranking paths would have done better.
+
+### HOW
+- Logged structured top-hit data into existing `tool_calls.metadata` instead of inventing a second metrics pipe
+- Derived search episodes from nearby `fast_search` calls within a session, using a burst-plus-boundary model that closes on the first non-search tool
+- Classified search outcomes into stalled, one-shot, reformulation-converged, and exploratory-success buckets
+- Built a dashboard compare flow that replays captured cases against `shared_current` and `legacy_direct` strategies and stores the results in daemon SQLite tables
+- Kept the request path lean by pushing analysis into the dashboard and daemon DB instead of live query scoring
+
+### IMPACT
+Julie now has an internal search truth surface that can expose top hits, downstream actions, and corpus-level search patterns without depending on harness UI behavior. The dashboard can compare strategies side by side, which turns search tuning from anecdotes into evidence.
+

--- a/.memories/autonomous-run-2026-04-20-search-analysis-diagnostic-rework.md
+++ b/.memories/autonomous-run-2026-04-20-search-analysis-diagnostic-rework.md
@@ -1,0 +1,75 @@
+# Autonomous Run Report: Search Analysis Diagnostic Rework
+
+**Status:** Complete
+**Branch:** `search-analysis-diagnostic-rework`
+**Base:** `main`
+**Plan:** `docs/plans/2026-04-20-search-analysis-diagnostic-rework-implementation-plan.md`
+**Design:** `docs/plans/2026-04-20-search-analysis-diagnostic-rework-design.md`
+**Date:** 2026-04-20
+
+## What shipped
+
+Reworked `/search/analysis` from a chronological episode feed into a diagnostic tool for improving search quality. The page now surfaces:
+
+- **First-try success rate** as a headline metric (one_shot_success / total episodes)
+- **Problem queries table** ranked by failure frequency, with canonical key grouping (handles CamelCase/snake_case/qualified name variants), recall-vs-ranking triage signal, avg scores, avg result counts
+- **Reformulation pairs table** showing adjacent query transitions from reformulated episodes, deduplicated by canonical key
+- **Filtered episode feed** defaulting to flagged-only (stalled + reformulated) with toggle for all
+
+Additional fixes:
+- Episode builder now splits on workspace_id change (cross-workspace searches no longer merge)
+- SearchEpisodeQuery widened with 4 Option trace fields (score, result_count, strategy, relaxed) extracted from existing telemetry JSON
+- EpisodeStats extended with outcome breakdown counts
+
+## Commits
+
+1. `69cf3c2d` feat(dashboard): widen search analysis data model and fix episode boundaries
+2. `bb89cb2d` feat(dashboard): add search quality aggregation functions
+3. `9f4a9af2` feat(dashboard): rework search analysis into diagnostic tool
+4. `92c42994` fix(dashboard): address codex review findings
+
+## Files changed
+
+| File | Lines |
+|------|-------|
+| `src/dashboard/search_analysis.rs` | +333/-8 |
+| `src/tests/dashboard/search_analysis.rs` | +362/-1 |
+| `dashboard/templates/search_analysis.html` | +136/-7 |
+| `dashboard/templates/partials/search_episode_table.html` | +19/-9 |
+| `src/dashboard/routes/search_analysis.rs` | +21/-2 |
+
+## Tests
+
+- Dev tier: 10/10 buckets pass (272.9s)
+- Search analysis unit tests: 22/22 pass
+- Dashboard integration tests: all pass (including `/search/analysis` 200 check)
+
+## External review
+
+**Reviewer:** codex (gpt-5.4, xhigh reasoning)
+**Verdict:** needs-attention (3 findings)
+**Findings fixed:** 3/3
+
+| # | Severity | Title | Classification | Action |
+|---|----------|-------|---------------|--------|
+| 1 | high | Triage treats any same-name hit as ranking win | real-improvement | Fixed: compare file path alongside symbol name |
+| 2 | medium | Zero-result failures render as missing data | real-bug | Fixed: use Tera `is number` test instead of truthiness |
+| 3 | medium | Reformulation pairs include unrelated hops | real-improvement | Fixed: filter to overlapping query pairs only |
+
+Fix commit: `92c42994`
+
+## Judgment calls
+
+- Chose `is number` for Tera zero-value handling over server-side string formatting. Keeps the data model clean; Tera has native type tests.
+- `fast_search_row_with_hit` test helper updated to use matching file path (`src/dashboard/routes/search.rs`) so triage test correctly exercises file-aware comparison.
+- "explore one"/"explore two" test queries replaced with "database pool"/"centrality badge" because the originals shared the "explore" token, triggering false overlap detection.
+
+## Blockers hit
+
+None.
+
+## Next steps
+
+- Accumulate telemetry data over a few days, then review the analysis page with real data
+- Consider adding a time-series trend for first-try success rate (requires storing historical snapshots)
+- The canonical_key filler token list may need tuning based on real query patterns

--- a/dashboard/templates/partials/search_compare_results.html
+++ b/dashboard/templates/partials/search_compare_results.html
@@ -1,0 +1,75 @@
+{% if compare_runs | length == 0 %}
+<div class="julie-card" style="text-align: center; padding: 2rem; color: var(--julie-text-muted);">
+  <p>No compare runs yet.</p>
+  <p style="margin-top: 0.5rem;">Run one after collecting a few search episodes.</p>
+</div>
+{% else %}
+<div class="julie-card" style="margin-bottom: 1rem;">
+  <p class="label-text" style="margin-bottom: 0.5rem;">Recent Runs</p>
+  {% for run in compare_runs %}
+  <div style="display: flex; justify-content: space-between; gap: 1rem; padding: 0.35rem 0; border-top: 1px solid var(--julie-border);">
+    <div>
+      <a class="mono" href="/search/compare?run_id={{ run.id }}">{{ run.baseline_strategy }} vs {{ run.candidate_strategy }}</a>
+      <span style="color: var(--julie-text-muted);">({{ run.case_count }} cases)</span>
+    </div>
+    <div class="mono" style="color: var(--julie-text-muted);">
+      top1 {{ run.baseline_top1_hits }} / {{ run.candidate_top1_hits }}
+    </div>
+  </div>
+  {% endfor %}
+</div>
+
+{% if selected_run %}
+<div class="julie-card" style="margin-bottom: 1rem;">
+  <div style="display: flex; gap: 1.5rem; flex-wrap: wrap;">
+    <div>
+      <p class="label-text">Strategies</p>
+      <p class="mono">{{ selected_run.baseline_strategy }} vs {{ selected_run.candidate_strategy }}</p>
+    </div>
+    <div>
+      <p class="label-text">Top 1 Hits</p>
+      <p class="mono">{{ selected_run.baseline_top1_hits }} / {{ selected_run.candidate_top1_hits }}</p>
+    </div>
+    <div>
+      <p class="label-text">Top 3 Hits</p>
+      <p class="mono">{{ selected_run.baseline_top3_hits }} / {{ selected_run.candidate_top3_hits }}</p>
+    </div>
+    <div>
+      <p class="label-text">Source Wins</p>
+      <p class="mono">{{ selected_run.baseline_source_wins }} / {{ selected_run.candidate_source_wins }}</p>
+    </div>
+    <div>
+      <p class="label-text">Convergence</p>
+      <p class="mono">{{ selected_run.convergence_rate | default(value=0.0) | round(method="floor", precision=2) }}</p>
+    </div>
+    <div>
+      <p class="label-text">Stall Rate</p>
+      <p class="mono">{{ selected_run.stall_rate | default(value=0.0) | round(method="floor", precision=2) }}</p>
+    </div>
+  </div>
+</div>
+
+<div class="julie-card">
+  <p class="label-text" style="margin-bottom: 0.5rem;">Cases</p>
+  {% for case in compare_cases %}
+  <div style="padding: 0.6rem 0; border-top: 1px solid var(--julie-border);">
+    <p class="mono" style="color: var(--julie-text);">{{ case.query }}</p>
+    <p style="color: var(--julie-text-muted); margin-top: 0.25rem;">
+      expected:
+      {% if case.expected_symbol_name %}<span class="mono">{{ case.expected_symbol_name }}</span>{% endif %}
+      {% if case.expected_file_path %}<span class="mono">{{ case.expected_file_path }}</span>{% endif %}
+    </p>
+    <p style="color: var(--julie-text-muted); margin-top: 0.25rem;">
+      shared rank {{ case.baseline_rank | default(value="miss") }}, legacy rank {{ case.candidate_rank | default(value="miss") }}
+    </p>
+    <p style="color: var(--julie-text-muted); margin-top: 0.25rem;">
+      shared top hit: <span class="mono">{{ case.baseline_top_hit | default(value="none") }}</span>
+    </p>
+    <p style="color: var(--julie-text-muted);">
+      legacy top hit: <span class="mono">{{ case.candidate_top_hit | default(value="none") }}</span>
+    </p>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
+{% endif %}

--- a/dashboard/templates/partials/search_episode_table.html
+++ b/dashboard/templates/partials/search_episode_table.html
@@ -1,7 +1,19 @@
+{# Toggle link #}
+{% if total_episode_count is defined %}
+<div style="margin-bottom: 0.75rem; color: var(--julie-text-muted); font-size: 0.85rem;">
+  {% if show_all %}
+    Showing all {{ episodes | length }} episodes.
+    <a href="/search/analysis?days={{ days }}">Show flagged only</a>
+  {% else %}
+    Showing {{ episodes | length }} flagged of {{ total_episode_count }} total episodes.
+    <a href="/search/analysis?days={{ days }}&show_all=true">Show all</a>
+  {% endif %}
+</div>
+{% endif %}
+
 {% if episodes | length == 0 %}
 <div class="julie-card" style="text-align: center; padding: 2rem; color: var(--julie-text-muted);">
-  <p>No search episodes yet.</p>
-  <p style="margin-top: 0.5rem;">Run a few `fast_search` calls and come back when the tools have something to confess.</p>
+  <p>No search episodes to show.</p>
 </div>
 {% else %}
 {% for episode in episodes %}
@@ -21,6 +33,9 @@
         <div style="margin-top: 0.35rem;">
           <span class="mono" style="color: var(--julie-text);">{{ query.query }}</span>
           <span style="color: var(--julie-text-muted);">({{ query.intent }}, {{ query.search_target }})</span>
+          {% if query.top_hit_score %}
+          <span class="tag is-dark is-small" style="margin-left: 0.25rem;" title="Top hit score">{{ query.top_hit_score | round(precision=2) }}</span>
+          {% endif %}
           {% if query.top_hit_name %}
           <div style="color: var(--julie-text-muted); font-size: 0.85rem;">top hit: <span class="mono">{{ query.top_hit_name }}</span>{% if query.top_hit_file %} in <span class="mono">{{ query.top_hit_file }}</span>{% endif %}</div>
           {% endif %}

--- a/dashboard/templates/partials/search_episode_table.html
+++ b/dashboard/templates/partials/search_episode_table.html
@@ -33,7 +33,7 @@
         <div style="margin-top: 0.35rem;">
           <span class="mono" style="color: var(--julie-text);">{{ query.query }}</span>
           <span style="color: var(--julie-text-muted);">({{ query.intent }}, {{ query.search_target }})</span>
-          {% if query.top_hit_score %}
+          {% if query.top_hit_score is number %}
           <span class="tag is-dark is-small" style="margin-left: 0.25rem;" title="Top hit score">{{ query.top_hit_score | round(precision=2) }}</span>
           {% endif %}
           {% if query.top_hit_name %}

--- a/dashboard/templates/partials/search_episode_table.html
+++ b/dashboard/templates/partials/search_episode_table.html
@@ -1,0 +1,44 @@
+{% if episodes | length == 0 %}
+<div class="julie-card" style="text-align: center; padding: 2rem; color: var(--julie-text-muted);">
+  <p>No search episodes yet.</p>
+  <p style="margin-top: 0.5rem;">Run a few `fast_search` calls and come back when the tools have something to confess.</p>
+</div>
+{% else %}
+{% for episode in episodes %}
+<div class="julie-card" style="margin-bottom: 0.75rem; padding: 1rem;">
+  <div style="display: flex; justify-content: space-between; gap: 1rem; align-items: start;">
+    <div>
+      <div style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;">
+        <span class="mono" style="color: var(--julie-text); font-weight: 600;">{{ episode.outcome }}</span>
+        {% if episode.suspicious %}
+        <span class="tag is-warning is-light">Flagged</span>
+        {% endif %}
+        <span class="mono" style="color: var(--julie-text-muted);">{{ episode.search_count }} search{{ episode.search_count | pluralize }}</span>
+        <span class="mono" style="color: var(--julie-text-muted);">{{ episode.workspace_id }}</span>
+      </div>
+      <div style="margin-top: 0.5rem;">
+        {% for query in episode.queries %}
+        <div style="margin-top: 0.35rem;">
+          <span class="mono" style="color: var(--julie-text);">{{ query.query }}</span>
+          <span style="color: var(--julie-text-muted);">({{ query.intent }}, {{ query.search_target }})</span>
+          {% if query.top_hit_name %}
+          <div style="color: var(--julie-text-muted); font-size: 0.85rem;">top hit: <span class="mono">{{ query.top_hit_name }}</span>{% if query.top_hit_file %} in <span class="mono">{{ query.top_hit_file }}</span>{% endif %}</div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    <div style="min-width: 15rem;">
+      <p class="label-text" style="margin-bottom: 0.35rem;">Downstream</p>
+      <p class="mono" style="color: var(--julie-text);">{{ episode.downstream_tool | default(value="none") }}</p>
+      {% if episode.target_symbol_name %}
+      <p style="margin-top: 0.35rem; color: var(--julie-text-muted);">symbol: <span class="mono">{{ episode.target_symbol_name }}</span></p>
+      {% endif %}
+      {% if episode.target_file_path %}
+      <p style="color: var(--julie-text-muted);">file: <span class="mono">{{ episode.target_file_path }}</span></p>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endfor %}
+{% endif %}

--- a/dashboard/templates/partials/search_results.html
+++ b/dashboard/templates/partials/search_results.html
@@ -11,6 +11,8 @@
   <strong style="color: var(--julie-text);">{{ query }}</strong>
   {% if language %}&middot; language: <span class="mono">{{ language }}</span>{% endif %}
   {% if file_pattern %}&middot; pattern: <span class="mono">{{ file_pattern }}</span>{% endif %}
+  {% if strategy_id %}&middot; strategy: <span class="mono">{{ strategy_id }}</span>{% endif %}
+  {% if search_relaxed %}&middot; relaxed fallback{% endif %}
 </div>
 
 {% for result in results %}

--- a/dashboard/templates/search.html
+++ b/dashboard/templates/search.html
@@ -4,6 +4,12 @@
 
 <h1 class="title" style="color: var(--julie-text); margin-bottom: 1.5rem;">Search Playground</h1>
 
+<div style="display: flex; gap: 0.5rem; margin-bottom: 1rem;">
+  <a class="button is-small is-primary" href="/search">Playground</a>
+  <a class="button is-small" href="/search/analysis">Analysis</a>
+  <a class="button is-small" href="/search/compare">Compare</a>
+</div>
+
 <!-- Search form -->
 <div class="julie-card">
   <form hx-post="/search" hx-target="#search-results" hx-swap="innerHTML">

--- a/dashboard/templates/search_analysis.html
+++ b/dashboard/templates/search_analysis.html
@@ -92,10 +92,10 @@
             {% endif %}
           </td>
           <td style="text-align: right;" class="mono">
-            {% if problem.avg_top_score %}{{ problem.avg_top_score | round(precision=1) }}{% else %}-{% endif %}
+            {% if problem.avg_top_score is number %}{{ problem.avg_top_score | round(precision=1) }}{% else %}-{% endif %}
           </td>
           <td style="text-align: right;" class="mono">
-            {% if problem.avg_result_count %}{{ problem.avg_result_count | round(precision=0) }}{% else %}-{% endif %}
+            {% if problem.avg_result_count is number %}{{ problem.avg_result_count | round(precision=0) }}{% else %}-{% endif %}
           </td>
           <td class="mono" style="color: var(--julie-text-muted); font-size: 0.8rem;">
             {{ problem.last_seen }}

--- a/dashboard/templates/search_analysis.html
+++ b/dashboard/templates/search_analysis.html
@@ -5,7 +5,7 @@
 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
   <div>
     <h1 class="title" style="color: var(--julie-text); margin-bottom: 0.25rem;">Search Analysis</h1>
-    <p style="color: var(--julie-text-muted);">Episodes derived from recent tool calls instead of transcript guesswork.</p>
+    <p style="color: var(--julie-text-muted);">First-try success and failure patterns from tool call history.</p>
   </div>
   <div style="display: flex; gap: 0.5rem;">
     <a class="button is-small" href="/search">Playground</a>
@@ -14,19 +14,28 @@
   </div>
 </div>
 
-<div class="julie-card" style="margin-bottom: 1rem;">
-  <div style="display: flex; gap: 1.5rem; flex-wrap: wrap;">
+{# Section 1: Headline Metrics #}
+<div class="julie-card" style="margin-bottom: 1.5rem;">
+  <div style="display: flex; gap: 2rem; flex-wrap: wrap; align-items: baseline;">
     <div>
-      <p class="label-text">Episodes</p>
-      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.total_episodes }}</p>
+      <p class="label-text">First-Try Success</p>
+      <p class="mono" style="font-size: 1.6rem; color: var(--julie-accent);">{{ (episode_stats.first_try_rate * 100) | round(precision=1) }}%</p>
     </div>
     <div>
-      <p class="label-text">Convergence</p>
-      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.convergence_rate | round(method="floor", precision=2) }}</p>
+      <p class="label-text">One-Shot</p>
+      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.one_shot_count }}</p>
     </div>
     <div>
-      <p class="label-text">Stall Rate</p>
-      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.stall_rate | round(method="floor", precision=2) }}</p>
+      <p class="label-text">Reformulated</p>
+      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.reformulation_count }}</p>
+    </div>
+    <div>
+      <p class="label-text">Stalled</p>
+      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.stall_count }}</p>
+    </div>
+    <div>
+      <p class="label-text">Exploratory</p>
+      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.exploratory_count }}</p>
     </div>
     <div>
       <p class="label-text">Window</p>
@@ -35,6 +44,115 @@
   </div>
 </div>
 
+{# Section 2: Problem Queries #}
+<div class="julie-card" style="margin-bottom: 1.5rem;">
+  <h2 class="subtitle" style="color: var(--julie-text); margin-bottom: 0.75rem;">Problem Queries</h2>
+  {% if problems | length == 0 %}
+  <p style="color: var(--julie-text-muted); text-align: center; padding: 1rem;">
+    No problem queries detected. Either search is working well or there isn't enough data yet.
+  </p>
+  {% else %}
+  <div style="overflow-x: auto;">
+    <table class="table is-fullwidth is-narrow" style="background: transparent; font-size: 0.85rem;">
+      <thead>
+        <tr style="color: var(--julie-text-muted);">
+          <th>Query</th>
+          <th>Variants</th>
+          <th style="text-align: right;">Failures</th>
+          <th>Triage</th>
+          <th style="text-align: right;">Avg Score</th>
+          <th style="text-align: right;">Avg Results</th>
+          <th>Last Seen</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for problem in problems %}
+        <tr style="color: var(--julie-text);">
+          <td class="mono">{{ problem.representative_query }}</td>
+          <td>
+            {% for v in problem.variants %}
+            <span class="tag is-dark is-small" style="margin: 1px;">{{ v }}</span>
+            {% endfor %}
+          </td>
+          <td style="text-align: right;" class="mono">
+            {{ problem.failure_count }}
+            <span style="color: var(--julie-text-muted); font-size: 0.8rem;">
+              ({{ problem.stall_count }}s / {{ problem.reformulation_count }}r)
+            </span>
+          </td>
+          <td>
+            {% if problem.triage_signal == "recall_gap" %}
+            <span class="tag is-danger is-light is-small">recall</span>
+            {% elif problem.triage_signal == "ranking_problem" %}
+            <span class="tag is-warning is-light is-small">ranking</span>
+            {% elif problem.triage_signal == "mixed" %}
+            <span class="tag is-light is-small">mixed</span>
+            {% else %}
+            <span class="tag is-light is-small" style="opacity: 0.5;">unknown</span>
+            {% endif %}
+          </td>
+          <td style="text-align: right;" class="mono">
+            {% if problem.avg_top_score %}{{ problem.avg_top_score | round(precision=1) }}{% else %}-{% endif %}
+          </td>
+          <td style="text-align: right;" class="mono">
+            {% if problem.avg_result_count %}{{ problem.avg_result_count | round(precision=0) }}{% else %}-{% endif %}
+          </td>
+          <td class="mono" style="color: var(--julie-text-muted); font-size: 0.8rem;">
+            {{ problem.last_seen }}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
+</div>
+
+{# Section 3: Reformulation Pairs #}
+<div class="julie-card" style="margin-bottom: 1.5rem;">
+  <h2 class="subtitle" style="color: var(--julie-text); margin-bottom: 0.75rem;">Reformulation Pairs</h2>
+  {% if reformulations | length == 0 %}
+  <p style="color: var(--julie-text-muted); text-align: center; padding: 1rem;">
+    No reformulation patterns detected.
+  </p>
+  {% else %}
+  <div style="overflow-x: auto;">
+    <table class="table is-fullwidth is-narrow" style="background: transparent; font-size: 0.85rem;">
+      <thead>
+        <tr style="color: var(--julie-text-muted);">
+          <th>Initial Query</th>
+          <th></th>
+          <th>Successful Query</th>
+          <th>Target</th>
+          <th style="text-align: right;">Occurrences</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for pair in reformulations %}
+        <tr style="color: var(--julie-text);">
+          <td class="mono">{{ pair.initial_query }}</td>
+          <td style="color: var(--julie-text-muted);">&rarr;</td>
+          <td class="mono">{{ pair.successful_query }}</td>
+          <td>
+            {% if pair.target_name %}
+            <span class="mono" style="color: var(--julie-text);">{{ pair.target_name }}</span>
+            {% if pair.target_file %}
+            <span style="color: var(--julie-text-muted); font-size: 0.8rem;"> @ {{ pair.target_file }}</span>
+            {% endif %}
+            {% else %}
+            <span style="color: var(--julie-text-muted);">-</span>
+            {% endif %}
+          </td>
+          <td style="text-align: right;" class="mono">{{ pair.occurrences }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
+</div>
+
+{# Section 4: Episode Feed #}
 {% include "partials/search_episode_table.html" %}
 
 {% endblock %}

--- a/dashboard/templates/search_analysis.html
+++ b/dashboard/templates/search_analysis.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% block title %}Search Analysis - Julie Dashboard{% endblock %}
+{% block content %}
+
+<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
+  <div>
+    <h1 class="title" style="color: var(--julie-text); margin-bottom: 0.25rem;">Search Analysis</h1>
+    <p style="color: var(--julie-text-muted);">Episodes derived from recent tool calls instead of transcript guesswork.</p>
+  </div>
+  <div style="display: flex; gap: 0.5rem;">
+    <a class="button is-small" href="/search">Playground</a>
+    <a class="button is-small is-primary" href="/search/analysis">Analysis</a>
+    <a class="button is-small" href="/search/compare">Compare</a>
+  </div>
+</div>
+
+<div class="julie-card" style="margin-bottom: 1rem;">
+  <div style="display: flex; gap: 1.5rem; flex-wrap: wrap;">
+    <div>
+      <p class="label-text">Episodes</p>
+      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.total_episodes }}</p>
+    </div>
+    <div>
+      <p class="label-text">Convergence</p>
+      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.convergence_rate | round(method="floor", precision=2) }}</p>
+    </div>
+    <div>
+      <p class="label-text">Stall Rate</p>
+      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.stall_rate | round(method="floor", precision=2) }}</p>
+    </div>
+    <div>
+      <p class="label-text">Window</p>
+      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ days }} day{{ days | pluralize }}</p>
+    </div>
+  </div>
+</div>
+
+{% include "partials/search_episode_table.html" %}
+
+{% endblock %}

--- a/dashboard/templates/search_compare.html
+++ b/dashboard/templates/search_compare.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Search Compare - Julie Dashboard{% endblock %}
+{% block content %}
+
+<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
+  <div>
+    <h1 class="title" style="color: var(--julie-text); margin-bottom: 0.25rem;">Search Compare</h1>
+    <p style="color: var(--julie-text-muted);">Replays real search episodes against the shared search path and the old direct path.</p>
+  </div>
+  <div style="display: flex; gap: 0.5rem;">
+    <a class="button is-small" href="/search">Playground</a>
+    <a class="button is-small" href="/search/analysis">Analysis</a>
+    <a class="button is-small is-primary" href="/search/compare">Compare</a>
+  </div>
+</div>
+
+<div class="julie-card" style="margin-bottom: 1rem;">
+  <form method="post" action="/search/compare" style="display: flex; gap: 0.75rem; align-items: end; flex-wrap: wrap;">
+    <div>
+      <label class="label" style="color: var(--julie-text-muted); font-size: 0.8rem;">Episode window</label>
+      <input class="input is-small" type="number" name="days" min="1" value="{{ days }}" style="max-width: 8rem;" />
+    </div>
+    <button class="button is-primary is-small" type="submit">Run Compare</button>
+  </form>
+</div>
+
+{% include "partials/search_compare_results.html" %}
+
+{% endblock %}

--- a/docs/plans/2026-04-20-fast-search-observability-and-comparison-design.md
+++ b/docs/plans/2026-04-20-fast-search-observability-and-comparison-design.md
@@ -1,0 +1,429 @@
+# Fast Search Observability and Comparison Design
+
+## Summary
+
+Build a dashboard-centered observability and comparison system for `fast_search`.
+
+The project has three linked goals:
+
+1. Make the dashboard the source of truth for `fast_search` behavior now that harness transcripts no longer show tool output reliably.
+2. Capture enough live search telemetry to explain what happened during real agent sessions without pushing analysis work onto the hot path.
+3. Add a side-by-side comparison bench so Julie can replay real query corpora against baseline and candidate search strategies and judge whether ranking changes help or hurt.
+
+The design uses `tool_calls` as the raw event log, extends `fast_search` metadata with compact top-hit telemetry, analyzes behavior in terms of search episodes instead of isolated calls, and adds a dashboard comparison surface that runs offline or background replay jobs against captured corpora.
+
+## Why this is a separate project
+
+This is not a cosmetic dashboard polish task.
+
+- `fast_search` is Julie's highest-volume tool, so blind spots here matter more than blind spots elsewhere.
+- The harness layer now hides tool output in many sessions, which removes the old feedback loop.
+- The current dashboard search playground does not execute the same path as `fast_search`. It queries `SearchIndex` directly in [`src/dashboard/routes/search.rs`](</Users/murphy/source/julie/src/dashboard/routes/search.rs:46>), so it cannot explain hybrid merge, path priors, filter defaults, or future ranking variants truthfully.
+- The current metrics page counts calls and latency, but it cannot answer the hard questions: Did search converge? Did it stall? Did docs outrank source? Did the agent pick rank 1 or rank 7?
+
+Without this project, search tuning stays guesswork.
+
+## Goals
+
+1. Capture structured `fast_search` telemetry from live sessions with low request-path cost.
+2. Group bursts of related `fast_search` calls into search episodes so exploratory bursts are not mislabeled as failure.
+3. Record enough downstream-tool target metadata to tell whether search converged on a symbol or file.
+4. Expose trace, episode, and comparison views in the dashboard.
+5. Refactor the dashboard search playground onto the same shared execution core as `fast_search`.
+6. Add a replay bench that compares baseline and candidate search strategies over a captured or hand-built corpus.
+
+## Non-goals
+
+- No live quality scoring on the `fast_search` hot path.
+- No model-based judge in v1.
+- No harness UI changes.
+- No attempt to infer agent intent from prompt text outside Julie's own tool-call stream.
+- No rewrite of Julie's ranking stack before observability exists.
+
+## Current pressure points
+
+### 1. Search output is hidden upstream
+
+The user can no longer trust the harness transcript as a record of `fast_search` behavior. Julie needs first-party visibility.
+
+### 2. The current search playground is not faithful
+
+The search playground route in [`src/dashboard/routes/search.rs`](</Users/murphy/source/julie/src/dashboard/routes/search.rs:46>) calls `search_symbols` and `search_content` on the index directly. That path bypasses the actual `fast_search` tool pipeline in [`src/handler.rs`](</Users/murphy/source/julie/src/handler.rs:2378>) and [`src/tools/search/text_search.rs`](</Users/murphy/source/julie/src/tools/search/text_search.rs:25>).
+
+### 3. Repeated search bursts are ambiguous
+
+Agents often fire many `fast_search` calls in close succession on purpose. A raw count of repeated searches will over-report failure unless Julie reasons in episodes and looks at what those bursts lead to.
+
+### 4. Existing metrics are too coarse
+
+The metrics page in [`src/dashboard/routes/metrics.rs`](</Users/murphy/source/julie/src/dashboard/routes/metrics.rs:20>) can show volume, latency, and output size, but not search quality or convergence.
+
+## Primary code areas
+
+### Existing files
+
+- [`src/handler.rs`](</Users/murphy/source/julie/src/handler.rs:1627>) for tool-call recording and `fast_search` entrypoint metadata.
+- [`src/tools/search/text_search.rs`](</Users/murphy/source/julie/src/tools/search/text_search.rs:25>) for shared search behavior.
+- [`src/search/hybrid.rs`](</Users/murphy/source/julie/src/search/hybrid.rs:174>) for hybrid merge behavior.
+- [`src/daemon/database.rs`](</Users/murphy/source/julie/src/daemon/database.rs:495>) for raw tool-call persistence and replay-result persistence.
+- [`src/dashboard/mod.rs`](</Users/murphy/source/julie/src/dashboard/mod.rs:109>) for route registration.
+- [`src/dashboard/routes/search.rs`](</Users/murphy/source/julie/src/dashboard/routes/search.rs:24>) for the search playground.
+- [`src/dashboard/routes/metrics.rs`](</Users/murphy/source/julie/src/dashboard/routes/metrics.rs:20>) for summary cards and tool breakdown.
+- [`src/dashboard/routes/events.rs`](</Users/murphy/source/julie/src/dashboard/routes/events.rs:13>) and [`src/dashboard/state.rs`](</Users/murphy/source/julie/src/dashboard/state.rs:30>) for live dashboard events.
+- [`dashboard/templates/search.html`](</Users/murphy/source/julie/dashboard/templates/search.html:1>) and [`dashboard/templates/partials/search_results.html`](</Users/murphy/source/julie/dashboard/templates/partials/search_results.html:1>) for the playground UI.
+- [`dashboard/templates/partials/search_detail.html`](</Users/murphy/source/julie/dashboard/templates/partials/search_detail.html:1>) for expandable hit detail.
+- [`dashboard/templates/metrics.html`](</Users/murphy/source/julie/dashboard/templates/metrics.html:1>) and [`dashboard/templates/partials/metrics_table.html`](</Users/murphy/source/julie/dashboard/templates/partials/metrics_table.html:1>) for metrics surfaces.
+
+### Planned new files
+
+- `src/tools/search/trace.rs`
+- `src/dashboard/search_analysis.rs`
+- `src/dashboard/search_compare.rs`
+- `src/dashboard/routes/search_analysis.rs`
+- `src/dashboard/routes/search_compare.rs`
+- `dashboard/templates/search_analysis.html`
+- `dashboard/templates/partials/search_episode_table.html`
+- `dashboard/templates/partials/search_compare_results.html`
+
+These modules keep route handlers lean and avoid pushing large analysis code into existing files that are already busy.
+
+## Design decisions
+
+### 1. The dashboard must run the real search path
+
+Chosen behavior: extract a shared structured search execution layer and route both `fast_search` and the dashboard search playground through it.
+
+The current split is not acceptable:
+
+- `fast_search` goes through the tool path and can use hybrid search, heuristics, metadata capture, and future strategy variants.
+- the dashboard playground uses a narrower path and shows a partial truth
+
+The new shared execution layer should return a structured result object with:
+
+- ranked hits
+- trace diagnostics
+- result counts
+- strategy id
+- telemetry-ready top-hit summaries
+
+The MCP tool can still render its current text output from that structure. The dashboard can render rich panels from the same structure without parsing the tool's formatted text.
+
+This is the foundation that makes the rest of the design honest.
+
+### 2. Raw telemetry stays on the existing metrics path
+
+Chosen behavior: capture compact search telemetry in `tool_calls.metadata` and reuse the existing bounded async metrics writer.
+
+This keeps request-path cost close to today's cost envelope:
+
+- `record_tool_call` already serializes metadata and `try_send`s it through the bounded metrics channel in [`src/handler.rs`](</Users/murphy/source/julie/src/handler.rs:1665>).
+- the background writer already handles SQLite persistence in [`src/handler.rs`](</Users/murphy/source/julie/src/handler.rs:176>).
+
+New search telemetry fields for `fast_search` should include:
+
+- `query`
+- `normalized_query`
+- `search_target`
+- `language`
+- `file_pattern`
+- `limit`
+- `intent`
+- `strategy`
+- `result_count`
+- `top_hits` with top 3 hit summaries
+- `trace_version`
+
+Each top-hit summary should include:
+
+- `rank`
+- `symbol_id` when available
+- `name`
+- `kind`
+- `file_path`
+- `line`
+- `score`
+
+No live clustering, no replay judgment, and no cross-query comparison work belongs on the request path.
+
+### 3. Intent labels are telemetry-first, not ranking-first
+
+Chosen behavior: infer a small stable intent label for telemetry and dashboard grouping, but do not let that label drive ranking until it proves useful.
+
+The first label set should be:
+
+- `symbol_lookup`
+- `code_investigation`
+- `api_tool_lookup`
+- `conceptual_code`
+- `content_grep`
+- `unknown`
+
+The classifier should use cheap heuristics:
+
+- query shape
+- identifier signals
+- word count
+- `search_target`
+- tool-oriented phrases such as `find references`, `wrapper`, `handler`, `mcp`, `call path`
+
+This keeps the label set interpretable and avoids baking a shaky classifier into retrieval before Julie has evidence that it helps.
+
+### 4. Search episodes are the unit of analysis
+
+Chosen behavior: group related `fast_search` calls into episodes and analyze what the episode led to.
+
+Episode rule set:
+
+1. An episode starts with a `fast_search`.
+2. Additional `fast_search` calls join the same episode while they occur within 10 seconds of the prior search and no non-search tool fires in between.
+3. The first non-search tool closes the episode.
+4. A new `fast_search` after that boundary starts a new episode.
+
+This matches the user requirement:
+
+- bursts of many searches can be intentional exploration
+- the burst itself is not suspicious
+- the outcome is what matters
+
+### 5. Useful downstream action is explicit
+
+Chosen behavior: treat the following tools as useful downstream actions for search episodes:
+
+- `deep_dive`
+- `get_symbols`
+- `fast_refs`
+- `call_path`
+- `get_context`
+- `edit_file`
+- `rewrite_symbol`
+- `rename_symbol`
+
+This set treats `get_context` as valid exploration and not dead air.
+
+### 6. Convergence is symbol-first with file fallback
+
+Chosen behavior: define convergence in terms of the same symbol when possible, with file-path fallback when symbol resolution is absent or the tool is file-oriented.
+
+Downstream useful-action metadata should capture:
+
+- `target_symbol_id` when resolvable
+- `target_symbol_name` when available
+- `target_file_path`
+- `target_line` when available
+
+Suspicious search episodes under the default balanced rule are:
+
+- overlapping or near-duplicate queries that converge on the same downstream symbol or file
+- episodes that end without a useful downstream action
+
+For v1, overlap detection should use a deterministic normalized-query comparison:
+
+- exact normalized match
+- one normalized query contains the other
+- token-overlap threshold
+
+That logic belongs in dashboard analysis code, not the hot path.
+
+### 7. Search outcomes should be classified, not guessed
+
+Chosen behavior: assign each episode one outcome label.
+
+The first outcome set should be:
+
+- `one_shot_success`
+- `exploratory_success`
+- `reformulation_converged`
+- `stalled`
+- `dispersed`
+- `insufficient_data`
+
+Meaning:
+
+- `one_shot_success`: one search, then a useful downstream action
+- `exploratory_success`: multiple searches, then a useful downstream action without suspicious convergence
+- `reformulation_converged`: overlapping searches collapsed onto the same target
+- `stalled`: no useful downstream action after the episode
+- `dispersed`: burst ended in multiple unrelated downstream targets
+- `insufficient_data`: missing telemetry or dropped metrics left the result ambiguous
+
+### 8. The metrics page stays light, the search area gets the heavy surfaces
+
+Chosen behavior: leave the current metrics page focused on volume and latency, add search quality summary cards there, and put detailed episode analysis and replay comparison under the search area.
+
+Reasoning:
+
+- [`dashboard/templates/metrics.html`](</Users/murphy/source/julie/dashboard/templates/metrics.html:1>) auto-refreshes and should stay cheap.
+- search analysis and replay are heavier and more interactive.
+- the existing search playground is the natural home for search transparency.
+
+The search area should gain three tabs or sibling views:
+
+- `Playground`
+- `Analysis`
+- `Compare`
+
+### 9. Comparison is a first-class replay bench
+
+Chosen behavior: add side-by-side replay comparison against captured or hand-built corpora.
+
+Corpus sources:
+
+- captured live `fast_search` rows from `tool_calls`
+- filtered by workspace, time range, intent, or outcome
+- optional hand-entered query list for focused inspection
+
+Comparison behavior:
+
+- choose baseline strategy and candidate strategy
+- run both against the same corpus
+- show per-query hit diffs and aggregate metrics
+
+Aggregate metrics should include:
+
+- top-1 match rate against later chosen symbol or file when known
+- top-3 containment rate against later chosen symbol or file when known
+- source-over-docs win rate for `code_investigation`
+- episode stall rate
+- reformulation-convergence rate
+- duplicate-result rate
+- latency deltas
+
+### 10. Replay runs are persisted, episode analysis is derived
+
+Chosen behavior: keep raw event capture in `tool_calls`, derive episodes from raw events, and persist replay-run artifacts in dedicated daemon tables.
+
+This split keeps the live path lean while still saving the expensive comparison work.
+
+New daemon tables:
+
+- `search_compare_runs`
+- `search_compare_cases`
+
+`search_compare_runs` should store:
+
+- run id
+- created_at
+- workspace scope
+- corpus spec
+- baseline strategy
+- candidate strategy
+- case count
+- summary metrics
+- status
+
+`search_compare_cases` should store:
+
+- run id
+- ordinal
+- query
+- expected downstream target when known
+- baseline top hits
+- candidate top hits
+- per-case judgment summary
+
+Episode analysis does not need its own persistence in v1. It can be rebuilt from `tool_calls` for the requested time window.
+
+## Data flow
+
+### Live capture flow
+
+1. `fast_search` executes through the shared structured search core.
+2. The tool records compact telemetry in `ToolCallReport.metadata`.
+3. `record_tool_call` writes the raw event through the existing bounded metrics channel.
+4. The background writer persists the event into workspace `tool_calls` and daemon `tool_calls`.
+5. Useful downstream tools write target metadata into their own `tool_calls.metadata`.
+6. The dashboard analysis layer reconstructs episodes from chronological tool calls within a session.
+
+### Dashboard analysis flow
+
+1. The dashboard reads recent tool calls for the selected workspace and time window.
+2. It filters to sessions that include `fast_search`.
+3. It groups `fast_search` calls into episodes using the agreed 10-second plus boundary rule.
+4. It attaches the first downstream useful action when present.
+5. It computes outcome labels and summary aggregates.
+6. It renders trace tables, episode tables, and drill-down views.
+
+### Replay comparison flow
+
+1. The dashboard builds a corpus from captured tool calls or a manual query set.
+2. It schedules a background comparison job.
+3. The job runs baseline and candidate strategies against the same corpus.
+4. It computes aggregate metrics and per-case diffs.
+5. It stores the run and case results in the daemon database.
+6. The dashboard renders the finished run and allows later inspection.
+
+## Error handling and failure behavior
+
+### Metrics backpressure
+
+The current metrics path drops records under backpressure. Search analysis must account for that and surface gaps as `insufficient_data` and never pretend the trace is complete.
+
+### Missing target metadata
+
+When downstream symbol resolution fails, convergence falls back to file path. If both are absent, the episode remains analyzable but with weaker judgment.
+
+### Dashboard comparison failures
+
+Replay jobs should be background tasks with explicit status:
+
+- `queued`
+- `running`
+- `succeeded`
+- `failed`
+
+The compare page should never block on a long-running replay in the request thread.
+
+### Strategy drift
+
+Each telemetry row and replay result should include `trace_version` and `strategy_id` fields so old traces remain interpretable after future search changes.
+
+## Verification strategy
+
+### Unit tests
+
+- intent classification tests
+- top-hit summary extraction tests
+- normalized-query overlap tests
+- episode builder tests for burst boundaries
+- outcome-label tests
+
+### Integration tests
+
+- handler metrics recording with enriched `fast_search` metadata
+- daemon DB migration and replay-table persistence
+- dashboard route tests for new search analysis and compare views
+- replay comparison tests with deterministic fixture corpora
+
+### Dogfood validation
+
+- run the dashboard against real Julie sessions
+- confirm the search playground and `fast_search` agree on ranked hits for the same query and workspace
+- confirm intentional exploratory bursts are not mislabeled as failure
+- confirm known reformulation cases are surfaced as `reformulation_converged`
+
+## Acceptance criteria
+
+- [ ] The dashboard search playground uses the same shared search execution core as `fast_search`.
+- [ ] `fast_search` persists compact structured telemetry with top 3 hits through the existing metrics path.
+- [ ] Useful downstream tools persist enough target metadata for symbol-or-file convergence analysis.
+- [ ] The dashboard can reconstruct search episodes from real tool-call history using the agreed 10-second plus boundary rule.
+- [ ] The dashboard exposes search episode analysis with outcome labels and drill-down traces.
+- [ ] The dashboard exposes a side-by-side replay comparison view for baseline and candidate strategies.
+- [ ] Replay runs are persisted in the daemon database and can be revisited later.
+- [ ] The request-path cost stays within the current metrics shape by avoiding live quality analysis on the hot path.
+- [ ] Tests cover intent labels, episode construction, replay comparison, and dashboard rendering for the new surfaces.
+
+## Deliverables
+
+- shared structured search execution path for tool and dashboard use
+- enriched `fast_search` telemetry in `tool_calls`
+- useful-action target telemetry for downstream tools
+- dashboard `Analysis` and `Compare` surfaces
+- persisted replay-run artifacts in daemon DB
+- search-quality summary cards that point from metrics into the search analysis views
+
+## Follow-up questions for implementation planning
+
+- Which search-strategy enum gives the cleanest baseline-versus-candidate comparison story without infecting the hot path with experimental branches?
+- Which downstream tools can resolve a stable `target_symbol_id` cheaply, and where does file-path fallback need to carry more weight?
+- How should the compare page sample corpora so large workspaces stay usable without hiding important outliers?

--- a/docs/plans/2026-04-20-fast-search-observability-and-comparison-implementation-plan.md
+++ b/docs/plans/2026-04-20-fast-search-observability-and-comparison-implementation-plan.md
@@ -1,0 +1,178 @@
+# Fast Search Observability And Comparison Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use razorback:team-driven-development (on Claude Code) or razorback:subagent-driven-development (elsewhere) to implement this plan. Fall back to razorback:executing-plans for single-task or tightly-sequential plans.
+
+**Goal:** Build a dashboard-backed observability and comparison loop for `fast_search` so Julie can measure first-hit quality, inspect search episodes, and compare ranking changes against real query corpora.
+
+**Architecture:** This work has a sequential foundation and a parallel middle. First, extract a shared structured search execution layer so the dashboard playground and `fast_search` use the same core path. Next, extend tool-call telemetry for `fast_search` and downstream navigation or edit tools. After that foundation lands, split the work: one track builds episode analysis and dashboard trace views, the other builds replay persistence and comparison UI. Finish by wiring the dashboard to the new routes, running search-heavy verification, and reviewing whether the traces answer the product questions that started this project.
+
+**Tech Stack:** Rust, Axum, Tera, SQLite, existing `tool_calls` metrics pipeline, Julie search stack, `cargo nextest`, `cargo xtask test changed`, `cargo xtask test dogfood`, `cargo xtask test dev`
+
+---
+
+## Execution notes
+
+- The dashboard playground must route through the same shared execution core as `fast_search`. If the playground keeps calling raw index APIs, the observability story is fake.
+- Keep new logic out of `src/handler.rs`, `src/daemon/database.rs`, `src/dashboard/state.rs`, and `src/tools/search/text_search.rs` where possible. Those files are already over the project size target and do not need more passengers.
+- Keep request-path work narrow. Capture data once, persist it through the existing metrics writer, then analyze it later in the dashboard or replay path.
+- Treat `tool_calls` as the raw event log. Derive episodes, convergence, stall signals, and compare summaries from stored calls instead of inventing a second live metrics pipeline.
+- Follow TDD for behavior changes and regression fixes. The first failing test for this project should prove the dashboard playground and `fast_search` can disagree today.
+
+## Task 1: Extract a shared structured search execution core
+
+**Files:**
+- Create: `src/tools/search/execution.rs`
+- Create: `src/tools/search/trace.rs`
+- Modify: `src/tools/search/mod.rs`
+- Modify: `src/tools/search/text_search.rs`
+- Modify: `src/dashboard/routes/search.rs`
+- Modify: `src/tests/dashboard/integration.rs`
+- Modify: `src/tests/tools/search_quality/dogfood_tests.rs`
+
+**What to build:** Pull the common execution path for `fast_search` into a structured search service that returns ranked hits, trace diagnostics, result counts, and top-hit summaries without forcing callers to parse formatted tool output.
+
+**Approach:**
+- Move the shared search work out of `text_search.rs` into `execution.rs` so the file stops growing.
+- Define trace-friendly result types in `trace.rs`, including top-hit summaries that can feed telemetry and dashboard rendering.
+- Keep tool-specific response formatting in `text_search.rs`; the structured execution layer should stay presentation-neutral.
+- Change the dashboard search route to call the shared execution core instead of direct `SearchIndex` entrypoints.
+- Add one regression that proves the dashboard playground and `fast_search` now use the same ranked result source for the same query and filters.
+
+**Acceptance criteria:**
+- [ ] `fast_search` and the dashboard playground call the same structured search execution entrypoint.
+- [ ] The shared result type includes ranked hits, result count, strategy id, and compact top-hit summaries.
+- [ ] The dashboard no longer needs to reconstruct search behavior from raw Tantivy responses.
+- [ ] Focused tests cover shared execution parity for at least one definition search and one content search.
+
+## Task 2: Extend telemetry for search traces and downstream targets
+
+**Files:**
+- Create: `src/handler/search_telemetry.rs`
+- Create: `src/handler/tool_targets.rs`
+- Modify: `src/handler.rs`
+- Modify: `src/dashboard/state.rs`
+- Modify: `src/tests/daemon/database.rs`
+- Modify: `src/tests/integration/daemon_lifecycle.rs`
+- Modify: `src/tests/dashboard/integration.rs`
+
+**What to build:** Capture richer `fast_search` metadata and enough downstream-tool target metadata to tell where search bursts landed.
+
+**Approach:**
+- Move metadata-building helpers into `src/handler/search_telemetry.rs` and target-resolution helpers into `src/handler/tool_targets.rs` so `handler.rs` does not absorb another block of JSON assembly logic.
+- Extend `fast_search` metadata with query, normalized query, filters, intent label, strategy id, result count, trace version, and top 3 hit summaries.
+- Extend useful downstream tools with target metadata that prefers symbol id and falls back to file path and line.
+- Keep dashboard live events lean. Broadcast summary data that helps the UI update, not full trace payloads that belong in SQLite.
+- Reuse the existing bounded metrics writer path. No new synchronous database writes belong in tool handlers.
+
+**Acceptance criteria:**
+- [ ] `fast_search` writes structured trace metadata into `tool_calls.metadata`.
+- [ ] Useful downstream tools write target metadata that can support symbol-first and file-fallback convergence.
+- [ ] The existing metrics writer still owns persistence; tool handlers do not gain direct SQLite writes.
+- [ ] Focused tests cover metadata shape for `fast_search` and at least one downstream action.
+
+## Task 3: Add episode analysis services and dashboard trace views
+
+**Files:**
+- Create: `src/dashboard/search_analysis.rs`
+- Create: `src/dashboard/routes/search_analysis.rs`
+- Create: `dashboard/templates/search_analysis.html`
+- Create: `dashboard/templates/partials/search_episode_table.html`
+- Modify: `src/dashboard/mod.rs`
+- Modify: `src/dashboard/routes/mod.rs`
+- Modify: `src/daemon/database.rs`
+- Modify: `src/tests/dashboard/integration.rs`
+- Modify: `src/tests/daemon/database.rs`
+
+**What to build:** Add dashboard analysis views that turn raw tool calls into search episodes and explain whether a burst of searches converged, dispersed, or stalled.
+
+**Approach:**
+- Keep episode derivation in `search_analysis.rs`, not in route handlers and not in the request path.
+- Use the agreed rule set:
+  - episode starts with `fast_search`
+  - another `fast_search` joins when it lands within 10 seconds and no non-search tool fired in between
+  - the first non-search tool closes the episode
+- Treat these tools as useful downstream actions: `deep_dive`, `get_symbols`, `fast_refs`, `call_path`, `get_context`, `edit_file`, `rewrite_symbol`, `rename_symbol`.
+- Define convergence as same symbol when available, otherwise same file.
+- Add queries in the daemon database layer that fetch raw tool-call windows for one session, then let the dashboard analysis layer derive episode outcomes.
+
+**Acceptance criteria:**
+- [ ] The dashboard can render episode lists with query bursts, timing, top hits, downstream action, and final target.
+- [ ] Episode analysis flags `reformulation_converged` and `stalled` using stored tool-call data, not transcript guesses.
+- [ ] Intent labels and outcome labels are visible in the analysis view.
+- [ ] Focused tests cover the 10-second burst boundary, useful-action closure, and same-symbol or same-file convergence rules.
+
+## Task 4: Build replay persistence and side-by-side comparison
+
+**Files:**
+- Create: `src/dashboard/search_compare.rs`
+- Create: `src/dashboard/routes/search_compare.rs`
+- Create: `dashboard/templates/partials/search_compare_results.html`
+- Modify: `src/dashboard/mod.rs`
+- Modify: `src/dashboard/routes/mod.rs`
+- Modify: `src/daemon/database.rs`
+- Modify: `src/dashboard/routes/search.rs`
+- Modify: `src/tests/dashboard/integration.rs`
+- Modify: `src/tests/daemon/database.rs`
+
+**What to build:** Add a comparison bench that reruns a captured query corpus against baseline and candidate search strategies and stores the run plus per-case results for review in the dashboard.
+
+**Approach:**
+- Persist replay artifacts in new daemon-database tables for compare runs and compare cases, while keeping raw session traces in `tool_calls`.
+- Reuse the shared execution core from Task 1 so compare runs exercise the same ranking path as live search.
+- Store enough case-level detail to inspect top-1 and top-3 changes, duplicate-heavy outputs, source-versus-doc ordering, and whether the later chosen target appeared higher or lower.
+- Keep compare execution out of page-render code. Routes should trigger or load persisted runs, then render summaries and drill-down rows.
+- Start with deterministic heuristics and captured traces. Leave model judging out of v1.
+
+**Acceptance criteria:**
+- [ ] The dashboard can run a compare pass between two search strategies over a stored corpus.
+- [ ] Compare results persist run-level summaries and case-level rankings.
+- [ ] The comparison UI can show top-1 win rate, top-3 containment, source-over-doc win rate, convergence rate, and stall rate.
+- [ ] Focused tests cover compare-run persistence and one rendered compare result page.
+
+## Task 5: Wire the dashboard navigation and tighten search UX
+
+**Files:**
+- Modify: `dashboard/templates/search.html`
+- Modify: `dashboard/templates/partials/search_results.html`
+- Modify: `dashboard/templates/partials/search_detail.html`
+- Modify: `src/dashboard/routes/search.rs`
+- Modify: `src/dashboard/mod.rs`
+- Modify: `src/tests/dashboard/integration.rs`
+
+**What to build:** Turn the search area into a three-part surface: playground, analysis, and compare, with shared filters and visible trace details.
+
+**Approach:**
+- Keep the current playground for single-query inspection, but add links or tabs into analysis and compare.
+- Show strategy id, intent label, and top-hit trace details in the playground so one search can be inspected without hopping to the metrics page.
+- Keep the metrics page light. Search-heavy drill-down belongs in the search section.
+- Make page flows clear enough that the dashboard becomes the default debugging surface when harness transcripts hide tool output.
+
+**Acceptance criteria:**
+- [ ] The search page links cleanly to analysis and compare views.
+- [ ] Playground results expose trace details from the shared execution core.
+- [ ] Search observability lives under the search area, not bolted onto the metrics page.
+- [ ] Dashboard integration tests cover the new navigation surfaces.
+
+## Task 6: Verify search behavior and guard against dashboard fiction
+
+**Files:**
+- Modify: `src/tests/dashboard/integration.rs`
+- Modify: `src/tests/daemon/database.rs`
+- Modify: `src/tests/tools/search_quality/dogfood_tests.rs`
+- Modify: `src/tests/integration/daemon_lifecycle.rs`
+- No new production files required
+
+**What to build:** Run the narrow tests added in earlier tasks, then the calibrated tiers that match search-risk changes.
+
+**Approach:**
+- During implementation, use exact test-name runs for RED and GREEN loops.
+- Before handoff, run `cargo xtask test changed`, `cargo xtask test dogfood`, and `cargo xtask test dev`.
+- If dogfood catches search-ranking drift, inspect it with the new comparison bench before calling the project done.
+- End with a brief review note that answers the product question: can Julie now explain what `fast_search` did, whether it helped, and whether a candidate ranking is better?
+
+**Acceptance criteria:**
+- [ ] New narrow tests for shared execution, telemetry, episode analysis, and compare persistence pass.
+- [ ] `cargo xtask test changed` passes.
+- [ ] `cargo xtask test dogfood` passes.
+- [ ] `cargo xtask test dev` passes.
+- [ ] The final implementation summary includes remaining blind spots, if any, instead of pretending the dashboard sees everything.

--- a/docs/plans/2026-04-20-search-analysis-diagnostic-rework-design.md
+++ b/docs/plans/2026-04-20-search-analysis-diagnostic-rework-design.md
@@ -1,0 +1,167 @@
+# Search Analysis Diagnostic Rework
+
+## Problem
+
+Claude Code and other harnesses no longer display MCP tool results inline. Where developers used to observe search quality by watching `fast_search` results scroll by, they now see "Called julie 2 times (ctrl+o to expand)" with no result detail. The process of spotting search quality issues and debugging them has lost its primary feedback loop.
+
+The search analysis dashboard page (`/search/analysis`) was built to replace this lost observability, but it renders a chronological episode feed instead of a diagnostic tool. The telemetry layer captures rich per-query data (scores, top hits, strategies, result counts) but the analysis page discards most of it at parse time. The page cannot answer "which queries fail?" or "why do they fail?" because the evidence gets thrown away before display.
+
+## Goal
+
+Make search better at delivering the right result the first time. The analysis page should surface actionable quality signals: what's failing, how often, and enough context to triage whether it's a scoring problem or a coverage gap. Detailed investigation belongs on the Compare page (`/search/compare`); detection and triage belong here.
+
+## Design Decisions (Agreed)
+
+1. **Query aggregation**: Token-set overlap (Jaccard on word tokens, reusing existing `token_set` + `queries_overlap` logic) to group similar failing queries. Prevents fragmented views of the same underlying problem.
+2. **Episode feed**: Keep below analytics sections, filtered to flagged (stalled + reformulated) episodes by default, with a toggle for all.
+3. **Diagnostic depth per problem query**: Failure signal + top hit context (score, result count). Enough to distinguish "scored low" from "no results" at a glance. Full trace investigation is the Compare page's job.
+4. **Reformulation pairs**: Dedicated ranked table, not inline on episodes. Pattern detection requires scannability.
+
+## Architecture
+
+No new database queries, routes, or pages. This reworks the aggregation layer between the existing `list_tool_calls_for_search_analysis` DB query and the template.
+
+```
+daemon DB (tool_calls table, unchanged)
+  -> list_tool_calls_for_search_analysis (unchanged)
+    -> analyze_tool_calls (unchanged, produces Vec<SearchEpisode>)
+      -> NEW: aggregate_problems (token-set grouping of failing queries)
+      -> NEW: extract_reformulation_pairs (query pairs from reformulated episodes)
+      -> episode_stats (extended with first-try rate + outcome breakdown)
+        -> template (reworked layout, 4 sections)
+```
+
+## Data Model Changes
+
+### Widen `SearchEpisodeQuery`
+
+Add fields from the trace JSON that is already stored in the `metadata` column:
+
+| Field | Type | Source in metadata JSON |
+|-------|------|------------------------|
+| `top_hit_score` | `Option<f32>` | `trace.top_hits[0].score` |
+| `result_count` | `usize` | `trace.result_count` |
+| `strategy` | `String` | `trace.strategy` |
+| `relaxed` | `bool` | `trace.relaxed` |
+
+These are extracted in `parse_search_query` from the same JSON blob already being parsed. No DB schema changes.
+
+### New `QueryProblem` struct
+
+One per aggregated problem query group:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `representative_query` | `String` | Most frequent query text in the group |
+| `variants` | `Vec<String>` | Other query texts that token-overlap with representative |
+| `failure_count` | `usize` | Total episodes where this group stalled or reformulated |
+| `stall_count` | `usize` | Episodes where this group stalled |
+| `reformulation_count` | `usize` | Episodes where this group required reformulation |
+| `last_seen` | `i64` | Most recent failure timestamp |
+| `avg_top_score` | `Option<f32>` | Average top hit score across failures (None when no results) |
+| `avg_result_count` | `f32` | Average result count across failures |
+
+### New `ReformulationPair` struct
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `initial_query` | `String` | What the agent searched first (the failing query) |
+| `successful_query` | `String` | What the agent searched that worked |
+| `target_name` | `Option<String>` | Downstream symbol found |
+| `target_file` | `Option<String>` | File where target was found |
+| `occurrences` | `usize` | How many times this pair appeared |
+
+### Extend `EpisodeStats`
+
+Add to existing struct:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `first_try_rate` | `f64` | `one_shot_success / total_episodes` |
+| `one_shot_count` | `usize` | Outcome breakdown |
+| `reformulation_count` | `usize` | Outcome breakdown |
+| `stall_count` | `usize` | Outcome breakdown |
+| `exploratory_count` | `usize` | Outcome breakdown |
+
+Existing `convergence_rate` and `stall_rate` stay (used by compare page).
+
+## Aggregation Functions
+
+### `aggregate_problems(episodes: &[SearchEpisode]) -> Vec<QueryProblem>`
+
+1. Filter episodes to those with outcome `stalled` or `reformulation_converged`.
+2. Collect all queries from those episodes.
+3. Group queries by token-set overlap: for each query, check if it overlaps with an existing group's representative (using `token_set` and a Jaccard threshold). If yes, add to that group. If no, start a new group.
+4. For each group, compute: representative (most frequent query text), variants, failure/stall/reformulation counts, last_seen, avg_top_score, avg_result_count.
+5. Sort by `failure_count` descending.
+6. Return top 20.
+
+### `extract_reformulation_pairs(episodes: &[SearchEpisode]) -> Vec<ReformulationPair>`
+
+1. Filter episodes to those with outcome `reformulation_converged`.
+2. For each episode: take the first query as `initial_query`, the last query as `successful_query`, and the episode's `target_symbol_name`/`target_file_path` as the target.
+3. Deduplicate pairs by token-set overlap on both initial and successful queries. Sum occurrences.
+4. Sort by `occurrences` descending.
+5. Return top 15.
+
+## Template Layout
+
+### Section 1: Headline Metrics (summary cards row)
+
+- **First-try success rate** (percentage, prominent, larger font)
+- **Outcome breakdown**: one-shot | reformulated | stalled | exploratory (counts)
+- **Window** (days, same as current)
+
+### Section 2: Problem Queries (table)
+
+Columns: Query | Variants | Failures (stall/reform split) | Avg Score | Avg Results | Last Seen
+
+Sorted by failure count descending. Capped at 20 rows. Note if truncated.
+
+Empty state: "No problem queries detected. Either search is working well or there isn't enough data yet."
+
+### Section 3: Reformulation Pairs (table)
+
+Columns: Initial Query -> Successful Query | Target (symbol @ file) | Occurrences
+
+Sorted by occurrences descending. Capped at 15 rows.
+
+Empty state: "No reformulation patterns detected."
+
+### Section 4: Flagged Episodes (existing cards, filtered)
+
+Default: only stalled + reformulated episodes. Toggle link: "Show all N episodes".
+
+Episode cards are unchanged except: add a small score badge next to each query line showing the top hit score (when available), so you can see at a glance whether results existed but scored low.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/dashboard/search_analysis.rs` | Widen `SearchEpisodeQuery` (4 fields), add `QueryProblem` struct, add `ReformulationPair` struct, extend `EpisodeStats` (5 fields), add `aggregate_problems` fn, add `extract_reformulation_pairs` fn, update `parse_search_query` to extract trace fields |
+| `src/dashboard/routes/search_analysis.rs` | Call new aggregation functions, pass `problems`, `reformulations` to template context |
+| `dashboard/templates/search_analysis.html` | Replace current layout with 4-section diagnostic layout |
+| `dashboard/templates/partials/search_episode_table.html` | Add score badge per query, support `show_all` toggle |
+| `src/tests/dashboard/search_analysis.rs` | Tests for `aggregate_problems`, `extract_reformulation_pairs`, extended `episode_stats` |
+
+## Files Unchanged
+
+- `src/tools/search/trace.rs` (trace infrastructure)
+- `src/handler/search_telemetry.rs` (telemetry capture)
+- `src/daemon/database.rs` (DB schema and queries)
+- `src/dashboard/search_compare.rs` (compare page)
+- Episode builder logic (`analyze_tool_calls`, `EpisodeBuilder`)
+
+## Acceptance Criteria
+
+- [ ] First-try success rate displayed as headline percentage on `/search/analysis`
+- [ ] Outcome breakdown (one-shot, reformulated, stalled, exploratory) shown as counts
+- [ ] Problem queries table ranks failing queries by frequency with token-set grouping
+- [ ] Each problem query row shows avg top hit score and avg result count for triage
+- [ ] Reformulation pairs table shows initial -> successful query with target and occurrences
+- [ ] Episode feed defaults to flagged-only with toggle for all
+- [ ] Episode query lines show top hit score badge when available
+- [ ] All new aggregation functions have unit tests
+- [ ] Existing search_analysis tests still pass
+- [ ] Page renders correctly with zero episodes (empty states)
+- [ ] Page renders correctly with episodes that have no trace data (pre-telemetry calls)

--- a/docs/plans/2026-04-20-search-analysis-diagnostic-rework-design.md
+++ b/docs/plans/2026-04-20-search-analysis-diagnostic-rework-design.md
@@ -12,21 +12,22 @@ Make search better at delivering the right result the first time. The analysis p
 
 ## Design Decisions (Agreed)
 
-1. **Query aggregation**: Token-set overlap (Jaccard on word tokens, reusing existing `token_set` + `queries_overlap` logic) to group similar failing queries. Prevents fragmented views of the same underlying problem.
+1. **Query aggregation**: Canonical key grouping (lowercase, split on case/punctuation/`::` boundaries, drop filler tokens) for problem queries. Handles `SearchHandler` / `search_handler` / `search::handler` as one group. No fuzzy overlap on reformulation pairs (exact canonical match only).
 2. **Episode feed**: Keep below analytics sections, filtered to flagged (stalled + reformulated) episodes by default, with a toggle for all.
-3. **Diagnostic depth per problem query**: Failure signal + top hit context (score, result count). Enough to distinguish "scored low" from "no results" at a glance. Full trace investigation is the Compare page's job.
-4. **Reformulation pairs**: Dedicated ranked table, not inline on episodes. Pattern detection requires scannability.
+3. **Diagnostic depth per problem query**: Failure signal + top hit context (score, result count) + recall-vs-ranking triage signal. Enough to distinguish "scored low" from "no results" and "had the answer but ranked wrong" at a glance. Full trace investigation is the Compare page's job.
+4. **Reformulation pairs**: Dedicated ranked table, not inline on episodes. Extract adjacent query transitions (not just first-vs-last endpoints). Pattern detection requires scannability.
+5. **Episode boundaries**: Add workspace_id as a boundary condition in `analyze_tool_calls`. Cross-workspace searches in the same session must not merge into one episode.
 
 ## Architecture
 
-No new database queries, routes, or pages. This reworks the aggregation layer between the existing `list_tool_calls_for_search_analysis` DB query and the template.
+No new database queries, routes, or pages. This reworks the episode builder boundary logic and the aggregation layer between the existing `list_tool_calls_for_search_analysis` DB query and the template.
 
 ```
 daemon DB (tool_calls table, unchanged)
   -> list_tool_calls_for_search_analysis (unchanged)
-    -> analyze_tool_calls (unchanged, produces Vec<SearchEpisode>)
-      -> NEW: aggregate_problems (token-set grouping of failing queries)
-      -> NEW: extract_reformulation_pairs (query pairs from reformulated episodes)
+    -> analyze_tool_calls (FIX: add workspace_id boundary)
+      -> NEW: aggregate_problems (canonical key grouping of failing queries)
+      -> NEW: extract_reformulation_pairs (adjacent transitions from reformulated episodes)
       -> episode_stats (extended with first-try rate + outcome breakdown)
         -> template (reworked layout, 4 sections)
 ```
@@ -35,14 +36,14 @@ daemon DB (tool_calls table, unchanged)
 
 ### Widen `SearchEpisodeQuery`
 
-Add fields from the trace JSON that is already stored in the `metadata` column:
+Add fields from the trace JSON that is already stored in the `metadata` column. All new fields are `Option` to handle pre-telemetry calls and failed executions where `trace` is null:
 
 | Field | Type | Source in metadata JSON |
 |-------|------|------------------------|
 | `top_hit_score` | `Option<f32>` | `trace.top_hits[0].score` |
-| `result_count` | `usize` | `trace.result_count` |
-| `strategy` | `String` | `trace.strategy` |
-| `relaxed` | `bool` | `trace.relaxed` |
+| `result_count` | `Option<usize>` | `trace.result_count` |
+| `strategy` | `Option<String>` | `trace.strategy` |
+| `relaxed` | `Option<bool>` | `trace.relaxed` |
 
 These are extracted in `parse_search_query` from the same JSON blob already being parsed. No DB schema changes.
 
@@ -53,23 +54,24 @@ One per aggregated problem query group:
 | Field | Type | Purpose |
 |-------|------|---------|
 | `representative_query` | `String` | Most frequent query text in the group |
-| `variants` | `Vec<String>` | Other query texts that token-overlap with representative |
+| `variants` | `Vec<String>` | Other query texts that canonicalize to the same key |
 | `failure_count` | `usize` | Total episodes where this group stalled or reformulated |
 | `stall_count` | `usize` | Episodes where this group stalled |
 | `reformulation_count` | `usize` | Episodes where this group required reformulation |
 | `last_seen` | `i64` | Most recent failure timestamp |
 | `avg_top_score` | `Option<f32>` | Average top hit score across failures (None when no results) |
-| `avg_result_count` | `f32` | Average result count across failures |
+| `avg_result_count` | `Option<f32>` | Average result count across failures (None when no trace data) |
+| `triage_signal` | `String` | "recall_gap", "ranking_problem", "mixed", or "unknown" |
 
 ### New `ReformulationPair` struct
 
 | Field | Type | Purpose |
 |-------|------|---------|
-| `initial_query` | `String` | What the agent searched first (the failing query) |
-| `successful_query` | `String` | What the agent searched that worked |
+| `initial_query` | `String` | What the agent searched in this transition step |
+| `successful_query` | `String` | What the agent searched next (that led to convergence) |
 | `target_name` | `Option<String>` | Downstream symbol found |
 | `target_file` | `Option<String>` | File where target was found |
-| `occurrences` | `usize` | How many times this pair appeared |
+| `occurrences` | `usize` | How many times this adjacent pair appeared |
 
 ### Extend `EpisodeStats`
 
@@ -85,22 +87,72 @@ Add to existing struct:
 
 Existing `convergence_rate` and `stall_rate` stay (used by compare page).
 
+## Episode Builder Fix
+
+### Workspace boundary in `analyze_tool_calls`
+
+Add `workspace_id` mismatch as a boundary condition in the `should_start_new` check. Current boundaries: different session, >10s gap, episode closed. New boundary: different workspace.
+
+```rust
+let should_start_new = current.as_ref().is_none_or(|episode| {
+    episode.session_id != row.session_id
+        || episode.workspace_id != row.workspace_id  // NEW
+        || row.timestamp - episode.last_search_ts > 10
+        || episode.closed
+});
+```
+
+This prevents cross-workspace searches from merging into one episode, which would corrupt all downstream metrics.
+
+### Problem query extraction
+
+For stalled episodes: all queries are candidates for the problem query table.
+
+For reformulated episodes: exclude the terminal successful query (the last one). The successful query solved the problem; including it in the "problem" pool inflates failure counts and pollutes groupings. Count at most once per episode per group to prevent multi-query episodes from inflating a single group.
+
 ## Aggregation Functions
+
+### Canonical key for query grouping
+
+```
+fn canonical_key(query: &str) -> Vec<String>
+```
+
+1. Split on whitespace, `::`, `_`, `.`, and camelCase boundaries
+2. Lowercase all tokens
+3. Drop filler tokens: "find", "get", "the", "a", "an", "for", "in", "of", "to", "with"
+4. Sort tokens alphabetically (order-independent)
+5. Return as `Vec<String>`
+
+Two queries match when their canonical keys are identical. This handles `SearchHandler`, `search_handler`, `search::handler`, and `search handler` as the same group.
 
 ### `aggregate_problems(episodes: &[SearchEpisode]) -> Vec<QueryProblem>`
 
 1. Filter episodes to those with outcome `stalled` or `reformulation_converged`.
-2. Collect all queries from those episodes.
-3. Group queries by token-set overlap: for each query, check if it overlaps with an existing group's representative (using `token_set` and a Jaccard threshold). If yes, add to that group. If no, start a new group.
-4. For each group, compute: representative (most frequent query text), variants, failure/stall/reformulation counts, last_seen, avg_top_score, avg_result_count.
-5. Sort by `failure_count` descending.
-6. Return top 20.
+2. Collect candidate queries: for stalled episodes, all queries; for reformulated episodes, all except the last query.
+3. Group by canonical key. For each group, count at most one failure per episode to prevent inflation.
+4. For each group, compute: representative (most frequent raw query text), variants (other raw texts), failure/stall/reformulation counts, last_seen, avg_top_score, avg_result_count.
+5. Compute `triage_signal` per group (see below).
+6. Sort by `failure_count` descending.
+7. Return top 20.
+
+### Recall-vs-ranking triage
+
+For reformulated episodes where we have both the initial query's `top_hits` (from trace) and the episode's `target_symbol_name`:
+
+- If the target symbol name appears in the initial query's top_hits: **ranking_problem** (search had the answer but ranked it too low)
+- If the target symbol name does not appear in the initial query's top_hits: **recall_gap** (search didn't find it at all)
+- If trace data is missing or target is unknown: **unknown**
+
+Aggregate per problem group: if >50% ranking, "ranking_problem"; if >50% recall, "recall_gap"; otherwise "mixed".
+
+This is the strongest diagnostic signal: it tells you whether to fix scoring or fix indexing/tokenization.
 
 ### `extract_reformulation_pairs(episodes: &[SearchEpisode]) -> Vec<ReformulationPair>`
 
 1. Filter episodes to those with outcome `reformulation_converged`.
-2. For each episode: take the first query as `initial_query`, the last query as `successful_query`, and the episode's `target_symbol_name`/`target_file_path` as the target.
-3. Deduplicate pairs by token-set overlap on both initial and successful queries. Sum occurrences.
+2. For each episode with N queries, extract N-1 adjacent transitions: `(query[0] -> query[1])`, `(query[1] -> query[2])`, etc. Each transition carries the episode's downstream target.
+3. Deduplicate by exact canonical key match on both sides of the pair. Sum occurrences.
 4. Sort by `occurrences` descending.
 5. Return top 15.
 
@@ -114,7 +166,9 @@ Existing `convergence_rate` and `stall_rate` stay (used by compare page).
 
 ### Section 2: Problem Queries (table)
 
-Columns: Query | Variants | Failures (stall/reform split) | Avg Score | Avg Results | Last Seen
+Columns: Query | Variants | Failures (stall/reform split) | Triage | Avg Score | Avg Results | Last Seen
+
+The Triage column shows a compact label: "ranking" (amber), "recall" (red), "mixed" (grey), or "unknown" (muted).
 
 Sorted by failure count descending. Capped at 20 rows. Note if truncated.
 
@@ -134,15 +188,23 @@ Default: only stalled + reformulated episodes. Toggle link: "Show all N episodes
 
 Episode cards are unchanged except: add a small score badge next to each query line showing the top hit score (when available), so you can see at a glance whether results existed but scored low.
 
+The toggle is controlled via a query parameter (`?show_all=true`), requiring the route to accept it.
+
 ## Files Modified
 
 | File | Change |
 |------|--------|
-| `src/dashboard/search_analysis.rs` | Widen `SearchEpisodeQuery` (4 fields), add `QueryProblem` struct, add `ReformulationPair` struct, extend `EpisodeStats` (5 fields), add `aggregate_problems` fn, add `extract_reformulation_pairs` fn, update `parse_search_query` to extract trace fields |
-| `src/dashboard/routes/search_analysis.rs` | Call new aggregation functions, pass `problems`, `reformulations` to template context |
+| `src/dashboard/search_analysis.rs` | Widen `SearchEpisodeQuery` (4 `Option` fields), add `QueryProblem` struct (with `triage_signal`), add `ReformulationPair` struct, extend `EpisodeStats` (5 fields), add `canonical_key` fn, add `aggregate_problems` fn, add `extract_reformulation_pairs` fn, add recall-vs-ranking triage logic, update `parse_search_query` to extract trace fields, fix problem query extraction to exclude terminal successful query |
+| `src/dashboard/routes/search_analysis.rs` | Accept `show_all` query param, call new aggregation functions, pass `problems`, `reformulations`, `show_all` to template context |
 | `dashboard/templates/search_analysis.html` | Replace current layout with 4-section diagnostic layout |
-| `dashboard/templates/partials/search_episode_table.html` | Add score badge per query, support `show_all` toggle |
-| `src/tests/dashboard/search_analysis.rs` | Tests for `aggregate_problems`, `extract_reformulation_pairs`, extended `episode_stats` |
+| `dashboard/templates/partials/search_episode_table.html` | Add score badge per query, support filtered/all toggle |
+| `src/tests/dashboard/search_analysis.rs` | Tests for `canonical_key`, `aggregate_problems`, `extract_reformulation_pairs`, extended `episode_stats`, recall-vs-ranking triage, workspace boundary, null trace handling |
+
+## Files With Targeted Fix
+
+| File | Change |
+|------|--------|
+| `src/dashboard/search_analysis.rs` (`analyze_tool_calls`) | Add `workspace_id` to the `should_start_new` boundary check. One-line addition to existing condition. |
 
 ## Files Unchanged
 
@@ -150,18 +212,36 @@ Episode cards are unchanged except: add a small score badge next to each query l
 - `src/handler/search_telemetry.rs` (telemetry capture)
 - `src/daemon/database.rs` (DB schema and queries)
 - `src/dashboard/search_compare.rs` (compare page)
-- Episode builder logic (`analyze_tool_calls`, `EpisodeBuilder`)
+
+## Test Coverage Requirements
+
+Beyond the acceptance criteria, the following edge cases must be covered:
+
+- Null trace metadata (pre-telemetry tool calls)
+- Zero-hit trace (trace exists but `top_hits` is empty, `result_count` is 0)
+- 3+ query reformulation episodes (adjacent pair extraction)
+- Workspace switches within a session (boundary check)
+- >10s gaps between searches (episode split)
+- Mixed `search_target` within an episode (definitions vs content)
+- Repeated query variants within a single episode (one-per-episode counting)
+- Empty episode list (all empty states render)
+- `show_all` toggle (route param handling)
 
 ## Acceptance Criteria
 
+- [ ] Episode builder splits on workspace_id change (cross-workspace searches never merge)
 - [ ] First-try success rate displayed as headline percentage on `/search/analysis`
 - [ ] Outcome breakdown (one-shot, reformulated, stalled, exploratory) shown as counts
-- [ ] Problem queries table ranks failing queries by frequency with token-set grouping
-- [ ] Each problem query row shows avg top hit score and avg result count for triage
-- [ ] Reformulation pairs table shows initial -> successful query with target and occurrences
-- [ ] Episode feed defaults to flagged-only with toggle for all
+- [ ] Problem queries table ranks failing queries by canonical key grouping
+- [ ] Problem query extraction excludes terminal successful query from reformulated episodes
+- [ ] Each problem query row shows triage signal (ranking/recall/mixed/unknown)
+- [ ] Each problem query row shows avg top hit score and avg result count
+- [ ] Reformulation pairs table shows adjacent transitions with target and occurrences
+- [ ] Reformulation pair dedup uses exact canonical key match (no fuzzy)
+- [ ] Episode feed defaults to flagged-only with toggle for all (`?show_all=true`)
 - [ ] Episode query lines show top hit score badge when available
-- [ ] All new aggregation functions have unit tests
+- [ ] All trace-derived fields are `Option` and handle null trace gracefully
+- [ ] All new aggregation functions have unit tests covering edge cases listed above
 - [ ] Existing search_analysis tests still pass
 - [ ] Page renders correctly with zero episodes (empty states)
 - [ ] Page renders correctly with episodes that have no trace data (pre-telemetry calls)

--- a/docs/plans/2026-04-20-search-analysis-diagnostic-rework-implementation-plan.md
+++ b/docs/plans/2026-04-20-search-analysis-diagnostic-rework-implementation-plan.md
@@ -1,0 +1,122 @@
+# Search Analysis Diagnostic Rework — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use razorback:executing-plans to implement this plan. Tasks are sequential (shared file prevents parallelism).
+
+**Goal:** Rework `/search/analysis` from a chronological episode feed into a diagnostic tool that surfaces first-try success rate, problem queries, and reformulation pairs.
+
+**Architecture:** No new DB queries or routes. Widen the data model to carry trace fields through, add aggregation functions (canonical key grouping, adjacent pair extraction, recall-vs-ranking triage), and rework the template into 4 diagnostic sections.
+
+**Tech Stack:** Rust (axum, serde, tera), HTML (tera templates)
+
+**Design Spec:** `docs/plans/2026-04-20-search-analysis-diagnostic-rework-design.md`
+
+---
+
+### Task 1: Data Model + Episode Builder Fix
+
+**Files:**
+- Modify: `src/dashboard/search_analysis.rs:18-26` (SearchEpisodeQuery)
+- Modify: `src/dashboard/search_analysis.rs:44-48` (EpisodeStats)
+- Modify: `src/dashboard/search_analysis.rs:59-61` (should_start_new in analyze_tool_calls)
+- Modify: `src/dashboard/search_analysis.rs:103-119` (episode_stats fn)
+- Modify: `src/dashboard/search_analysis.rs:188-207` (parse_search_query)
+- Modify: `src/tests/dashboard/search_analysis.rs:4-35` (fast_search_row helper)
+- Modify: `src/tests/dashboard/search_analysis.rs` (add new tests)
+
+**What to build:** Foundation changes that all subsequent tasks depend on. Three things:
+
+1. Widen `SearchEpisodeQuery` with 4 new `Option` fields: `top_hit_score: Option<f32>`, `result_count: Option<usize>`, `strategy: Option<String>`, `relaxed: Option<bool>`. Update `parse_search_query` to extract these from the trace JSON that's already being parsed (lines 188-207). The trace can be null for pre-telemetry calls, so all fields must gracefully handle missing data.
+
+2. Add `workspace_id` boundary to `analyze_tool_calls`. In the `should_start_new` condition (line 59-61), add `|| episode.workspace_id != row.workspace_id`. Also add the same check in the non-search branch (line 75) where `session_id` is already checked.
+
+3. Extend `EpisodeStats` with `first_try_rate: f64`, `one_shot_count: usize`, `reformulation_count: usize`, `stall_count: usize`, `exploratory_count: usize`. Update `episode_stats` fn to compute these from episode outcomes. Keep existing `convergence_rate` and `stall_rate`.
+
+**Approach:**
+- The `parse_search_query` function already accesses `trace["top_hits"][0]["name"]`. Add sibling extractions for `trace["top_hits"][0]["score"]`, `trace["result_count"]`, `trace["strategy"]`, `trace["relaxed"]`. Use `.as_f64().map(|v| v as f32)` for score, `.as_u64().map(|v| v as usize)` for result_count, `.as_str().map(ToOwned::to_owned)` for strategy, `.as_bool()` for relaxed.
+- Update the `fast_search_row` test helper to include `score`, `result_count`, `strategy`, `relaxed` in its trace JSON. Add a second helper `fast_search_row_no_trace` that sets `metadata` to a JSON blob with no `trace` key (for null-trace tests).
+- Outcome counting in `episode_stats`: iterate episodes, match on `outcome.as_str()` for "one_shot_success", "reformulation_converged", "stalled", and count "exploratory_success" as the remainder.
+
+**Acceptance criteria:**
+- [ ] `SearchEpisodeQuery` has 4 new Option fields populated from trace JSON
+- [ ] `parse_search_query` handles null trace (all new fields are None)
+- [ ] Episodes split on workspace_id change
+- [ ] `EpisodeStats` has first_try_rate and outcome breakdown counts
+- [ ] Test: workspace boundary splits episodes correctly
+- [ ] Test: null trace metadata produces None fields (not panics or fake zeros)
+- [ ] Test: episode_stats computes first_try_rate and outcome counts correctly
+- [ ] Existing 3 tests still pass
+- [ ] Tests pass, committed
+
+---
+
+### Task 2: Aggregation Functions
+
+**Files:**
+- Modify: `src/dashboard/search_analysis.rs` (add structs and functions after existing code)
+- Modify: `src/tests/dashboard/search_analysis.rs` (add tests)
+
+**What to build:** Three new public functions and two new structs that transform episodes into diagnostic views.
+
+1. **`canonical_key(query: &str) -> Vec<String>`**: Split on whitespace, `::`, `_`, `.`, and camelCase boundaries (insert split before each uppercase letter that follows a lowercase). Lowercase all tokens. Drop filler tokens: `["find", "get", "the", "a", "an", "for", "in", "of", "to", "with"]`. Sort alphabetically. Return as Vec.
+
+2. **`QueryProblem` struct** and **`aggregate_problems(episodes: &[SearchEpisode]) -> Vec<QueryProblem>`**: Filter to stalled + reformulated episodes. For reformulated episodes, exclude the last query (it succeeded). Group remaining queries by canonical key. Count at most one failure per episode per group (prevent inflation from multi-query episodes). Compute avg_top_score (average of `top_hit_score` values where Some), avg_result_count (average of `result_count` values where Some). Compute `triage_signal`: for reformulated episodes in the group, check if `target_symbol_name` appears in any of the group's queries' `top_hit_name` — if yes, "ranking_problem"; if no, "recall_gap"; mixed if both occur; "unknown" if no target data. Sort by failure_count desc, return top 20.
+
+3. **`ReformulationPair` struct** and **`extract_reformulation_pairs(episodes: &[SearchEpisode]) -> Vec<ReformulationPair>`**: Filter to reformulated episodes. For each episode with N queries, extract N-1 adjacent transitions: `(queries[i].query, queries[i+1].query)`. Each pair carries the episode's `target_symbol_name` and `target_file_path`. Deduplicate by exact canonical key match on both sides (canonical_key of initial == canonical_key of existing initial AND canonical_key of successful == canonical_key of existing successful). Sum occurrences. Sort by occurrences desc, return top 15.
+
+**Approach:**
+- CamelCase splitting: iterate chars, when an uppercase char follows a lowercase char, start a new token. This handles `SearchHandler` -> `["search", "handler"]` and `HTMLParser` -> `["html", "parser"]` (consecutive uppercase stays together until a lowercase follows).
+- For triage, the comparison is between `episode.target_symbol_name` and the query's `top_hit_name` field. Both are `Option<String>`. A match means the target was in results (ranking problem); no match means it wasn't (recall gap).
+- `avg_top_score` and `avg_result_count` should be `Option` — None when no queries in the group have trace data.
+
+**Acceptance criteria:**
+- [ ] `canonical_key("SearchHandler")` == `canonical_key("search_handler")` == `canonical_key("search::handler")`
+- [ ] `canonical_key` drops filler tokens: `canonical_key("find the handler")` == `canonical_key("handler")`
+- [ ] `aggregate_problems` excludes terminal successful query from reformulated episodes
+- [ ] `aggregate_problems` counts at most one failure per episode per group
+- [ ] `aggregate_problems` computes triage_signal (ranking_problem / recall_gap / mixed / unknown)
+- [ ] `extract_reformulation_pairs` extracts N-1 adjacent pairs from N-query episodes
+- [ ] `extract_reformulation_pairs` deduplicates by exact canonical key on both sides
+- [ ] Both functions handle empty episode list (return empty vec)
+- [ ] Both functions handle episodes with no trace data gracefully
+- [ ] Tests pass, committed
+
+---
+
+### Task 3: Route + Templates
+
+**Files:**
+- Modify: `src/dashboard/routes/search_analysis.rs:9` (imports)
+- Modify: `src/dashboard/routes/search_analysis.rs:12-14` (SearchAnalysisParams)
+- Modify: `src/dashboard/routes/search_analysis.rs:16-36` (index handler)
+- Modify: `dashboard/templates/search_analysis.html` (full rewrite)
+- Modify: `dashboard/templates/partials/search_episode_table.html` (score badge + filter)
+- Modify: `src/tests/dashboard/integration.rs` (if analysis route integration tests exist)
+
+**What to build:** Wire the new aggregation functions into the route and rework the template into 4 diagnostic sections.
+
+1. **Route changes**: Add `show_all: Option<bool>` to `SearchAnalysisParams`. Import `aggregate_problems`, `extract_reformulation_pairs` alongside existing imports. After computing episodes and stats, call `aggregate_problems(&episodes)` and `extract_reformulation_pairs(&episodes)`. Filter episodes for template: if `show_all` is not true, filter to only episodes where `suspicious == true`. Insert `problems`, `reformulations`, `filtered_episodes`, `show_all`, and `total_episode_count` into the template context.
+
+2. **Template rework** (`search_analysis.html`): Replace the current layout with 4 sections. Keep the header with Playground/Analysis/Compare nav buttons. Section 1: summary cards row — first_try_rate as percentage (multiply by 100, format to 1 decimal), outcome counts (one_shot_count, reformulation_count, stall_count, exploratory_count), window days. Section 2: problem queries table. Section 3: reformulation pairs table. Section 4: episode feed (using the existing partial).
+
+3. **Episode table partial** (`search_episode_table.html`): Add a score badge after each query line — when `query.top_hit_score` is present, show a small `<span class="tag">` with the score formatted to 2 decimals. Add a toggle link above the feed: if not show_all, show "Showing N flagged episodes. Show all M episodes" linking to `?show_all=true&days=D`; if show_all, show "Showing all M episodes. Show flagged only" linking to `?days=D`.
+
+**Approach:**
+- Follow the existing dashboard styling conventions: `julie-card` class for sections, `label-text` for labels, `mono` for values, `tag` classes for badges. Check `dashboard/templates/metrics.html` or `dashboard/templates/projects.html` for table styling patterns.
+- The triage signal column in the problem queries table should use color-coded tags: `is-danger is-light` for recall_gap (red), `is-warning is-light` for ranking_problem (amber), no special color for mixed/unknown.
+- Empty states: use a centered `julie-card` with muted text, matching the existing empty state in `search_episode_table.html` line 2-5.
+- The `first_try_rate` value from stats is 0.0-1.0. Multiply by 100 in the template and show with 1 decimal: `{{ (episode_stats.first_try_rate * 100) | round(precision=1) }}%`.
+
+**Acceptance criteria:**
+- [ ] Route accepts `?show_all=true` param and filters episodes accordingly
+- [ ] Route passes problems, reformulations, filtered episodes to template
+- [ ] Headline metrics section shows first-try success rate as percentage
+- [ ] Outcome breakdown shows counts for all 4 outcome types
+- [ ] Problem queries table renders with columns: Query, Variants, Failures, Triage, Avg Score, Avg Results, Last Seen
+- [ ] Triage column uses color-coded tags (red for recall, amber for ranking)
+- [ ] Reformulation pairs table renders with columns: Initial -> Successful, Target, Occurrences
+- [ ] Episode feed shows flagged-only by default with toggle to show all
+- [ ] Score badge appears on query lines when top_hit_score is present
+- [ ] Empty states render correctly for each section
+- [ ] Page renders without errors when there are zero episodes
+- [ ] Page renders without errors when episodes have no trace data
+- [ ] Tests pass, committed

--- a/src/daemon/database.rs
+++ b/src/daemon/database.rs
@@ -79,6 +79,9 @@ impl DaemonDatabase {
         if current < 3 {
             Self::migration_003_cleanup_events_and_drop_workspace_references(conn)?;
         }
+        if current < 4 {
+            Self::migration_004_add_search_compare_tables(conn)?;
+        }
 
         Ok(())
     }
@@ -184,6 +187,51 @@ impl DaemonDatabase {
         )?;
         tx.commit()?;
         info!("daemon.db migration 003 complete");
+        Ok(())
+    }
+
+    fn migration_004_add_search_compare_tables(conn: &mut Connection) -> Result<()> {
+        info!("daemon.db migration 004: add search compare tables");
+        let tx = conn.transaction()?;
+        tx.execute_batch(
+            "CREATE TABLE IF NOT EXISTS search_compare_runs (
+                id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at               INTEGER NOT NULL,
+                baseline_strategy        TEXT NOT NULL,
+                candidate_strategy       TEXT NOT NULL,
+                case_count               INTEGER NOT NULL,
+                baseline_top1_hits       INTEGER NOT NULL,
+                candidate_top1_hits      INTEGER NOT NULL,
+                baseline_top3_hits       INTEGER NOT NULL,
+                candidate_top3_hits      INTEGER NOT NULL,
+                baseline_source_wins     INTEGER NOT NULL,
+                candidate_source_wins    INTEGER NOT NULL,
+                convergence_rate         REAL,
+                stall_rate               REAL
+            );
+            CREATE TABLE IF NOT EXISTS search_compare_cases (
+                id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_id                INTEGER NOT NULL REFERENCES search_compare_runs(id) ON DELETE CASCADE,
+                session_id            TEXT NOT NULL,
+                workspace_id          TEXT NOT NULL,
+                query                 TEXT NOT NULL,
+                search_target         TEXT NOT NULL,
+                expected_symbol_name  TEXT,
+                expected_file_path    TEXT,
+                baseline_rank         INTEGER,
+                candidate_rank        INTEGER,
+                baseline_top_hit      TEXT,
+                candidate_top_hit     TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_search_compare_runs_created_at
+                ON search_compare_runs(created_at DESC, id DESC);
+            CREATE INDEX IF NOT EXISTS idx_search_compare_cases_run
+                ON search_compare_cases(run_id, id);
+            INSERT OR REPLACE INTO schema_version (version, applied_at)
+            VALUES (4, unixepoch());",
+        )?;
+        tx.commit()?;
+        info!("daemon.db migration 004 complete");
         Ok(())
     }
 
@@ -627,6 +675,119 @@ impl DaemonDatabase {
         Ok(())
     }
 
+    pub fn list_tool_calls_for_search_analysis(&self, days: u32) -> Result<Vec<SearchToolCallRow>> {
+        let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
+        let cutoff = now_unix() - (days as i64 * 86400);
+        let mut stmt = conn.prepare_cached(
+            "SELECT id, workspace_id, session_id, timestamp, tool_name, metadata
+             FROM tool_calls
+             WHERE timestamp >= ?1
+             ORDER BY session_id, timestamp, id",
+        )?;
+        let rows = stmt.query_map(params![cutoff], |row| {
+            Ok(SearchToolCallRow {
+                id: row.get(0)?,
+                workspace_id: row.get(1)?,
+                session_id: row.get(2)?,
+                timestamp: row.get(3)?,
+                tool_name: row.get(4)?,
+                metadata: row.get(5)?,
+            })
+        })?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    pub fn insert_search_compare_run(&self, run: &SearchCompareRunInput) -> Result<i64> {
+        let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
+        conn.execute(
+            "INSERT INTO search_compare_runs
+                (created_at, baseline_strategy, candidate_strategy, case_count,
+                 baseline_top1_hits, candidate_top1_hits, baseline_top3_hits, candidate_top3_hits,
+                 baseline_source_wins, candidate_source_wins, convergence_rate, stall_rate)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                now_unix(),
+                run.baseline_strategy,
+                run.candidate_strategy,
+                run.case_count,
+                run.baseline_top1_hits,
+                run.candidate_top1_hits,
+                run.baseline_top3_hits,
+                run.candidate_top3_hits,
+                run.baseline_source_wins,
+                run.candidate_source_wins,
+                run.convergence_rate,
+                run.stall_rate,
+            ],
+        )?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    pub fn replace_search_compare_cases(
+        &self,
+        run_id: i64,
+        cases: &[SearchCompareCaseInput],
+    ) -> Result<()> {
+        let mut conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
+        let tx = conn.transaction()?;
+        tx.execute(
+            "DELETE FROM search_compare_cases WHERE run_id = ?1",
+            params![run_id],
+        )?;
+        {
+            let mut stmt = tx.prepare_cached(
+                "INSERT INTO search_compare_cases
+                    (run_id, session_id, workspace_id, query, search_target, expected_symbol_name,
+                     expected_file_path, baseline_rank, candidate_rank, baseline_top_hit, candidate_top_hit)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            )?;
+            for case in cases {
+                stmt.execute(params![
+                    run_id,
+                    case.session_id,
+                    case.workspace_id,
+                    case.query,
+                    case.search_target,
+                    case.expected_symbol_name,
+                    case.expected_file_path,
+                    case.baseline_rank,
+                    case.candidate_rank,
+                    case.baseline_top_hit,
+                    case.candidate_top_hit,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn list_search_compare_runs(&self, limit: u32) -> Result<Vec<SearchCompareRunRow>> {
+        let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
+        let mut stmt = conn.prepare_cached(
+            "SELECT id, created_at, baseline_strategy, candidate_strategy, case_count,
+                    baseline_top1_hits, candidate_top1_hits, baseline_top3_hits, candidate_top3_hits,
+                    baseline_source_wins, candidate_source_wins, convergence_rate, stall_rate
+             FROM search_compare_runs
+             ORDER BY created_at DESC, id DESC
+             LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(params![limit as i64], SearchCompareRunRow::from_row)?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    pub fn list_search_compare_cases(&self, run_id: i64) -> Result<Vec<SearchCompareCaseRow>> {
+        let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
+        let mut stmt = conn.prepare_cached(
+            "SELECT id, run_id, session_id, workspace_id, query, search_target, expected_symbol_name,
+                    expected_file_path, baseline_rank, candidate_rank, baseline_top_hit, candidate_top_hit
+             FROM search_compare_cases
+             WHERE run_id = ?1
+             ORDER BY id",
+        )?;
+        let rows = stmt.query_map(params![run_id], SearchCompareCaseRow::from_row)?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
     /// Direct connection access for tests only.
     #[cfg(test)]
     pub fn conn_for_test(&self) -> std::sync::MutexGuard<'_, Connection> {
@@ -802,6 +963,114 @@ impl DaemonDatabase {
 // -----------------------------------------------------------------------------
 // Row types
 // -----------------------------------------------------------------------------
+
+pub struct SearchToolCallRow {
+    pub id: i64,
+    pub workspace_id: String,
+    pub session_id: String,
+    pub timestamp: i64,
+    pub tool_name: String,
+    pub metadata: Option<String>,
+}
+
+pub struct SearchCompareRunInput {
+    pub baseline_strategy: String,
+    pub candidate_strategy: String,
+    pub case_count: i64,
+    pub baseline_top1_hits: i64,
+    pub candidate_top1_hits: i64,
+    pub baseline_top3_hits: i64,
+    pub candidate_top3_hits: i64,
+    pub baseline_source_wins: i64,
+    pub candidate_source_wins: i64,
+    pub convergence_rate: Option<f64>,
+    pub stall_rate: Option<f64>,
+}
+
+pub struct SearchCompareCaseInput {
+    pub session_id: String,
+    pub workspace_id: String,
+    pub query: String,
+    pub search_target: String,
+    pub expected_symbol_name: Option<String>,
+    pub expected_file_path: Option<String>,
+    pub baseline_rank: Option<i64>,
+    pub candidate_rank: Option<i64>,
+    pub baseline_top_hit: Option<String>,
+    pub candidate_top_hit: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SearchCompareRunRow {
+    pub id: i64,
+    pub created_at: i64,
+    pub baseline_strategy: String,
+    pub candidate_strategy: String,
+    pub case_count: i64,
+    pub baseline_top1_hits: i64,
+    pub candidate_top1_hits: i64,
+    pub baseline_top3_hits: i64,
+    pub candidate_top3_hits: i64,
+    pub baseline_source_wins: i64,
+    pub candidate_source_wins: i64,
+    pub convergence_rate: Option<f64>,
+    pub stall_rate: Option<f64>,
+}
+
+impl SearchCompareRunRow {
+    fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get(0)?,
+            created_at: row.get(1)?,
+            baseline_strategy: row.get(2)?,
+            candidate_strategy: row.get(3)?,
+            case_count: row.get(4)?,
+            baseline_top1_hits: row.get(5)?,
+            candidate_top1_hits: row.get(6)?,
+            baseline_top3_hits: row.get(7)?,
+            candidate_top3_hits: row.get(8)?,
+            baseline_source_wins: row.get(9)?,
+            candidate_source_wins: row.get(10)?,
+            convergence_rate: row.get(11)?,
+            stall_rate: row.get(12)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SearchCompareCaseRow {
+    pub id: i64,
+    pub run_id: i64,
+    pub session_id: String,
+    pub workspace_id: String,
+    pub query: String,
+    pub search_target: String,
+    pub expected_symbol_name: Option<String>,
+    pub expected_file_path: Option<String>,
+    pub baseline_rank: Option<i64>,
+    pub candidate_rank: Option<i64>,
+    pub baseline_top_hit: Option<String>,
+    pub candidate_top_hit: Option<String>,
+}
+
+impl SearchCompareCaseRow {
+    fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get(0)?,
+            run_id: row.get(1)?,
+            session_id: row.get(2)?,
+            workspace_id: row.get(3)?,
+            query: row.get(4)?,
+            search_target: row.get(5)?,
+            expected_symbol_name: row.get(6)?,
+            expected_file_path: row.get(7)?,
+            baseline_rank: row.get(8)?,
+            candidate_rank: row.get(9)?,
+            baseline_top_hit: row.get(10)?,
+            candidate_top_hit: row.get(11)?,
+        })
+    }
+}
 
 /// A row from the `workspaces` table.
 #[derive(Debug, Clone, serde::Serialize)]

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -2,6 +2,8 @@
 
 pub mod error_buffer;
 pub mod routes;
+pub mod search_analysis;
+pub mod search_compare;
 pub mod state;
 
 use std::path::PathBuf;
@@ -156,6 +158,9 @@ pub fn create_router(
         .route("/metrics/summary", get(routes::metrics::summary))
         .route("/search", get(routes::search::index))
         .route("/search", post(routes::search::search))
+        .route("/search/analysis", get(routes::search_analysis::index))
+        .route("/search/compare", get(routes::search_compare::index))
+        .route("/search/compare", post(routes::search_compare::run))
         .route(
             "/intelligence/{workspace_id}",
             get(routes::intelligence::index),

--- a/src/dashboard/routes/mod.rs
+++ b/src/dashboard/routes/mod.rs
@@ -6,4 +6,6 @@ pub mod metrics;
 pub mod projects;
 pub mod projects_actions;
 pub mod search;
+pub mod search_analysis;
+pub mod search_compare;
 pub mod status;

--- a/src/dashboard/routes/projects_actions.rs
+++ b/src/dashboard/routes/projects_actions.rs
@@ -39,7 +39,7 @@ fn extract_text_from_result(result: &CallToolResult) -> String {
         .join("\n")
 }
 
-async fn dashboard_handler(
+pub(crate) async fn dashboard_handler(
     state: &AppState,
 ) -> anyhow::Result<(JulieServerHandler, tempfile::TempDir, String)> {
     let anchor_dir = tempfile::tempdir()?;
@@ -67,7 +67,10 @@ async fn dashboard_handler(
     Ok((handler, anchor_dir, anchor_id))
 }
 
-async fn disconnect_dashboard_attached_workspaces(state: &AppState, handler: &JulieServerHandler) {
+pub(crate) async fn disconnect_dashboard_attached_workspaces(
+    state: &AppState,
+    handler: &JulieServerHandler,
+) {
     let Some(pool) = state.dashboard.workspace_pool() else {
         return;
     };
@@ -78,7 +81,7 @@ async fn disconnect_dashboard_attached_workspaces(state: &AppState, handler: &Ju
     }
 }
 
-async fn cleanup_dashboard_anchor(state: &AppState, anchor_id: &str) {
+pub(crate) async fn cleanup_dashboard_anchor(state: &AppState, anchor_id: &str) {
     if let Some(pool) = state.dashboard.workspace_pool() {
         pool.evict_workspace(anchor_id).await;
     }

--- a/src/dashboard/routes/search.rs
+++ b/src/dashboard/routes/search.rs
@@ -8,7 +8,11 @@ use tera::Context;
 
 use crate::dashboard::AppState;
 use crate::dashboard::render_template;
-use crate::search::index::SearchFilter;
+use crate::dashboard::routes::projects_actions::{
+    cleanup_dashboard_anchor, dashboard_handler, disconnect_dashboard_attached_workspaces,
+};
+use crate::tools::search::execution::{self, SearchExecutionWorkspace};
+use crate::tools::search::trace::{SearchExecutionKind, SearchExecutionResult, SearchHit};
 
 #[derive(Deserialize)]
 pub struct SearchParams {
@@ -79,7 +83,7 @@ pub async fn search(
     context.insert("debug", &debug);
 
     // Run the actual search against the workspace's Tantivy index
-    let results = run_search(
+    let execution = run_search(
         &state,
         &query,
         &workspace_id,
@@ -91,7 +95,16 @@ pub async fn search(
     .await;
 
     let no_pool = state.dashboard.workspace_pool().is_none();
+    let results = execution
+        .as_ref()
+        .map(|result| result.hits.clone())
+        .unwrap_or_default();
     context.insert("results", &results);
+    if let Some(result) = &execution {
+        context.insert("search_trace", &result.trace);
+        context.insert("strategy_id", &result.trace.strategy_id);
+        context.insert("search_relaxed", &result.relaxed);
+    }
     context.insert("no_pool", &no_pool);
 
     // Build centrality ranks (name -> rank 1..=20) for badge display.
@@ -141,21 +154,15 @@ async fn run_search(
     language: &str,
     file_pattern: &str,
     limit: usize,
-) -> Vec<serde_json::Value> {
-    let pool = match state.dashboard.workspace_pool() {
-        Some(pool) => pool,
-        None => return vec![],
-    };
+) -> Option<SearchExecutionResult> {
+    if state.dashboard.workspace_pool().is_none() {
+        return None;
+    }
 
-    // Determine which workspaces to search
-    let ws_ids: Vec<String> = if workspace_id.is_empty() {
-        // Search all loaded workspaces
-        let db = match state.dashboard.daemon_db() {
-            Some(db) => db,
-            None => return vec![],
-        };
+    let workspaces: Vec<String> = if workspace_id.is_empty() {
+        let db = state.dashboard.daemon_db()?;
         db.list_workspaces()
-            .unwrap_or_default()
+            .ok()?
             .iter()
             .map(|ws| ws.workspace_id.clone())
             .collect()
@@ -163,97 +170,69 @@ async fn run_search(
         vec![workspace_id.to_string()]
     };
 
-    let filter = SearchFilter {
-        language: if language.is_empty() {
-            None
-        } else {
-            Some(language.to_string())
-        },
-        file_pattern: if file_pattern.is_empty() {
-            None
-        } else {
-            Some(file_pattern.to_string())
-        },
-        ..Default::default()
-    };
-
-    let mut all_results = Vec::new();
-
-    for ws_id in &ws_ids {
-        let ws = match pool.get(ws_id).await {
-            Some(ws) => ws,
-            None => continue,
-        };
-
-        let search_idx = match &ws.search_index {
-            Some(idx) => idx.clone(),
-            None => continue,
-        };
-
-        let query_str = query.to_string();
-        let filter_clone = filter.clone();
-        let target = search_target.to_string();
-        let ws_id_clone = ws_id.clone();
-
-        // Run search on blocking thread (Tantivy uses synchronous I/O)
-        let results = tokio::task::spawn_blocking(move || {
-            let idx = search_idx.lock().unwrap_or_else(|p| p.into_inner());
-            if target == "content" {
-                // Content search returns file-level matches
-                match idx.search_content(&query_str, &filter_clone, limit) {
-                    Ok(results) => results
-                        .results
-                        .into_iter()
-                        .map(|r| {
-                            let filename = r.file_path.split('/').last().unwrap_or(&r.file_path).to_string();
-                            serde_json::json!({
-                                "name": filename,
-                                "file": r.file_path,
-                                "kind": "file",
-                                "language": r.language,
-                                "score": r.score,
-                                "workspace": ws_id_clone,
-                            })
-                        })
-                        .collect::<Vec<_>>(),
-                    Err(_) => vec![],
-                }
-            } else {
-                // Symbol/definition search
-                match idx.search_symbols(&query_str, &filter_clone, limit) {
-                    Ok(results) => results
-                        .results
-                        .into_iter()
-                        .map(|r| {
-                            serde_json::json!({
-                                "name": r.name,
-                                "file": r.file_path,
-                                "line": r.start_line,
-                                "kind": r.kind,
-                                "language": r.language,
-                                "score": r.score,
-                                "snippet": if r.signature.is_empty() { r.doc_comment } else { r.signature },
-                                "workspace": ws_id_clone,
-                            })
-                        })
-                        .collect::<Vec<_>>(),
-                    Err(_) => vec![],
-                }
-            }
-        })
-        .await
-        .unwrap_or_default();
-
-        all_results.extend(results);
+    if workspaces.is_empty() {
+        return None;
     }
 
-    // Sort by score descending across all workspaces
-    all_results.sort_by(|a, b| {
-        let sa = a["score"].as_f64().unwrap_or(0.0);
-        let sb = b["score"].as_f64().unwrap_or(0.0);
-        sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal)
-    });
+    let (handler, _anchor_dir, anchor_id) = match dashboard_handler(state).await {
+        Ok(session) => session,
+        Err(_) => return None,
+    };
+    let execution_workspaces = workspaces
+        .into_iter()
+        .map(SearchExecutionWorkspace::target)
+        .collect::<Vec<_>>();
+    let language_filter = (!language.is_empty()).then(|| language.to_string());
+    let file_pattern_filter = (!file_pattern.is_empty()).then(|| file_pattern.to_string());
+    let result = execution::execute_search(
+        execution::SearchExecutionParams {
+            query,
+            language: &language_filter,
+            file_pattern: &file_pattern_filter,
+            limit: limit as u32,
+            search_target,
+            context_lines: None,
+            exclude_tests: None,
+        },
+        &execution_workspaces,
+        &handler,
+    )
+    .await
+    .ok();
 
-    all_results.truncate(limit);
-    all_results
+    disconnect_dashboard_attached_workspaces(state, &handler).await;
+    cleanup_dashboard_anchor(state, &anchor_id).await;
+
+    result.map(normalize_dashboard_results)
+}
+
+fn normalize_dashboard_results(result: SearchExecutionResult) -> SearchExecutionResult {
+    let hits = result
+        .hits
+        .into_iter()
+        .map(normalize_dashboard_hit)
+        .collect();
+    SearchExecutionResult {
+        hits,
+        relaxed: result.relaxed,
+        total_results: result.total_results,
+        trace: result.trace,
+        kind: match result.kind {
+            SearchExecutionKind::Definitions => SearchExecutionKind::Definitions,
+            SearchExecutionKind::Content {
+                workspace_label,
+                file_level,
+            } => SearchExecutionKind::Content {
+                workspace_label,
+                file_level,
+            },
+        },
+    }
+}
+
+fn normalize_dashboard_hit(mut hit: SearchHit) -> SearchHit {
+    if hit.kind == "line" && hit.line.is_some() && hit.snippet.is_none() {
+        hit.snippet = Some(String::new());
+    }
+    hit
 }

--- a/src/dashboard/routes/search_analysis.rs
+++ b/src/dashboard/routes/search_analysis.rs
@@ -1,0 +1,36 @@
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::Html;
+use serde::Deserialize;
+use tera::Context;
+
+use crate::dashboard::AppState;
+use crate::dashboard::render_template;
+use crate::dashboard::search_analysis::{analyze_tool_calls, episode_stats};
+
+#[derive(Debug, Deserialize, Default)]
+pub struct SearchAnalysisParams {
+    pub days: Option<u32>,
+}
+
+pub async fn index(
+    State(state): State<AppState>,
+    Query(params): Query<SearchAnalysisParams>,
+) -> Result<Html<String>, StatusCode> {
+    let days = params.days.unwrap_or(7).max(1);
+    let episodes = state
+        .dashboard
+        .daemon_db()
+        .and_then(|db| db.list_tool_calls_for_search_analysis(days).ok())
+        .map(|rows| analyze_tool_calls(&rows))
+        .unwrap_or_default();
+    let stats = episode_stats(&episodes);
+
+    let mut context = Context::new();
+    context.insert("active_page", "search");
+    context.insert("days", &days);
+    context.insert("episodes", &episodes);
+    context.insert("episode_stats", &stats);
+
+    render_template(&state, "search_analysis.html", context).await
+}

--- a/src/dashboard/routes/search_analysis.rs
+++ b/src/dashboard/routes/search_analysis.rs
@@ -6,11 +6,14 @@ use tera::Context;
 
 use crate::dashboard::AppState;
 use crate::dashboard::render_template;
-use crate::dashboard::search_analysis::{analyze_tool_calls, episode_stats};
+use crate::dashboard::search_analysis::{
+    aggregate_problems, analyze_tool_calls, episode_stats, extract_reformulation_pairs,
+};
 
 #[derive(Debug, Deserialize, Default)]
 pub struct SearchAnalysisParams {
     pub days: Option<u32>,
+    pub show_all: Option<bool>,
 }
 
 pub async fn index(
@@ -18,6 +21,7 @@ pub async fn index(
     Query(params): Query<SearchAnalysisParams>,
 ) -> Result<Html<String>, StatusCode> {
     let days = params.days.unwrap_or(7).max(1);
+    let show_all = params.show_all.unwrap_or(false);
     let episodes = state
         .dashboard
         .daemon_db()
@@ -25,12 +29,25 @@ pub async fn index(
         .map(|rows| analyze_tool_calls(&rows))
         .unwrap_or_default();
     let stats = episode_stats(&episodes);
+    let problems = aggregate_problems(&episodes);
+    let reformulations = extract_reformulation_pairs(&episodes);
+
+    let total_episode_count = episodes.len();
+    let filtered_episodes: Vec<_> = if show_all {
+        episodes
+    } else {
+        episodes.into_iter().filter(|e| e.suspicious).collect()
+    };
 
     let mut context = Context::new();
     context.insert("active_page", "search");
     context.insert("days", &days);
-    context.insert("episodes", &episodes);
+    context.insert("show_all", &show_all);
+    context.insert("episodes", &filtered_episodes);
+    context.insert("total_episode_count", &total_episode_count);
     context.insert("episode_stats", &stats);
+    context.insert("problems", &problems);
+    context.insert("reformulations", &reformulations);
 
     render_template(&state, "search_analysis.html", context).await
 }

--- a/src/dashboard/routes/search_compare.rs
+++ b/src/dashboard/routes/search_compare.rs
@@ -1,0 +1,59 @@
+use axum::extract::{Form, Query, State};
+use axum::http::StatusCode;
+use axum::response::Html;
+use serde::Deserialize;
+use tera::Context;
+
+use crate::dashboard::AppState;
+use crate::dashboard::render_template;
+use crate::dashboard::search_compare::{latest_compare_view, run_compare};
+
+#[derive(Debug, Deserialize, Default)]
+pub struct SearchCompareParams {
+    pub days: Option<u32>,
+    pub run_id: Option<i64>,
+}
+
+pub async fn index(
+    State(state): State<AppState>,
+    Query(params): Query<SearchCompareParams>,
+) -> Result<Html<String>, StatusCode> {
+    render_compare(&state, params.days.unwrap_or(7), params.run_id).await
+}
+
+pub async fn run(
+    State(state): State<AppState>,
+    Form(params): Form<SearchCompareParams>,
+) -> Result<Html<String>, StatusCode> {
+    let days = params.days.unwrap_or(7).max(1);
+    let view = run_compare(&state, days)
+        .await
+        .or_else(|_| latest_compare_view(&state, 10, params.run_id))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let mut context = Context::new();
+    context.insert("active_page", "search");
+    context.insert("days", &days);
+    context.insert("compare_runs", &view.runs);
+    context.insert("selected_run", &view.selected_run);
+    context.insert("compare_cases", &view.cases);
+
+    render_template(&state, "search_compare.html", context).await
+}
+
+async fn render_compare(
+    state: &AppState,
+    days: u32,
+    run_id: Option<i64>,
+) -> Result<Html<String>, StatusCode> {
+    let view =
+        latest_compare_view(state, 10, run_id).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let mut context = Context::new();
+    context.insert("active_page", "search");
+    context.insert("days", &days);
+    context.insert("compare_runs", &view.runs);
+    context.insert("selected_run", &view.selected_run);
+    context.insert("compare_cases", &view.cases);
+
+    render_template(state, "search_compare.html", context).await
+}

--- a/src/dashboard/search_analysis.rs
+++ b/src/dashboard/search_analysis.rs
@@ -23,6 +23,10 @@ pub struct SearchEpisodeQuery {
     pub search_target: String,
     pub top_hit_name: Option<String>,
     pub top_hit_file: Option<String>,
+    pub top_hit_score: Option<f32>,
+    pub result_count: Option<usize>,
+    pub strategy: Option<String>,
+    pub relaxed: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -45,6 +49,11 @@ pub struct EpisodeStats {
     pub total_episodes: usize,
     pub convergence_rate: f64,
     pub stall_rate: f64,
+    pub first_try_rate: f64,
+    pub one_shot_count: usize,
+    pub reformulation_count: usize,
+    pub stall_count: usize,
+    pub exploratory_count: usize,
 }
 
 pub fn analyze_tool_calls(rows: &[SearchToolCallRow]) -> Vec<SearchEpisode> {
@@ -56,6 +65,7 @@ pub fn analyze_tool_calls(rows: &[SearchToolCallRow]) -> Vec<SearchEpisode> {
             let search = parse_search_query(row);
             let should_start_new = current.as_ref().is_none_or(|episode| {
                 episode.session_id != row.session_id
+                    || episode.workspace_id != row.workspace_id
                     || row.timestamp - episode.last_search_ts > 10
                     || episode.closed
             });
@@ -72,7 +82,9 @@ pub fn analyze_tool_calls(rows: &[SearchToolCallRow]) -> Vec<SearchEpisode> {
         }
 
         if let Some(episode) = current.as_mut() {
-            if episode.session_id != row.session_id {
+            if episode.session_id != row.session_id
+                || episode.workspace_id != row.workspace_id
+            {
                 let finished = current.take().expect("episode");
                 episodes.push(finished.finish());
             } else {
@@ -102,19 +114,29 @@ pub fn analyze_tool_calls(rows: &[SearchToolCallRow]) -> Vec<SearchEpisode> {
 
 pub fn episode_stats(episodes: &[SearchEpisode]) -> EpisodeStats {
     let total = episodes.len().max(1) as f64;
-    let converged = episodes
-        .iter()
-        .filter(|episode| episode.outcome == "reformulation_converged")
-        .count() as f64;
-    let stalled = episodes
-        .iter()
-        .filter(|episode| episode.outcome == "stalled")
-        .count() as f64;
+    let mut one_shot = 0usize;
+    let mut reformulated = 0usize;
+    let mut stalled = 0usize;
+    let mut exploratory = 0usize;
+
+    for episode in episodes {
+        match episode.outcome.as_str() {
+            "one_shot_success" => one_shot += 1,
+            "reformulation_converged" => reformulated += 1,
+            "stalled" => stalled += 1,
+            _ => exploratory += 1,
+        }
+    }
 
     EpisodeStats {
         total_episodes: episodes.len(),
-        convergence_rate: converged / total,
-        stall_rate: stalled / total,
+        convergence_rate: reformulated as f64 / total,
+        stall_rate: stalled as f64 / total,
+        first_try_rate: one_shot as f64 / total,
+        one_shot_count: one_shot,
+        reformulation_count: reformulated,
+        stall_count: stalled,
+        exploratory_count: exploratory,
     }
 }
 
@@ -203,6 +225,10 @@ fn parse_search_query(row: &SearchToolCallRow) -> SearchEpisodeQuery {
             .to_string(),
         top_hit_name: trace["top_hits"][0]["name"].as_str().map(ToOwned::to_owned),
         top_hit_file: trace["top_hits"][0]["file"].as_str().map(ToOwned::to_owned),
+        top_hit_score: trace["top_hits"][0]["score"].as_f64().map(|v| v as f32),
+        result_count: trace["result_count"].as_u64().map(|v| v as usize),
+        strategy: trace["strategy"].as_str().map(ToOwned::to_owned),
+        relaxed: trace["relaxed"].as_bool(),
     }
 }
 

--- a/src/dashboard/search_analysis.rs
+++ b/src/dashboard/search_analysis.rs
@@ -1,0 +1,234 @@
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::daemon::database::SearchToolCallRow;
+
+const USEFUL_ACTIONS: &[&str] = &[
+    "deep_dive",
+    "get_symbols",
+    "fast_refs",
+    "call_path",
+    "get_context",
+    "edit_file",
+    "rewrite_symbol",
+    "rename_symbol",
+];
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchEpisodeQuery {
+    pub timestamp: i64,
+    pub query: String,
+    pub normalized_query: String,
+    pub intent: String,
+    pub search_target: String,
+    pub top_hit_name: Option<String>,
+    pub top_hit_file: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchEpisode {
+    pub session_id: String,
+    pub workspace_id: String,
+    pub start_ts: i64,
+    pub end_ts: i64,
+    pub search_count: usize,
+    pub queries: Vec<SearchEpisodeQuery>,
+    pub downstream_tool: Option<String>,
+    pub target_symbol_name: Option<String>,
+    pub target_file_path: Option<String>,
+    pub outcome: String,
+    pub suspicious: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EpisodeStats {
+    pub total_episodes: usize,
+    pub convergence_rate: f64,
+    pub stall_rate: f64,
+}
+
+pub fn analyze_tool_calls(rows: &[SearchToolCallRow]) -> Vec<SearchEpisode> {
+    let mut episodes = Vec::new();
+    let mut current: Option<EpisodeBuilder> = None;
+
+    for row in rows {
+        if row.tool_name == "fast_search" {
+            let search = parse_search_query(row);
+            let should_start_new = current.as_ref().is_none_or(|episode| {
+                episode.session_id != row.session_id
+                    || row.timestamp - episode.last_search_ts > 10
+                    || episode.closed
+            });
+
+            if should_start_new {
+                if let Some(episode) = current.take() {
+                    episodes.push(episode.finish());
+                }
+                current = Some(EpisodeBuilder::new(row, search));
+            } else if let Some(episode) = current.as_mut() {
+                episode.push_search(row, search);
+            }
+            continue;
+        }
+
+        if let Some(episode) = current.as_mut() {
+            if episode.session_id != row.session_id {
+                let finished = current.take().expect("episode");
+                episodes.push(finished.finish());
+            } else {
+                episode.closed = true;
+                if USEFUL_ACTIONS.contains(&row.tool_name.as_str()) {
+                    episode.downstream_tool = Some(row.tool_name.clone());
+                    let metadata = parse_metadata(row.metadata.as_deref());
+                    episode.target_symbol_name = metadata["target"]["target_symbol_name"]
+                        .as_str()
+                        .map(ToOwned::to_owned);
+                    episode.target_file_path = metadata["target"]["target_file_path"]
+                        .as_str()
+                        .map(ToOwned::to_owned);
+                }
+                let finished = current.take().expect("episode");
+                episodes.push(finished.finish());
+            }
+        }
+    }
+
+    if let Some(episode) = current.take() {
+        episodes.push(episode.finish());
+    }
+
+    episodes
+}
+
+pub fn episode_stats(episodes: &[SearchEpisode]) -> EpisodeStats {
+    let total = episodes.len().max(1) as f64;
+    let converged = episodes
+        .iter()
+        .filter(|episode| episode.outcome == "reformulation_converged")
+        .count() as f64;
+    let stalled = episodes
+        .iter()
+        .filter(|episode| episode.outcome == "stalled")
+        .count() as f64;
+
+    EpisodeStats {
+        total_episodes: episodes.len(),
+        convergence_rate: converged / total,
+        stall_rate: stalled / total,
+    }
+}
+
+struct EpisodeBuilder {
+    session_id: String,
+    workspace_id: String,
+    start_ts: i64,
+    end_ts: i64,
+    last_search_ts: i64,
+    queries: Vec<SearchEpisodeQuery>,
+    downstream_tool: Option<String>,
+    target_symbol_name: Option<String>,
+    target_file_path: Option<String>,
+    closed: bool,
+}
+
+impl EpisodeBuilder {
+    fn new(row: &SearchToolCallRow, query: SearchEpisodeQuery) -> Self {
+        Self {
+            session_id: row.session_id.clone(),
+            workspace_id: row.workspace_id.clone(),
+            start_ts: row.timestamp,
+            end_ts: row.timestamp,
+            last_search_ts: row.timestamp,
+            queries: vec![query],
+            downstream_tool: None,
+            target_symbol_name: None,
+            target_file_path: None,
+            closed: false,
+        }
+    }
+
+    fn push_search(&mut self, row: &SearchToolCallRow, query: SearchEpisodeQuery) {
+        self.end_ts = row.timestamp;
+        self.last_search_ts = row.timestamp;
+        self.queries.push(query);
+    }
+
+    fn finish(self) -> SearchEpisode {
+        let search_count = self.queries.len();
+        let overlapping_queries = queries_overlap(&self.queries);
+        let outcome = if self.downstream_tool.is_none() {
+            "stalled".to_string()
+        } else if search_count == 1 {
+            "one_shot_success".to_string()
+        } else if overlapping_queries
+            && (self.target_symbol_name.is_some() || self.target_file_path.is_some())
+        {
+            "reformulation_converged".to_string()
+        } else {
+            "exploratory_success".to_string()
+        };
+        let suspicious = matches!(outcome.as_str(), "stalled" | "reformulation_converged");
+
+        SearchEpisode {
+            session_id: self.session_id,
+            workspace_id: self.workspace_id,
+            start_ts: self.start_ts,
+            end_ts: self.end_ts.max(self.last_search_ts),
+            search_count,
+            queries: self.queries,
+            downstream_tool: self.downstream_tool,
+            target_symbol_name: self.target_symbol_name,
+            target_file_path: self.target_file_path,
+            outcome,
+            suspicious,
+        }
+    }
+}
+
+fn parse_search_query(row: &SearchToolCallRow) -> SearchEpisodeQuery {
+    let metadata = parse_metadata(row.metadata.as_deref());
+    let trace = &metadata["trace"];
+
+    SearchEpisodeQuery {
+        timestamp: row.timestamp,
+        query: metadata["query"].as_str().unwrap_or_default().to_string(),
+        normalized_query: metadata["normalized_query"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+        intent: metadata["intent"].as_str().unwrap_or("unknown").to_string(),
+        search_target: metadata["search_target"]
+            .as_str()
+            .unwrap_or("definitions")
+            .to_string(),
+        top_hit_name: trace["top_hits"][0]["name"].as_str().map(ToOwned::to_owned),
+        top_hit_file: trace["top_hits"][0]["file"].as_str().map(ToOwned::to_owned),
+    }
+}
+
+fn parse_metadata(metadata: Option<&str>) -> Value {
+    metadata
+        .and_then(|text| serde_json::from_str::<Value>(text).ok())
+        .unwrap_or(Value::Null)
+}
+
+fn queries_overlap(queries: &[SearchEpisodeQuery]) -> bool {
+    for (idx, left) in queries.iter().enumerate() {
+        for right in queries.iter().skip(idx + 1) {
+            if left.normalized_query == right.normalized_query {
+                return true;
+            }
+            let left_tokens = token_set(&left.normalized_query);
+            let right_tokens = token_set(&right.normalized_query);
+            let overlap = left_tokens.intersection(&right_tokens).count();
+            if overlap > 0 && overlap * 2 >= left_tokens.len().max(right_tokens.len()) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn token_set(text: &str) -> std::collections::BTreeSet<&str> {
+    text.split_whitespace().collect()
+}

--- a/src/dashboard/search_analysis.rs
+++ b/src/dashboard/search_analysis.rs
@@ -257,6 +257,16 @@ fn queries_overlap(queries: &[SearchEpisodeQuery]) -> bool {
     false
 }
 
+fn pair_queries_overlap(left: &str, right: &str) -> bool {
+    if left == right {
+        return true;
+    }
+    let left_tokens = token_set(left);
+    let right_tokens = token_set(right);
+    let overlap = left_tokens.intersection(&right_tokens).count();
+    overlap > 0 && overlap * 2 >= left_tokens.len().max(right_tokens.len())
+}
+
 fn token_set(text: &str) -> std::collections::BTreeSet<&str> {
     text.split_whitespace().collect()
 }
@@ -364,8 +374,13 @@ pub fn aggregate_problems(episodes: &[SearchEpisode]) -> Vec<QueryProblem> {
             group.last_seen = group.last_seen.max(query.timestamp);
 
             if is_reformulated {
-                if let Some(target) = &episode.target_symbol_name {
-                    if query.top_hit_name.as_ref() == Some(target) {
+                if let Some(target_name) = &episode.target_symbol_name {
+                    let name_matches = query.top_hit_name.as_ref() == Some(target_name);
+                    let file_matches = match (&query.top_hit_file, &episode.target_file_path) {
+                        (Some(hit_file), Some(target_file)) => hit_file == target_file,
+                        _ => true,
+                    };
+                    if name_matches && file_matches {
                         group.ranking_hits += 1;
                     } else {
                         group.recall_misses += 1;
@@ -485,6 +500,9 @@ pub fn extract_reformulation_pairs(episodes: &[SearchEpisode]) -> Vec<Reformulat
             let initial_key = canonical_key(&window[0].query);
             let successful_key = canonical_key(&window[1].query);
             if initial_key.is_empty() || successful_key.is_empty() {
+                continue;
+            }
+            if !pair_queries_overlap(&window[0].normalized_query, &window[1].normalized_query) {
                 continue;
             }
 

--- a/src/dashboard/search_analysis.rs
+++ b/src/dashboard/search_analysis.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::Serialize;
 use serde_json::Value;
 
@@ -257,4 +259,269 @@ fn queries_overlap(queries: &[SearchEpisodeQuery]) -> bool {
 
 fn token_set(text: &str) -> std::collections::BTreeSet<&str> {
     text.split_whitespace().collect()
+}
+
+// ---------------------------------------------------------------------------
+// Canonical key for query grouping
+// ---------------------------------------------------------------------------
+
+const FILLER_TOKENS: &[&str] = &[
+    "find", "get", "the", "a", "an", "for", "in", "of", "to", "with",
+];
+
+pub fn canonical_key(query: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    for part in query.split(|c: char| c.is_whitespace() || c == ':' || c == '_' || c == '.') {
+        if part.is_empty() {
+            continue;
+        }
+        split_camel_case(part, &mut tokens);
+    }
+    tokens.retain(|t| !FILLER_TOKENS.contains(&t.as_str()));
+    tokens.sort();
+    tokens
+}
+
+fn split_camel_case(text: &str, out: &mut Vec<String>) {
+    let mut current = String::new();
+    let mut prev_lower = false;
+
+    for ch in text.chars() {
+        if ch.is_uppercase() && prev_lower {
+            if !current.is_empty() {
+                out.push(current.to_lowercase());
+                current.clear();
+            }
+        }
+        current.push(ch);
+        prev_lower = ch.is_lowercase();
+    }
+    if !current.is_empty() {
+        out.push(current.to_lowercase());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Problem query aggregation
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct QueryProblem {
+    pub representative_query: String,
+    pub variants: Vec<String>,
+    pub failure_count: usize,
+    pub stall_count: usize,
+    pub reformulation_count: usize,
+    pub last_seen: i64,
+    pub avg_top_score: Option<f32>,
+    pub avg_result_count: Option<f32>,
+    pub triage_signal: String,
+}
+
+pub fn aggregate_problems(episodes: &[SearchEpisode]) -> Vec<QueryProblem> {
+    let mut groups: HashMap<Vec<String>, ProblemGroup> = HashMap::new();
+
+    for episode in episodes {
+        let is_stalled = episode.outcome == "stalled";
+        let is_reformulated = episode.outcome == "reformulation_converged";
+        if !is_stalled && !is_reformulated {
+            continue;
+        }
+
+        let candidate_queries: &[SearchEpisodeQuery] = if is_reformulated && episode.queries.len() > 1 {
+            &episode.queries[..episode.queries.len() - 1]
+        } else {
+            &episode.queries
+        };
+
+        let mut counted_groups: std::collections::HashSet<Vec<String>> =
+            std::collections::HashSet::new();
+
+        for query in candidate_queries {
+            let key = canonical_key(&query.query);
+            if key.is_empty() {
+                continue;
+            }
+            let group = groups.entry(key.clone()).or_insert_with(|| ProblemGroup {
+                queries: HashMap::new(),
+                stall_count: 0,
+                reformulation_count: 0,
+                failure_count: 0,
+                last_seen: 0,
+                scores: Vec::new(),
+                result_counts: Vec::new(),
+                ranking_hits: 0,
+                recall_misses: 0,
+            });
+
+            *group.queries.entry(query.query.clone()).or_insert(0) += 1;
+            if let Some(score) = query.top_hit_score {
+                group.scores.push(score);
+            }
+            if let Some(count) = query.result_count {
+                group.result_counts.push(count);
+            }
+            group.last_seen = group.last_seen.max(query.timestamp);
+
+            if is_reformulated {
+                if let Some(target) = &episode.target_symbol_name {
+                    if query.top_hit_name.as_ref() == Some(target) {
+                        group.ranking_hits += 1;
+                    } else {
+                        group.recall_misses += 1;
+                    }
+                }
+            }
+
+            if counted_groups.insert(key) {
+                group.failure_count += 1;
+                if is_stalled {
+                    group.stall_count += 1;
+                } else {
+                    group.reformulation_count += 1;
+                }
+            }
+        }
+    }
+
+    let mut problems: Vec<QueryProblem> = groups
+        .into_values()
+        .map(|group| {
+            let (representative, variants) = group.representative_and_variants();
+            let avg_top_score = if group.scores.is_empty() {
+                None
+            } else {
+                Some(group.scores.iter().sum::<f32>() / group.scores.len() as f32)
+            };
+            let avg_result_count = if group.result_counts.is_empty() {
+                None
+            } else {
+                Some(
+                    group.result_counts.iter().sum::<usize>() as f32
+                        / group.result_counts.len() as f32,
+                )
+            };
+            let triage_signal = if group.ranking_hits == 0 && group.recall_misses == 0 {
+                "unknown"
+            } else if group.ranking_hits > 0 && group.recall_misses == 0 {
+                "ranking_problem"
+            } else if group.recall_misses > 0 && group.ranking_hits == 0 {
+                "recall_gap"
+            } else {
+                "mixed"
+            };
+
+            QueryProblem {
+                representative_query: representative,
+                variants,
+                failure_count: group.failure_count,
+                stall_count: group.stall_count,
+                reformulation_count: group.reformulation_count,
+                last_seen: group.last_seen,
+                avg_top_score,
+                avg_result_count,
+                triage_signal: triage_signal.to_string(),
+            }
+        })
+        .collect();
+
+    problems.sort_by(|a, b| b.failure_count.cmp(&a.failure_count));
+    problems.truncate(20);
+    problems
+}
+
+struct ProblemGroup {
+    queries: HashMap<String, usize>,
+    stall_count: usize,
+    reformulation_count: usize,
+    failure_count: usize,
+    last_seen: i64,
+    scores: Vec<f32>,
+    result_counts: Vec<usize>,
+    ranking_hits: usize,
+    recall_misses: usize,
+}
+
+impl ProblemGroup {
+    fn representative_and_variants(&self) -> (String, Vec<String>) {
+        let mut sorted: Vec<_> = self.queries.iter().collect();
+        sorted.sort_by(|a, b| b.1.cmp(a.1));
+        let representative = sorted
+            .first()
+            .map(|(q, _)| (*q).clone())
+            .unwrap_or_default();
+        let variants: Vec<String> = sorted
+            .iter()
+            .skip(1)
+            .map(|(q, _)| (*q).clone())
+            .collect();
+        (representative, variants)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reformulation pair extraction
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ReformulationPair {
+    pub initial_query: String,
+    pub successful_query: String,
+    pub target_name: Option<String>,
+    pub target_file: Option<String>,
+    pub occurrences: usize,
+}
+
+pub fn extract_reformulation_pairs(episodes: &[SearchEpisode]) -> Vec<ReformulationPair> {
+    let mut pair_map: HashMap<(Vec<String>, Vec<String>), ReformulationPairBuilder> =
+        HashMap::new();
+
+    for episode in episodes {
+        if episode.outcome != "reformulation_converged" || episode.queries.len() < 2 {
+            continue;
+        }
+
+        for window in episode.queries.windows(2) {
+            let initial_key = canonical_key(&window[0].query);
+            let successful_key = canonical_key(&window[1].query);
+            if initial_key.is_empty() || successful_key.is_empty() {
+                continue;
+            }
+
+            let map_key = (initial_key, successful_key);
+            let entry = pair_map.entry(map_key).or_insert_with(|| {
+                ReformulationPairBuilder {
+                    initial_query: window[0].query.clone(),
+                    successful_query: window[1].query.clone(),
+                    target_name: episode.target_symbol_name.clone(),
+                    target_file: episode.target_file_path.clone(),
+                    occurrences: 0,
+                }
+            });
+            entry.occurrences += 1;
+        }
+    }
+
+    let mut pairs: Vec<ReformulationPair> = pair_map
+        .into_values()
+        .map(|b| ReformulationPair {
+            initial_query: b.initial_query,
+            successful_query: b.successful_query,
+            target_name: b.target_name,
+            target_file: b.target_file,
+            occurrences: b.occurrences,
+        })
+        .collect();
+
+    pairs.sort_by(|a, b| b.occurrences.cmp(&a.occurrences));
+    pairs.truncate(15);
+    pairs
+}
+
+struct ReformulationPairBuilder {
+    initial_query: String,
+    successful_query: String,
+    target_name: Option<String>,
+    target_file: Option<String>,
+    occurrences: usize,
 }

--- a/src/dashboard/search_compare.rs
+++ b/src/dashboard/search_compare.rs
@@ -1,0 +1,310 @@
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::daemon::database::{
+    SearchCompareCaseInput, SearchCompareCaseRow, SearchCompareRunInput, SearchCompareRunRow,
+};
+use crate::dashboard::AppState;
+use crate::dashboard::routes::projects_actions::{
+    cleanup_dashboard_anchor, dashboard_handler, disconnect_dashboard_attached_workspaces,
+};
+use crate::dashboard::search_analysis::{SearchEpisode, analyze_tool_calls, episode_stats};
+use crate::search::index::SearchFilter;
+use crate::tools::search::execution::{self, SearchExecutionWorkspace};
+use crate::tools::search::trace::{SearchExecutionResult, SearchHit};
+
+const BASELINE_STRATEGY: &str = "shared_current";
+const CANDIDATE_STRATEGY: &str = "legacy_direct";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchCompareCaseView {
+    pub session_id: String,
+    pub workspace_id: String,
+    pub query: String,
+    pub search_target: String,
+    pub expected_symbol_name: Option<String>,
+    pub expected_file_path: Option<String>,
+    pub baseline_rank: Option<i64>,
+    pub candidate_rank: Option<i64>,
+    pub baseline_top_hit: Option<String>,
+    pub candidate_top_hit: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchCompareView {
+    pub runs: Vec<SearchCompareRunRow>,
+    pub selected_run: Option<SearchCompareRunRow>,
+    pub cases: Vec<SearchCompareCaseRow>,
+}
+
+pub async fn run_compare(state: &AppState, days: u32) -> Result<SearchCompareView> {
+    let daemon_db = state
+        .dashboard
+        .daemon_db()
+        .ok_or_else(|| anyhow::anyhow!("daemon database unavailable"))?;
+    let rows = daemon_db.list_tool_calls_for_search_analysis(days)?;
+    let episodes = analyze_tool_calls(&rows);
+    let corpus = episodes
+        .iter()
+        .filter_map(compare_case_from_episode)
+        .collect::<Vec<_>>();
+    let stats = episode_stats(&episodes);
+
+    let (handler, _anchor_dir, anchor_id) = dashboard_handler(state).await?;
+    let mut persisted_cases = Vec::new();
+    let mut baseline_top1_hits = 0i64;
+    let mut candidate_top1_hits = 0i64;
+    let mut baseline_top3_hits = 0i64;
+    let mut candidate_top3_hits = 0i64;
+    let mut baseline_source_wins = 0i64;
+    let mut candidate_source_wins = 0i64;
+
+    for case in corpus {
+        let shared = execute_shared_current(state, &handler, &case).await?;
+        let legacy = execute_legacy_direct(state, &case).await?;
+
+        let baseline_rank = expected_rank(&shared.hits, &case);
+        let candidate_rank = expected_rank(&legacy, &case);
+        if baseline_rank == Some(1) {
+            baseline_top1_hits += 1;
+        }
+        if candidate_rank == Some(1) {
+            candidate_top1_hits += 1;
+        }
+        if baseline_rank.is_some_and(|rank| rank <= 3) {
+            baseline_top3_hits += 1;
+        }
+        if candidate_rank.is_some_and(|rank| rank <= 3) {
+            candidate_top3_hits += 1;
+        }
+        if shared.hits.first().is_some_and(|hit| is_source_hit(hit)) {
+            baseline_source_wins += 1;
+        }
+        if legacy.first().is_some_and(|hit| is_source_hit(hit)) {
+            candidate_source_wins += 1;
+        }
+
+        persisted_cases.push(SearchCompareCaseInput {
+            session_id: case.session_id,
+            workspace_id: case.workspace_id,
+            query: case.query,
+            search_target: case.search_target,
+            expected_symbol_name: case.expected_symbol_name,
+            expected_file_path: case.expected_file_path,
+            baseline_rank: baseline_rank.map(|rank| rank as i64),
+            candidate_rank: candidate_rank.map(|rank| rank as i64),
+            baseline_top_hit: shared.hits.first().map(hit_label),
+            candidate_top_hit: legacy.first().map(hit_label),
+        });
+    }
+
+    disconnect_dashboard_attached_workspaces(state, &handler).await;
+    cleanup_dashboard_anchor(state, &anchor_id).await;
+
+    let run_id = daemon_db.insert_search_compare_run(&SearchCompareRunInput {
+        baseline_strategy: BASELINE_STRATEGY.to_string(),
+        candidate_strategy: CANDIDATE_STRATEGY.to_string(),
+        case_count: persisted_cases.len() as i64,
+        baseline_top1_hits,
+        candidate_top1_hits,
+        baseline_top3_hits,
+        candidate_top3_hits,
+        baseline_source_wins,
+        candidate_source_wins,
+        convergence_rate: Some(stats.convergence_rate),
+        stall_rate: Some(stats.stall_rate),
+    })?;
+    daemon_db.replace_search_compare_cases(run_id, &persisted_cases)?;
+
+    latest_compare_view(state, 10, Some(run_id))
+}
+
+pub fn latest_compare_view(
+    state: &AppState,
+    limit: u32,
+    selected_run_id: Option<i64>,
+) -> Result<SearchCompareView> {
+    let Some(daemon_db) = state.dashboard.daemon_db() else {
+        return Ok(SearchCompareView {
+            runs: Vec::new(),
+            selected_run: None,
+            cases: Vec::new(),
+        });
+    };
+    let runs = daemon_db.list_search_compare_runs(limit)?;
+    let chosen_run_id = selected_run_id.or_else(|| runs.first().map(|run| run.id));
+    let selected_run = runs
+        .iter()
+        .find(|run| Some(run.id) == chosen_run_id)
+        .cloned();
+    let cases = chosen_run_id
+        .map(|run_id| daemon_db.list_search_compare_cases(run_id))
+        .transpose()?
+        .unwrap_or_default();
+
+    Ok(SearchCompareView {
+        runs,
+        selected_run,
+        cases,
+    })
+}
+
+#[derive(Clone)]
+struct CompareCase {
+    session_id: String,
+    workspace_id: String,
+    query: String,
+    search_target: String,
+    expected_symbol_name: Option<String>,
+    expected_file_path: Option<String>,
+}
+
+fn compare_case_from_episode(episode: &SearchEpisode) -> Option<CompareCase> {
+    let first_query = episode.queries.first()?;
+    if episode.target_symbol_name.is_none() && episode.target_file_path.is_none() {
+        return None;
+    }
+
+    Some(CompareCase {
+        session_id: episode.session_id.clone(),
+        workspace_id: episode.workspace_id.clone(),
+        query: first_query.query.clone(),
+        search_target: first_query.search_target.clone(),
+        expected_symbol_name: episode.target_symbol_name.clone(),
+        expected_file_path: episode.target_file_path.clone(),
+    })
+}
+
+async fn execute_shared_current(
+    _state: &AppState,
+    handler: &crate::handler::JulieServerHandler,
+    case: &CompareCase,
+) -> Result<SearchExecutionResult> {
+    execution::execute_search(
+        execution::SearchExecutionParams {
+            query: &case.query,
+            language: &None,
+            file_pattern: &None,
+            limit: 10,
+            search_target: &case.search_target,
+            context_lines: None,
+            exclude_tests: None,
+        },
+        &[SearchExecutionWorkspace::target(case.workspace_id.clone())],
+        handler,
+    )
+    .await
+}
+
+async fn execute_legacy_direct(state: &AppState, case: &CompareCase) -> Result<Vec<SearchHit>> {
+    let pool = state
+        .dashboard
+        .workspace_pool()
+        .ok_or_else(|| anyhow::anyhow!("workspace pool unavailable"))?;
+    let workspace = pool
+        .get(&case.workspace_id)
+        .await
+        .ok_or_else(|| anyhow::anyhow!("workspace not attached"))?;
+    let search_index = workspace
+        .search_index
+        .as_ref()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("search index unavailable"))?;
+    let target = case.search_target.clone();
+    let query = case.query.clone();
+    let workspace_id = case.workspace_id.clone();
+    tokio::task::spawn_blocking(move || -> Result<Vec<SearchHit>> {
+        let index = search_index
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let filter = SearchFilter::default();
+        if target == "content" {
+            Ok(index
+                .search_content(&query, &filter, 10)?
+                .results
+                .into_iter()
+                .map(|result| SearchHit {
+                    name: result
+                        .file_path
+                        .rsplit('/')
+                        .next()
+                        .unwrap_or(&result.file_path)
+                        .to_string(),
+                    file: result.file_path,
+                    line: None,
+                    kind: "file".to_string(),
+                    language: result.language,
+                    score: result.score,
+                    snippet: None,
+                    workspace: workspace_id.clone(),
+                    symbol_id: None,
+                    backing: crate::tools::search::trace::SearchHitBacking::LineMatch(
+                        crate::tools::search::LineMatch {
+                            file_path: String::new(),
+                            line_number: 0,
+                            line_content: String::new(),
+                        },
+                    ),
+                })
+                .collect())
+        } else {
+            Ok(index
+                .search_symbols(&query, &filter, 10)?
+                .results
+                .into_iter()
+                .map(|result| SearchHit {
+                    name: result.name,
+                    file: result.file_path,
+                    line: Some(result.start_line),
+                    kind: result.kind,
+                    language: result.language,
+                    score: result.score,
+                    snippet: if result.signature.is_empty() {
+                        if result.doc_comment.is_empty() {
+                            None
+                        } else {
+                            Some(result.doc_comment)
+                        }
+                    } else {
+                        Some(result.signature)
+                    },
+                    workspace: workspace_id.clone(),
+                    symbol_id: Some(result.id),
+                    backing: crate::tools::search::trace::SearchHitBacking::LineMatch(
+                        crate::tools::search::LineMatch {
+                            file_path: String::new(),
+                            line_number: 0,
+                            line_content: String::new(),
+                        },
+                    ),
+                })
+                .collect())
+        }
+    })
+    .await?
+}
+
+fn expected_rank(hits: &[SearchHit], case: &CompareCase) -> Option<usize> {
+    hits.iter()
+        .position(|hit| {
+            case.expected_symbol_name.as_ref().is_some_and(|expected| {
+                hit.name == *expected || hit.symbol_id.as_deref() == Some(expected.as_str())
+            }) || case
+                .expected_file_path
+                .as_ref()
+                .is_some_and(|expected| hit.file == *expected)
+        })
+        .map(|idx| idx + 1)
+}
+
+fn is_source_hit(hit: &SearchHit) -> bool {
+    let file = hit.file.to_lowercase();
+    !(file.contains("/docs/")
+        || file.contains("/test")
+        || file.contains("/spec")
+        || file.ends_with(".md"))
+}
+
+fn hit_label(hit: &SearchHit) -> String {
+    format!("{} @ {}", hit.name, hit.file)
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,4 +1,8 @@
+#[path = "handler/search_telemetry.rs"]
+pub(crate) mod search_telemetry;
 pub mod session_workspace;
+#[path = "handler/tool_targets.rs"]
+pub(crate) mod tool_targets;
 
 use std::collections::{HashMap, HashSet};
 
@@ -2382,18 +2386,20 @@ impl JulieServerHandler {
         debug!("⚡ Fast search: {:?}", params);
         let start = std::time::Instant::now();
         let workspace_snapshot = self.require_primary_workspace_binding().ok();
-        let metadata = serde_json::json!({
-            "query": params.query,
-            "target": params.search_target,
-        });
-        let result = params
-            .call_tool(self)
+        let executed = params
+            .execute_with_trace(self)
             .await
             .map_err(|e| McpError::internal_error(format!("fast_search failed: {}", e), None))?;
+        let metadata = search_telemetry::fast_search_metadata(&params, executed.execution.as_ref());
+        let result = executed.result;
         let output_bytes = Self::output_bytes_from_result(&result);
-        let source_file_paths = Self::extract_paths_from_result(&result);
+        let source_file_paths =
+            search_telemetry::fast_search_source_paths(executed.execution.as_ref());
         let report = ToolCallReport {
-            result_count: None,
+            result_count: executed
+                .execution
+                .as_ref()
+                .map(|result| result.total_results.min(u32::MAX as usize) as u32),
             source_bytes: None,
             output_bytes,
             metadata,
@@ -2426,7 +2432,7 @@ impl JulieServerHandler {
         debug!("⚡ Fast find references: {:?}", params);
         let start = std::time::Instant::now();
         let workspace_snapshot = self.require_primary_workspace_binding().ok();
-        let metadata = serde_json::json!({ "symbol": params.symbol });
+        let metadata = tool_targets::fast_refs_metadata(&params);
         let result = params
             .call_tool(self)
             .await
@@ -2471,12 +2477,7 @@ impl JulieServerHandler {
         } else {
             None
         };
-        let metadata = serde_json::json!({
-            "from": params.from,
-            "to": params.to,
-            "max_hops": params.max_hops,
-            "workspace": params.workspace,
-        });
+        let metadata = tool_targets::call_path_metadata(&params);
         let result = params
             .call_tool(self)
             .await
@@ -2517,11 +2518,7 @@ impl JulieServerHandler {
         debug!("📋 Get symbols for file: {:?}", params);
         let start = std::time::Instant::now();
         let workspace_snapshot = self.require_primary_workspace_binding().ok();
-        let metadata = serde_json::json!({
-            "file": params.file_path,
-            "mode": params.mode,
-            "target": params.target,
-        });
+        let metadata = tool_targets::get_symbols_metadata(&params);
         let source_file_paths = vec![params.file_path.clone()];
         let result = params
             .call_tool(self)
@@ -2561,10 +2558,7 @@ impl JulieServerHandler {
         debug!("🔍 Deep dive: {:?}", params);
         let start = std::time::Instant::now();
         let workspace_snapshot = self.require_primary_workspace_binding().ok();
-        let metadata = serde_json::json!({
-            "symbol": params.symbol,
-            "depth": params.depth,
-        });
+        let metadata = tool_targets::deep_dive_metadata(&params);
         let result = params
             .call_tool(self)
             .await
@@ -2607,7 +2601,7 @@ impl JulieServerHandler {
         debug!("📦 Get context: {:?}", params);
         let start = std::time::Instant::now();
         let workspace_snapshot = self.require_primary_workspace_binding().ok();
-        let metadata = serde_json::json!({ "query": params.query });
+        let metadata = tool_targets::get_context_metadata(&params);
         let result = params
             .call_tool(self)
             .await
@@ -2650,11 +2644,7 @@ impl JulieServerHandler {
         debug!("✏️ Rename symbol: {:?}", params);
         let start = std::time::Instant::now();
         let workspace_snapshot = self.require_primary_workspace_binding().ok();
-        let metadata = serde_json::json!({
-            "old": params.old_name,
-            "new": params.new_name,
-            "dry_run": params.dry_run,
-        });
+        let metadata = tool_targets::rename_symbol_metadata(&params);
         let result = params
             .call_tool(self)
             .await
@@ -2740,11 +2730,7 @@ impl JulieServerHandler {
         );
         let start = std::time::Instant::now();
         let workspace_snapshot = self.require_primary_workspace_binding().ok();
-        let metadata = serde_json::json!({
-            "file": params.file_path,
-            "occurrence": params.occurrence,
-            "dry_run": params.dry_run,
-        });
+        let metadata = tool_targets::edit_file_metadata(&params);
         let result = params
             .call_tool(self)
             .await
@@ -2792,12 +2778,7 @@ impl JulieServerHandler {
         } else {
             None
         };
-        let metadata = serde_json::json!({
-            "symbol": params.symbol,
-            "operation": params.operation,
-            "dry_run": params.dry_run,
-            "workspace": params.workspace,
-        });
+        let metadata = tool_targets::rewrite_symbol_metadata(&params);
         let result = params
             .call_tool(self)
             .await

--- a/src/handler/search_telemetry.rs
+++ b/src/handler/search_telemetry.rs
@@ -1,0 +1,84 @@
+use serde_json::{Value, json};
+
+use crate::tools::search::FastSearchTool;
+use crate::tools::search::trace::SearchExecutionResult;
+
+const TRACE_VERSION: &str = "fast_search_trace_v1";
+
+pub(crate) fn fast_search_metadata(
+    params: &FastSearchTool,
+    execution: Option<&SearchExecutionResult>,
+) -> Value {
+    let intent = infer_intent(&params.query, &params.search_target);
+    let trace = execution.map(|result| {
+        json!({
+            "strategy": result.trace.strategy_id,
+            "returned_hit_count": result.hits.len(),
+            "result_count": result.total_results,
+            "relaxed": result.relaxed,
+            "top_hits": result.trace.top_hits,
+        })
+    });
+
+    json!({
+        "query": params.query,
+        "normalized_query": normalize_query(&params.query),
+        "search_target": params.search_target,
+        "language": params.language,
+        "file_pattern": params.file_pattern,
+        "limit": params.limit,
+        "exclude_tests": params.exclude_tests,
+        "intent": intent,
+        "trace_version": TRACE_VERSION,
+        "trace": trace,
+    })
+}
+
+pub(crate) fn fast_search_source_paths(execution: Option<&SearchExecutionResult>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    execution
+        .into_iter()
+        .flat_map(|result| result.hits.iter().map(|hit| hit.file.clone()))
+        .filter(|path| seen.insert(path.clone()))
+        .collect()
+}
+
+fn normalize_query(query: &str) -> String {
+    query.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn infer_intent(query: &str, search_target: &str) -> &'static str {
+    let normalized = query.to_lowercase();
+    let token_count = query.split_whitespace().count();
+    let has_symbol_shape = query.contains("::")
+        || query.contains('_')
+        || query.chars().any(|ch| ch.is_ascii_uppercase());
+    let has_tool_phrase = [
+        "find references",
+        "call path",
+        "wrapper",
+        "handler",
+        "mcp",
+        "tool",
+    ]
+    .iter()
+    .any(|phrase| normalized.contains(phrase));
+    let has_grep_shape = search_target == "content"
+        || normalized.contains("todo")
+        || normalized.contains("fixme")
+        || normalized.contains("grep");
+
+    if has_tool_phrase {
+        "api_tool_lookup"
+    } else if has_symbol_shape && token_count <= 3 {
+        "symbol_lookup"
+    } else if has_grep_shape {
+        "content_grep"
+    } else if token_count >= 5 {
+        "conceptual_code"
+    } else if token_count >= 2 {
+        "code_investigation"
+    } else {
+        "unknown"
+    }
+}

--- a/src/handler/tool_targets.rs
+++ b/src/handler/tool_targets.rs
@@ -1,0 +1,96 @@
+use serde_json::{Value, json};
+
+use crate::tools::editing::edit_file::EditFileTool;
+use crate::tools::editing::rewrite_symbol::RewriteSymbolTool;
+use crate::tools::get_context::GetContextTool;
+use crate::tools::navigation::{CallPathTool, FastRefsTool};
+use crate::tools::{DeepDiveTool, GetSymbolsTool, RenameSymbolTool};
+
+fn target_metadata(symbol_name: Option<&str>, file_path: Option<&str>, line: Option<u32>) -> Value {
+    json!({
+        "target_symbol_name": symbol_name,
+        "target_file_path": file_path,
+        "target_line": line,
+    })
+}
+
+pub(crate) fn fast_refs_metadata(params: &FastRefsTool) -> Value {
+    json!({
+        "symbol": params.symbol,
+        "reference_kind": params.reference_kind,
+        "workspace": params.workspace,
+        "target": target_metadata(Some(&params.symbol), None, None),
+    })
+}
+
+pub(crate) fn call_path_metadata(params: &CallPathTool) -> Value {
+    json!({
+        "from": params.from,
+        "to": params.to,
+        "max_hops": params.max_hops,
+        "workspace": params.workspace,
+        "target": target_metadata(Some(&params.to), params.to_file_path.as_deref(), None),
+    })
+}
+
+pub(crate) fn get_symbols_metadata(params: &GetSymbolsTool) -> Value {
+    json!({
+        "file": params.file_path,
+        "mode": params.mode,
+        "target_filter": params.target,
+        "workspace": params.workspace,
+        "target": target_metadata(params.target.as_deref(), Some(&params.file_path), None),
+    })
+}
+
+pub(crate) fn deep_dive_metadata(params: &DeepDiveTool) -> Value {
+    json!({
+        "symbol": params.symbol,
+        "depth": params.depth,
+        "context_file": params.context_file,
+        "workspace": params.workspace,
+        "target": target_metadata(Some(&params.symbol), params.context_file.as_deref(), None),
+    })
+}
+
+pub(crate) fn get_context_metadata(params: &GetContextTool) -> Value {
+    json!({
+        "query": params.query,
+        "language": params.language,
+        "file_pattern": params.file_pattern,
+        "max_tokens": params.max_tokens,
+        "workspace": params.workspace,
+        "target": target_metadata(None, None, None),
+    })
+}
+
+pub(crate) fn rename_symbol_metadata(params: &RenameSymbolTool) -> Value {
+    json!({
+        "old": params.old_name,
+        "new": params.new_name,
+        "dry_run": params.dry_run,
+        "scope": params.scope,
+        "workspace": params.workspace,
+        "target": target_metadata(Some(&params.old_name), params.scope.as_deref(), None),
+    })
+}
+
+pub(crate) fn edit_file_metadata(params: &EditFileTool) -> Value {
+    json!({
+        "file": params.file_path,
+        "occurrence": params.occurrence,
+        "dry_run": params.dry_run,
+        "target": target_metadata(None, Some(&params.file_path), None),
+    })
+}
+
+pub(crate) fn rewrite_symbol_metadata(params: &RewriteSymbolTool) -> Value {
+    json!({
+        "symbol": params.symbol,
+        "operation": params.operation,
+        "dry_run": params.dry_run,
+        "workspace": params.workspace,
+        "file_path": params.file_path,
+        "target": target_metadata(Some(&params.symbol), params.file_path.as_deref(), None),
+    })
+}

--- a/src/tests/core/handler_telemetry.rs
+++ b/src/tests/core/handler_telemetry.rs
@@ -1,0 +1,101 @@
+use crate::extractors::{Symbol, SymbolKind};
+use crate::handler::search_telemetry;
+use crate::handler::tool_targets;
+use crate::tools::search::FastSearchTool;
+use crate::tools::search::trace::{SearchExecutionKind, SearchExecutionResult, SearchHit};
+use crate::tools::{DeepDiveTool, GetSymbolsTool};
+
+fn sample_symbol() -> Symbol {
+    Symbol {
+        id: "sym_1".to_string(),
+        name: "search_handler".to_string(),
+        kind: SymbolKind::Function,
+        language: "rust".to_string(),
+        file_path: "src/dashboard/routes/search.rs".to_string(),
+        start_line: 42,
+        start_column: 0,
+        end_line: 42,
+        end_column: 24,
+        start_byte: 0,
+        end_byte: 24,
+        signature: Some("fn search_handler()".to_string()),
+        doc_comment: None,
+        visibility: None,
+        parent_id: None,
+        metadata: None,
+        semantic_group: None,
+        confidence: Some(7.5),
+        code_context: None,
+        content_type: None,
+    }
+}
+
+#[test]
+fn test_fast_search_metadata_captures_trace_and_intent() {
+    let params = FastSearchTool {
+        query: "find references for search handler".to_string(),
+        search_target: "definitions".to_string(),
+        language: Some("rust".to_string()),
+        file_pattern: Some("src/**/*.rs".to_string()),
+        limit: 10,
+        ..Default::default()
+    };
+    let hit = SearchHit::from_symbol(sample_symbol(), "workspace-a".to_string());
+    let execution = SearchExecutionResult::new(
+        vec![hit],
+        true,
+        4,
+        "fast_search_definitions",
+        SearchExecutionKind::Definitions,
+    );
+
+    let metadata = search_telemetry::fast_search_metadata(&params, Some(&execution));
+
+    assert_eq!(metadata["intent"], "api_tool_lookup");
+    assert_eq!(
+        metadata["normalized_query"],
+        "find references for search handler"
+    );
+    assert_eq!(metadata["trace"]["strategy"], "fast_search_definitions");
+    assert_eq!(metadata["trace"]["returned_hit_count"], 1);
+    assert_eq!(metadata["trace"]["result_count"], 4);
+    assert_eq!(metadata["trace"]["top_hits"][0]["name"], "search_handler");
+}
+
+#[test]
+fn test_get_symbols_metadata_prefers_file_target_with_symbol_filter() {
+    let params = GetSymbolsTool {
+        file_path: "src/dashboard/routes/search.rs".to_string(),
+        max_depth: 1,
+        target: Some("run_search".to_string()),
+        limit: Some(10),
+        mode: Some("minimal".to_string()),
+        workspace: Some("primary".to_string()),
+    };
+
+    let metadata = tool_targets::get_symbols_metadata(&params);
+
+    assert_eq!(metadata["target"]["target_symbol_name"], "run_search");
+    assert_eq!(
+        metadata["target"]["target_file_path"],
+        "src/dashboard/routes/search.rs"
+    );
+}
+
+#[test]
+fn test_deep_dive_metadata_carries_symbol_and_context_file_target() {
+    let params = DeepDiveTool {
+        symbol: "search_handler".to_string(),
+        depth: "context".to_string(),
+        context_file: Some("src/dashboard/routes/search.rs".to_string()),
+        workspace: Some("primary".to_string()),
+    };
+
+    let metadata = tool_targets::deep_dive_metadata(&params);
+
+    assert_eq!(metadata["target"]["target_symbol_name"], "search_handler");
+    assert_eq!(
+        metadata["target"]["target_file_path"],
+        "src/dashboard/routes/search.rs"
+    );
+}

--- a/src/tests/daemon/database.rs
+++ b/src/tests/daemon/database.rs
@@ -369,6 +369,100 @@ mod tests {
     }
 
     #[test]
+    fn test_insert_tool_call_persists_metadata_json() {
+        let (db, _tmp) = create_test_db();
+        let metadata = serde_json::json!({
+            "intent": "api_tool_lookup",
+            "trace": {
+                "strategy": "fast_search_definitions",
+                "top_hits": [
+                    {
+                        "name": "search_handler",
+                        "file": "src/dashboard/routes/search.rs"
+                    }
+                ]
+            }
+        });
+        let metadata_str = metadata.to_string();
+        db.insert_tool_call(
+            "ws1",
+            "sess1",
+            "fast_search",
+            12.5,
+            Some(1),
+            None,
+            Some(500),
+            true,
+            Some(&metadata_str),
+        )
+        .unwrap();
+
+        let stored_metadata: String = {
+            let conn = db.conn_for_test();
+            conn.query_row(
+                "SELECT metadata FROM tool_calls ORDER BY id DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        let stored_value: serde_json::Value =
+            serde_json::from_str(&stored_metadata).expect("stored metadata json");
+
+        assert_eq!(stored_value["intent"], "api_tool_lookup");
+        assert_eq!(
+            stored_value["trace"]["top_hits"][0]["name"],
+            "search_handler"
+        );
+    }
+
+    #[test]
+    fn test_insert_and_list_search_compare_runs_and_cases() {
+        let (db, _tmp) = create_test_db();
+        let run_id = db
+            .insert_search_compare_run(&crate::daemon::database::SearchCompareRunInput {
+                baseline_strategy: "shared_current".to_string(),
+                candidate_strategy: "legacy_direct".to_string(),
+                case_count: 2,
+                baseline_top1_hits: 1,
+                candidate_top1_hits: 0,
+                baseline_top3_hits: 2,
+                candidate_top3_hits: 1,
+                baseline_source_wins: 2,
+                candidate_source_wins: 1,
+                convergence_rate: Some(0.5),
+                stall_rate: Some(0.25),
+            })
+            .unwrap();
+        db.replace_search_compare_cases(
+            run_id,
+            &[crate::daemon::database::SearchCompareCaseInput {
+                session_id: "sess1".to_string(),
+                workspace_id: "ws1".to_string(),
+                query: "search handler".to_string(),
+                search_target: "definitions".to_string(),
+                expected_symbol_name: Some("search_handler".to_string()),
+                expected_file_path: Some("src/dashboard/routes/search.rs".to_string()),
+                baseline_rank: Some(1),
+                candidate_rank: Some(3),
+                baseline_top_hit: Some(
+                    "search_handler @ src/dashboard/routes/search.rs".to_string(),
+                ),
+                candidate_top_hit: Some("run_search @ src/dashboard/routes/search.rs".to_string()),
+            }],
+        )
+        .unwrap();
+
+        let runs = db.list_search_compare_runs(10).unwrap();
+        let cases = db.list_search_compare_cases(run_id).unwrap();
+
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].baseline_strategy, "shared_current");
+        assert_eq!(cases.len(), 1);
+        assert_eq!(cases[0].baseline_rank, Some(1));
+    }
+
+    #[test]
     fn test_prune_old_tool_calls() {
         let (db, _tmp) = create_test_db();
         // Insert a call with a very old timestamp (year 2001)

--- a/src/tests/dashboard/integration.rs
+++ b/src/tests/dashboard/integration.rs
@@ -181,12 +181,94 @@ async fn state_with_projection_lag() -> (DashboardState, tempfile::TempDir, Stri
     )
 }
 
+async fn state_with_search_workspace(
+    file_path: &str,
+    content: &str,
+    symbol_name: &str,
+) -> (DashboardState, tempfile::TempDir, String) {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let workspace_root = temp_dir.path().join("workspace");
+    std::fs::create_dir_all(&workspace_root).expect("workspace dir");
+    let workspace_id =
+        generate_workspace_id(&workspace_root.to_string_lossy()).expect("workspace id");
+
+    let daemon_db =
+        Arc::new(DaemonDatabase::open(&temp_dir.path().join("daemon.db")).expect("open daemon.db"));
+    daemon_db
+        .upsert_workspace(&workspace_id, &workspace_root.to_string_lossy(), "ready")
+        .unwrap();
+    daemon_db
+        .update_workspace_stats(&workspace_id, 1, 1, None, None, None)
+        .unwrap();
+
+    let pool = Arc::new(WorkspacePool::new(
+        temp_dir.path().join("indexes"),
+        Some(Arc::clone(&daemon_db)),
+        None,
+        None,
+    ));
+    let workspace = pool
+        .get_or_init(&workspace_id, workspace_root.clone())
+        .await
+        .expect("workspace init");
+
+    {
+        let mut db = workspace
+            .db
+            .as_ref()
+            .expect("workspace db")
+            .lock()
+            .expect("db lock");
+        db.bulk_store_fresh_atomic(
+            &[make_file(file_path, content)],
+            &[make_symbol("sym_1", symbol_name, file_path)],
+            &[],
+            &[],
+            &[],
+            &workspace_id,
+        )
+        .unwrap();
+
+        let search_index = workspace
+            .search_index
+            .as_ref()
+            .expect("search index")
+            .lock()
+            .expect("index lock");
+        SearchProjection::tantivy(&workspace_id)
+            .ensure_current_from_database(&mut db, &search_index)
+            .unwrap();
+    }
+
+    (
+        DashboardState::new(
+            Arc::new(SessionTracker::new()),
+            Some(daemon_db),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(RwLock::new(LifecyclePhase::Ready)),
+            Instant::now(),
+            None,
+            Some(pool),
+            50,
+        ),
+        temp_dir,
+        workspace_id,
+    )
+}
+
 #[tokio::test]
 async fn test_all_dashboard_pages_return_200() {
     let state = test_state();
     let config = DashboardConfig::default();
 
-    for path in ["/", "/projects", "/metrics", "/search"] {
+    for path in [
+        "/",
+        "/projects",
+        "/metrics",
+        "/search",
+        "/search/analysis",
+        "/search/compare",
+    ] {
         let app = create_router(state.clone(), config.clone()).unwrap();
         let response = app
             .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
@@ -435,6 +517,47 @@ async fn test_dashboard_post_search_returns_200() {
         .unwrap();
 
     assert_eq!(response.status().as_u16(), 200);
+}
+
+#[tokio::test]
+async fn test_dashboard_content_search_renders_line_match_preview() {
+    let (state, _temp_dir, workspace_id) = state_with_search_workspace(
+        "src/lib.rs",
+        "TODO: implement authentication\nfn helper() {}\n",
+        "helper",
+    )
+    .await;
+    let config = DashboardConfig::default();
+    let app = create_router(state, config).unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/search")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "query=TODO&workspace={workspace_id}&search_target=content"
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status().as_u16(), 200);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let html = String::from_utf8(body.to_vec()).expect("utf8 body");
+
+    assert!(
+        html.contains("TODO: implement authentication"),
+        "dashboard content search should render line-level match preview: {html}"
+    );
+    assert!(
+        html.contains("lib.rs:1"),
+        "dashboard content search should carry file and line detail: {html}"
+    );
 }
 
 #[tokio::test]

--- a/src/tests/dashboard/mod.rs
+++ b/src/tests/dashboard/mod.rs
@@ -4,4 +4,5 @@ mod intelligence;
 mod language_bar;
 mod projects_actions;
 mod router;
+mod search_analysis;
 mod state;

--- a/src/tests/dashboard/search_analysis.rs
+++ b/src/tests/dashboard/search_analysis.rs
@@ -1,5 +1,8 @@
 use crate::daemon::database::SearchToolCallRow;
-use crate::dashboard::search_analysis::{analyze_tool_calls, episode_stats};
+use crate::dashboard::search_analysis::{
+    aggregate_problems, analyze_tool_calls, canonical_key, episode_stats,
+    extract_reformulation_pairs,
+};
 
 fn fast_search_row(
     id: i64,
@@ -68,6 +71,44 @@ fn fast_search_row_no_trace(
                 "normalized_query": query,
                 "intent": "code_investigation",
                 "search_target": "definitions"
+            })
+            .to_string(),
+        ),
+    }
+}
+
+fn fast_search_row_with_hit(
+    id: i64,
+    session_id: &str,
+    timestamp: i64,
+    query: &str,
+    top_hit_name: &str,
+) -> SearchToolCallRow {
+    SearchToolCallRow {
+        id,
+        workspace_id: "ws1".to_string(),
+        session_id: session_id.to_string(),
+        timestamp,
+        tool_name: "fast_search".to_string(),
+        metadata: Some(
+            serde_json::json!({
+                "query": query,
+                "normalized_query": query,
+                "intent": "code_investigation",
+                "search_target": "definitions",
+                "trace": {
+                    "strategy": "definitions_first",
+                    "result_count": 3,
+                    "returned_hit_count": 3,
+                    "relaxed": false,
+                    "top_hits": [
+                        {
+                            "name": top_hit_name,
+                            "file": "src/lib.rs",
+                            "score": 8.0
+                        }
+                    ]
+                }
             })
             .to_string(),
         ),
@@ -231,4 +272,185 @@ fn test_episode_stats_computes_outcome_breakdown() {
     assert_eq!(stats.stall_count, 1);
     assert_eq!(stats.exploratory_count, 1);
     assert!((stats.first_try_rate - 0.25).abs() < 0.01);
+}
+
+// ---------------------------------------------------------------------------
+// canonical_key tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_canonical_key_unifies_naming_conventions() {
+    assert_eq!(canonical_key("SearchHandler"), canonical_key("search_handler"));
+    assert_eq!(canonical_key("search_handler"), canonical_key("search::handler"));
+    assert_eq!(canonical_key("SearchHandler"), canonical_key("search handler"));
+}
+
+#[test]
+fn test_canonical_key_drops_filler_tokens() {
+    assert_eq!(canonical_key("find the handler"), canonical_key("handler"));
+    assert_eq!(canonical_key("get search results"), canonical_key("search results"));
+}
+
+#[test]
+fn test_canonical_key_sorts_alphabetically() {
+    assert_eq!(canonical_key("handler search"), canonical_key("search handler"));
+}
+
+#[test]
+fn test_canonical_key_empty_input() {
+    assert!(canonical_key("").is_empty());
+    assert!(canonical_key("the a an").is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// aggregate_problems tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_aggregate_problems_excludes_terminal_successful_query() {
+    let rows = vec![
+        fast_search_row(1, "sess-a", 100, "search handler", "search handler"),
+        fast_search_row(2, "sess-a", 103, "handler search", "handler search"),
+        useful_action_row(3, "sess-a", 105),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+    assert_eq!(episodes[0].outcome, "reformulation_converged");
+
+    let problems = aggregate_problems(&episodes);
+
+    let all_representative_queries: Vec<&str> = problems
+        .iter()
+        .map(|p| p.representative_query.as_str())
+        .collect();
+    assert!(
+        !all_representative_queries.contains(&"handler search"),
+        "terminal successful query should be excluded"
+    );
+}
+
+#[test]
+fn test_aggregate_problems_counts_once_per_episode() {
+    let rows = vec![
+        fast_search_row(1, "sess-a", 100, "handler", "handler"),
+        fast_search_row(2, "sess-a", 103, "handler", "handler"),
+        fast_search_row(3, "sess-a", 106, "handler fixed", "handler fixed"),
+        useful_action_row(4, "sess-a", 108),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+    let problems = aggregate_problems(&episodes);
+
+    let handler_problem = problems.iter().find(|p| {
+        canonical_key(&p.representative_query) == canonical_key("handler")
+    });
+    assert!(handler_problem.is_some());
+    assert_eq!(handler_problem.unwrap().failure_count, 1);
+}
+
+#[test]
+fn test_aggregate_problems_triage_ranking_problem() {
+    let rows = vec![
+        fast_search_row_with_hit(1, "sess-a", 100, "search handler", "search_handler"),
+        fast_search_row(2, "sess-a", 103, "handler search", "handler search"),
+        useful_action_row(3, "sess-a", 105),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+    let problems = aggregate_problems(&episodes);
+
+    assert!(!problems.is_empty());
+    assert_eq!(problems[0].triage_signal, "ranking_problem");
+}
+
+#[test]
+fn test_aggregate_problems_triage_recall_gap() {
+    let rows = vec![
+        fast_search_row_with_hit(1, "sess-a", 100, "search handler", "wrong_symbol"),
+        fast_search_row(2, "sess-a", 103, "handler search", "handler search"),
+        useful_action_row(3, "sess-a", 105),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+    let problems = aggregate_problems(&episodes);
+
+    assert!(!problems.is_empty());
+    assert_eq!(problems[0].triage_signal, "recall_gap");
+}
+
+#[test]
+fn test_aggregate_problems_empty_episodes() {
+    let problems = aggregate_problems(&[]);
+    assert!(problems.is_empty());
+}
+
+#[test]
+fn test_aggregate_problems_stalled_episode_includes_all_queries() {
+    let rows = vec![
+        fast_search_row(1, "sess-a", 100, "handler", "handler"),
+        fast_search_row(2, "sess-a", 103, "different topic", "different topic"),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+    assert_eq!(episodes[0].outcome, "stalled");
+
+    let problems = aggregate_problems(&episodes);
+    assert_eq!(problems.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// extract_reformulation_pairs tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_extract_reformulation_pairs_adjacent_transitions() {
+    let rows = vec![
+        fast_search_row(1, "sess-a", 100, "search handler", "search handler"),
+        fast_search_row(2, "sess-a", 103, "handler route", "handler route"),
+        fast_search_row(3, "sess-a", 106, "route handler", "route handler"),
+        useful_action_row(4, "sess-a", 108),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+    let pairs = extract_reformulation_pairs(&episodes);
+
+    assert_eq!(pairs.len(), 2);
+}
+
+#[test]
+fn test_extract_reformulation_pairs_deduplication() {
+    let rows = vec![
+        fast_search_row(1, "sess-a", 100, "search handler", "search handler"),
+        fast_search_row(2, "sess-a", 103, "handler route", "handler route"),
+        useful_action_row(3, "sess-a", 105),
+        fast_search_row(4, "sess-b", 200, "handler search", "handler search"),
+        fast_search_row(5, "sess-b", 203, "route handler", "route handler"),
+        useful_action_row(6, "sess-b", 205),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+    let pairs = extract_reformulation_pairs(&episodes);
+
+    assert_eq!(pairs.len(), 1);
+    assert_eq!(pairs[0].occurrences, 2);
+}
+
+#[test]
+fn test_extract_reformulation_pairs_empty_episodes() {
+    let pairs = extract_reformulation_pairs(&[]);
+    assert!(pairs.is_empty());
+}
+
+#[test]
+fn test_extract_reformulation_pairs_skips_non_reformulated() {
+    let rows = vec![
+        fast_search_row(1, "sess-a", 100, "handler", "handler"),
+        useful_action_row(2, "sess-a", 102),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+    assert_eq!(episodes[0].outcome, "one_shot_success");
+
+    let pairs = extract_reformulation_pairs(&episodes);
+    assert!(pairs.is_empty());
 }

--- a/src/tests/dashboard/search_analysis.rs
+++ b/src/tests/dashboard/search_analysis.rs
@@ -1,5 +1,5 @@
 use crate::daemon::database::SearchToolCallRow;
-use crate::dashboard::search_analysis::analyze_tool_calls;
+use crate::dashboard::search_analysis::{analyze_tool_calls, episode_stats};
 
 fn fast_search_row(
     id: i64,
@@ -8,9 +8,20 @@ fn fast_search_row(
     query: &str,
     normalized_query: &str,
 ) -> SearchToolCallRow {
+    fast_search_row_in_workspace(id, session_id, "ws1", timestamp, query, normalized_query)
+}
+
+fn fast_search_row_in_workspace(
+    id: i64,
+    session_id: &str,
+    workspace_id: &str,
+    timestamp: i64,
+    query: &str,
+    normalized_query: &str,
+) -> SearchToolCallRow {
     SearchToolCallRow {
         id,
-        workspace_id: "ws1".to_string(),
+        workspace_id: workspace_id.to_string(),
         session_id: session_id.to_string(),
         timestamp,
         tool_name: "fast_search".to_string(),
@@ -21,13 +32,42 @@ fn fast_search_row(
                 "intent": "code_investigation",
                 "search_target": "definitions",
                 "trace": {
+                    "strategy": "definitions_first",
+                    "result_count": 5,
+                    "returned_hit_count": 5,
+                    "relaxed": false,
                     "top_hits": [
                         {
                             "name": "search_handler",
-                            "file": "src/dashboard/routes/search.rs"
+                            "file": "src/dashboard/routes/search.rs",
+                            "score": 12.5
                         }
                     ]
                 }
+            })
+            .to_string(),
+        ),
+    }
+}
+
+fn fast_search_row_no_trace(
+    id: i64,
+    session_id: &str,
+    timestamp: i64,
+    query: &str,
+) -> SearchToolCallRow {
+    SearchToolCallRow {
+        id,
+        workspace_id: "ws1".to_string(),
+        session_id: session_id.to_string(),
+        timestamp,
+        tool_name: "fast_search".to_string(),
+        metadata: Some(
+            serde_json::json!({
+                "query": query,
+                "normalized_query": query,
+                "intent": "code_investigation",
+                "search_target": "definitions"
             })
             .to_string(),
         ),
@@ -97,4 +137,98 @@ fn test_search_analysis_splits_episodes_after_non_search_boundary() {
     assert_eq!(episodes.len(), 2);
     assert_eq!(episodes[0].outcome, "one_shot_success");
     assert_eq!(episodes[1].outcome, "stalled");
+}
+
+#[test]
+fn test_search_analysis_splits_on_workspace_boundary() {
+    let rows = vec![
+        fast_search_row_in_workspace(1, "sess-a", "ws1", 100, "handler", "handler"),
+        fast_search_row_in_workspace(2, "sess-a", "ws2", 103, "handler", "handler"),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+
+    assert_eq!(episodes.len(), 2);
+    assert_eq!(episodes[0].workspace_id, "ws1");
+    assert_eq!(episodes[1].workspace_id, "ws2");
+}
+
+#[test]
+fn test_search_analysis_workspace_boundary_on_non_search_tool() {
+    let rows = vec![
+        fast_search_row_in_workspace(1, "sess-a", "ws1", 100, "handler", "handler"),
+        SearchToolCallRow {
+            id: 2,
+            workspace_id: "ws2".to_string(),
+            session_id: "sess-a".to_string(),
+            timestamp: 102,
+            tool_name: "deep_dive".to_string(),
+            metadata: None,
+        },
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+
+    assert_eq!(episodes.len(), 1);
+    assert_eq!(episodes[0].outcome, "stalled");
+    assert_eq!(episodes[0].workspace_id, "ws1");
+}
+
+#[test]
+fn test_search_analysis_null_trace_produces_none_fields() {
+    let rows = vec![
+        fast_search_row_no_trace(1, "sess-a", 100, "handler"),
+        useful_action_row(2, "sess-a", 102),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+
+    assert_eq!(episodes.len(), 1);
+    let query = &episodes[0].queries[0];
+    assert!(query.top_hit_score.is_none());
+    assert!(query.result_count.is_none());
+    assert!(query.strategy.is_none());
+    assert!(query.relaxed.is_none());
+    assert!(query.top_hit_name.is_none());
+}
+
+#[test]
+fn test_search_analysis_trace_fields_populated() {
+    let rows = vec![
+        fast_search_row(1, "sess-a", 100, "handler", "handler"),
+        useful_action_row(2, "sess-a", 102),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+
+    let query = &episodes[0].queries[0];
+    assert!((query.top_hit_score.unwrap() - 12.5).abs() < 0.01);
+    assert_eq!(query.result_count, Some(5));
+    assert_eq!(query.strategy.as_deref(), Some("definitions_first"));
+    assert_eq!(query.relaxed, Some(false));
+}
+
+#[test]
+fn test_episode_stats_computes_outcome_breakdown() {
+    let rows = vec![
+        fast_search_row(1, "sess-a", 100, "handler", "handler"),
+        useful_action_row(2, "sess-a", 102),
+        fast_search_row(3, "sess-b", 200, "search handler", "search handler"),
+        fast_search_row(4, "sess-b", 203, "handler search", "handler search"),
+        useful_action_row(5, "sess-b", 205),
+        fast_search_row(6, "sess-c", 300, "stalled query", "stalled query"),
+        fast_search_row(7, "sess-d", 400, "database pool", "database pool"),
+        fast_search_row(8, "sess-d", 403, "centrality badge", "centrality badge"),
+        useful_action_row(9, "sess-d", 405),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+    let stats = episode_stats(&episodes);
+
+    assert_eq!(stats.total_episodes, 4);
+    assert_eq!(stats.one_shot_count, 1);
+    assert_eq!(stats.reformulation_count, 1);
+    assert_eq!(stats.stall_count, 1);
+    assert_eq!(stats.exploratory_count, 1);
+    assert!((stats.first_try_rate - 0.25).abs() < 0.01);
 }

--- a/src/tests/dashboard/search_analysis.rs
+++ b/src/tests/dashboard/search_analysis.rs
@@ -104,7 +104,7 @@ fn fast_search_row_with_hit(
                     "top_hits": [
                         {
                             "name": top_hit_name,
-                            "file": "src/lib.rs",
+                            "file": "src/dashboard/routes/search.rs",
                             "score": 8.0
                         }
                     ]

--- a/src/tests/dashboard/search_analysis.rs
+++ b/src/tests/dashboard/search_analysis.rs
@@ -1,0 +1,100 @@
+use crate::daemon::database::SearchToolCallRow;
+use crate::dashboard::search_analysis::analyze_tool_calls;
+
+fn fast_search_row(
+    id: i64,
+    session_id: &str,
+    timestamp: i64,
+    query: &str,
+    normalized_query: &str,
+) -> SearchToolCallRow {
+    SearchToolCallRow {
+        id,
+        workspace_id: "ws1".to_string(),
+        session_id: session_id.to_string(),
+        timestamp,
+        tool_name: "fast_search".to_string(),
+        metadata: Some(
+            serde_json::json!({
+                "query": query,
+                "normalized_query": normalized_query,
+                "intent": "code_investigation",
+                "search_target": "definitions",
+                "trace": {
+                    "top_hits": [
+                        {
+                            "name": "search_handler",
+                            "file": "src/dashboard/routes/search.rs"
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+        ),
+    }
+}
+
+fn useful_action_row(id: i64, session_id: &str, timestamp: i64) -> SearchToolCallRow {
+    SearchToolCallRow {
+        id,
+        workspace_id: "ws1".to_string(),
+        session_id: session_id.to_string(),
+        timestamp,
+        tool_name: "deep_dive".to_string(),
+        metadata: Some(
+            serde_json::json!({
+                "target": {
+                    "target_symbol_name": "search_handler",
+                    "target_file_path": "src/dashboard/routes/search.rs"
+                }
+            })
+            .to_string(),
+        ),
+    }
+}
+
+#[test]
+fn test_search_analysis_groups_nearby_searches_into_one_episode() {
+    let rows = vec![
+        fast_search_row(1, "sess-a", 100, "search handler", "search handler"),
+        fast_search_row(2, "sess-a", 105, "centrality badge", "centrality badge"),
+        useful_action_row(3, "sess-a", 107),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+
+    assert_eq!(episodes.len(), 1);
+    assert_eq!(episodes[0].search_count, 2);
+    assert_eq!(episodes[0].downstream_tool.as_deref(), Some("deep_dive"));
+    assert_eq!(episodes[0].outcome, "exploratory_success");
+}
+
+#[test]
+fn test_search_analysis_flags_reformulation_when_queries_overlap_and_converge() {
+    let rows = vec![
+        fast_search_row(1, "sess-a", 100, "search handler", "search handler"),
+        fast_search_row(2, "sess-a", 103, "handler search", "handler search"),
+        useful_action_row(3, "sess-a", 105),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+
+    assert_eq!(episodes.len(), 1);
+    assert_eq!(episodes[0].outcome, "reformulation_converged");
+    assert!(episodes[0].suspicious);
+}
+
+#[test]
+fn test_search_analysis_splits_episodes_after_non_search_boundary() {
+    let rows = vec![
+        fast_search_row(1, "sess-a", 100, "search handler", "search handler"),
+        useful_action_row(2, "sess-a", 101),
+        fast_search_row(3, "sess-a", 102, "search compare", "search compare"),
+    ];
+
+    let episodes = analyze_tool_calls(&rows);
+
+    assert_eq!(episodes.len(), 2);
+    assert_eq!(episodes[0].outcome, "one_shot_success");
+    assert_eq!(episodes[1].outcome, "stalled");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -41,6 +41,7 @@ pub mod core {
     pub mod embedding_sidecar_protocol; // Sidecar protocol contracts + validation tests
     pub mod embedding_sidecar_provider; // Sidecar provider IPC + dimension guard tests
     pub mod handler; // MCP handler tests
+    pub mod handler_telemetry; // search telemetry and downstream target metadata tests
     pub mod incremental_update_atomic; // incremental_update_atomic write path tests (TDD)
     pub mod language; // Language detection and support tests
     pub mod memory_vectors; // Memory embedding vector storage (migration 012 + CRUD + KNN)
@@ -100,8 +101,8 @@ pub mod tools {
 
     pub mod phase4_token_savings; // Phase 4: Data structure optimization token savings tests (skip_serializing_if)
 
-    pub mod call_path_tests; // call_path shortest-path navigation tests
     pub mod call_path_disambiguation_tests; // call_path per-endpoint file-path disambiguation tests
+    pub mod call_path_tests; // call_path shortest-path navigation tests
     pub mod filtering_tests; // Symbol filter pipeline tests (index-based refactor TDD)
 
     pub mod get_context_allocation_tests; // get_context token allocation tests

--- a/src/tests/tools/call_path_tests.rs
+++ b/src/tests/tools/call_path_tests.rs
@@ -3,7 +3,9 @@ use std::fs;
 
 use crate::extractors::RelationshipKind;
 use crate::handler::JulieServerHandler;
-use crate::tools::navigation::call_path::{CallPathHop, CallPathResponse, CallPathTool, edge_label};
+use crate::tools::navigation::call_path::{
+    CallPathHop, CallPathResponse, CallPathTool, edge_label,
+};
 use crate::tools::workspace::ManageWorkspaceTool;
 use tempfile::TempDir;
 

--- a/src/tools/search/execution.rs
+++ b/src/tools/search/execution.rs
@@ -1,0 +1,168 @@
+use std::cmp::Ordering;
+
+use anyhow::Result;
+
+use crate::handler::JulieServerHandler;
+use crate::tools::navigation::resolution::WorkspaceTarget;
+
+use super::formatting;
+use super::line_mode;
+use super::text_search;
+use super::trace::{SearchExecutionKind, SearchExecutionResult, SearchHit};
+
+pub struct SearchExecutionParams<'a> {
+    pub query: &'a str,
+    pub language: &'a Option<String>,
+    pub file_pattern: &'a Option<String>,
+    pub limit: u32,
+    pub search_target: &'a str,
+    pub context_lines: Option<u32>,
+    pub exclude_tests: Option<bool>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchExecutionWorkspace {
+    pub workspace_id: String,
+    pub target: WorkspaceTarget,
+}
+
+impl SearchExecutionWorkspace {
+    pub fn primary(workspace_id: String) -> Self {
+        Self {
+            workspace_id,
+            target: WorkspaceTarget::Primary,
+        }
+    }
+
+    pub fn target(workspace_id: String) -> Self {
+        Self {
+            workspace_id: workspace_id.clone(),
+            target: WorkspaceTarget::Target(workspace_id),
+        }
+    }
+}
+
+pub async fn execute_search(
+    params: SearchExecutionParams<'_>,
+    workspaces: &[SearchExecutionWorkspace],
+    handler: &JulieServerHandler,
+) -> Result<SearchExecutionResult> {
+    if params.search_target == "content" {
+        execute_content_search(params, workspaces, handler).await
+    } else {
+        execute_definition_search(params, workspaces, handler).await
+    }
+}
+
+fn sort_hits_by_score_desc(hits: &mut [SearchHit]) {
+    hits.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(Ordering::Equal));
+}
+
+async fn execute_definition_search(
+    params: SearchExecutionParams<'_>,
+    workspaces: &[SearchExecutionWorkspace],
+    handler: &JulieServerHandler,
+) -> Result<SearchExecutionResult> {
+    let mut hits = Vec::new();
+    let mut relaxed = false;
+    let mut total_results = 0usize;
+
+    for workspace in workspaces {
+        let (symbols, workspace_relaxed, workspace_total) = text_search::text_search_impl(
+            params.query,
+            params.language,
+            params.file_pattern,
+            params.limit,
+            Some(vec![workspace.workspace_id.clone()]),
+            "definitions",
+            params.context_lines,
+            params.exclude_tests,
+            handler,
+        )
+        .await?;
+
+        let symbols = formatting::truncate_code_context(symbols, params.context_lines);
+        relaxed |= workspace_relaxed;
+        total_results += workspace_total;
+        hits.extend(
+            symbols
+                .into_iter()
+                .map(|symbol| SearchHit::from_symbol(symbol, workspace.workspace_id.clone())),
+        );
+    }
+
+    sort_hits_by_score_desc(&mut hits);
+    hits.truncate(params.limit.max(1) as usize);
+
+    Ok(SearchExecutionResult::new(
+        hits,
+        relaxed,
+        total_results,
+        "fast_search_definitions",
+        SearchExecutionKind::Definitions,
+    ))
+}
+
+async fn execute_content_search(
+    params: SearchExecutionParams<'_>,
+    workspaces: &[SearchExecutionWorkspace],
+    handler: &JulieServerHandler,
+) -> Result<SearchExecutionResult> {
+    let mut hits = Vec::new();
+    let mut relaxed = false;
+    let mut total_results = 0usize;
+    let file_level = line_mode::query_uses_file_level_header(params.query);
+    let workspace_label = if workspaces.len() == 1 {
+        match &workspaces[0].target {
+            WorkspaceTarget::Primary => Some("primary".to_string()),
+            WorkspaceTarget::Target(id) => Some(id.clone()),
+        }
+    } else {
+        None
+    };
+
+    for workspace in workspaces {
+        let result = line_mode::line_mode_matches(
+            params.query,
+            params.language,
+            params.file_pattern,
+            params.limit,
+            params.exclude_tests,
+            &workspace.target,
+            handler,
+        )
+        .await?;
+
+        relaxed |= result.relaxed;
+        total_results += result.matches.len();
+        let workspace_total = result.matches.len().max(1) as f32;
+
+        for (idx, line_match) in result.matches.into_iter().enumerate() {
+            let score = workspace_total - idx as f32;
+            hits.push(SearchHit::from_line_match(
+                line_match,
+                workspace.workspace_id.clone(),
+                infer_language(params.language),
+                score,
+            ));
+        }
+    }
+
+    sort_hits_by_score_desc(&mut hits);
+    hits.truncate(params.limit.max(1) as usize);
+
+    Ok(SearchExecutionResult::new(
+        hits,
+        relaxed,
+        total_results,
+        "fast_search_content",
+        SearchExecutionKind::Content {
+            workspace_label,
+            file_level,
+        },
+    ))
+}
+
+fn infer_language(requested_language: &Option<String>) -> String {
+    requested_language.clone().unwrap_or_default()
+}

--- a/src/tools/search/line_mode.rs
+++ b/src/tools/search/line_mode.rs
@@ -14,6 +14,20 @@ use crate::tools::navigation::resolution::WorkspaceTarget;
 use super::query::{line_match_strategy, line_matches, matches_glob_pattern};
 use super::types::{LineMatch, LineMatchStrategy};
 
+pub(crate) struct LineModeSearchResult {
+    pub matches: Vec<LineMatch>,
+    pub relaxed: bool,
+    pub strategy: LineMatchStrategy,
+    pub workspace_label: String,
+}
+
+pub(crate) fn query_uses_file_level_header(query: &str) -> bool {
+    matches!(
+        line_match_strategy(query),
+        LineMatchStrategy::FileLevel { .. }
+    )
+}
+
 /// Line-level search mode (grep-style output with line numbers)
 ///
 /// Returns every line matching the query with file:line_number:line_content format.
@@ -21,6 +35,7 @@ use super::types::{LineMatch, LineMatchStrategy};
 ///
 /// Accepts a pre-resolved `WorkspaceTarget` to avoid redundant workspace resolution.
 /// The caller (`FastSearchTool::call_tool`) resolves the workspace once and passes it here.
+#[allow(dead_code)]
 pub async fn line_mode_search(
     query: &str,
     language: &Option<String>,
@@ -30,26 +45,53 @@ pub async fn line_mode_search(
     workspace_target: &WorkspaceTarget,
     handler: &JulieServerHandler,
 ) -> Result<CallToolResult> {
+    let result = line_mode_matches(
+        query,
+        language,
+        file_pattern,
+        limit,
+        exclude_tests,
+        workspace_target,
+        handler,
+    )
+    .await?;
+
+    if result.matches.is_empty() {
+        let message = format!(
+            "🔍 No lines found matching: '{}'\n\
+            💡 Try search_target=\"definitions\" if looking for a symbol name, or broaden file_pattern/language filters",
+            query
+        );
+        return Ok(CallToolResult::text_content(vec![Content::text(message)]));
+    }
+
+    Ok(CallToolResult::text_content(vec![Content::text(
+        format_line_mode_output(query, &result),
+    )]))
+}
+
+pub(crate) async fn line_mode_matches(
+    query: &str,
+    language: &Option<String>,
+    file_pattern: &Option<String>,
+    limit: u32,
+    exclude_tests: Option<bool>,
+    workspace_target: &WorkspaceTarget,
+    handler: &JulieServerHandler,
+) -> Result<LineModeSearchResult> {
     debug!("📄 Line-level search for: '{}'", query);
 
     let exclude_test_files = exclude_tests.unwrap_or(false);
-
-    // Display label for search result headers
     let workspace_label = match workspace_target {
         WorkspaceTarget::Primary => "primary".to_string(),
         WorkspaceTarget::Target(id) => id.clone(),
     };
-
     let match_strategy = line_match_strategy(query);
     let base_limit = limit.max(1) as usize;
     let has_file_filter = file_pattern.is_some();
     let fetch_limit = if has_file_filter {
-        // When file_pattern is active, most Tantivy results will be filtered out.
-        // Fetch more candidates so matching files aren't missed by the limit cap.
         base_limit.saturating_mul(100).max(500).min(1000)
     } else {
-        // 20x: compound token boosting broadens matching, so we need more candidates
-        // to surface precise matches after line-level re-ranking.
         base_limit.saturating_mul(20)
     };
     let filter = SearchFilter {
@@ -59,11 +101,8 @@ pub async fn line_mode_search(
         exclude_tests: false,
     };
 
-    // Search the single target workspace
-    let all_line_matches: Vec<LineMatch> = match workspace_target {
+    let (all_line_matches, relaxed): (Vec<LineMatch>, bool) = match workspace_target {
         WorkspaceTarget::Primary => {
-            // Capture the primary binding and storage handles together so a completed
-            // swap can't pair stale loaded-workspace handles with the new primary identity.
             let primary_snapshot = handler.primary_workspace_snapshot().await?;
             let db = primary_snapshot.database;
             let search_index = primary_snapshot.search_index.ok_or_else(|| {
@@ -77,7 +116,7 @@ pub async fn line_mode_search(
             let file_pattern_clone = file_pattern.clone();
             let language_clone = language.clone();
 
-            tokio::task::spawn_blocking(move || -> Result<Vec<LineMatch>> {
+            tokio::task::spawn_blocking(move || -> Result<(Vec<LineMatch>, bool)> {
                 let index = match search_index.lock() {
                     Ok(guard) => guard,
                     Err(poisoned) => {
@@ -85,7 +124,9 @@ pub async fn line_mode_search(
                         poisoned.into_inner()
                     }
                 };
-                let file_results = index.search_content(&query, &filter, fetch_limit)?.results;
+                let content_results = index.search_content(&query, &filter, fetch_limit)?;
+                let relaxed = content_results.relaxed;
+                let file_results = content_results.results;
                 drop(index);
 
                 let db_lock = match db.lock() {
@@ -102,16 +143,16 @@ pub async fn line_mode_search(
                         break;
                     }
 
-                    if let Some(ref pattern) = file_pattern_clone {
-                        if !matches_glob_pattern(&file_result.file_path, pattern) {
-                            continue;
-                        }
+                    if let Some(ref pattern) = file_pattern_clone
+                        && !matches_glob_pattern(&file_result.file_path, pattern)
+                    {
+                        continue;
                     }
 
-                    if let Some(ref lang) = language_clone {
-                        if !file_matches_language(&file_result.file_path, lang) {
-                            continue;
-                        }
+                    if let Some(ref lang) = language_clone
+                        && !file_matches_language(&file_result.file_path, lang)
+                    {
+                        continue;
                     }
 
                     if exclude_test_files
@@ -131,12 +172,11 @@ pub async fn line_mode_search(
                     }
                 }
 
-                Ok(matches)
+                Ok((matches, relaxed))
             })
             .await??
         }
         WorkspaceTarget::Target(workspace_id) => {
-            // Search the explicit workspace using handler helpers for DB + SearchIndex access.
             let db_arc = handler.get_database_for_workspace(workspace_id).await?;
             let si_arc = handler.get_search_index_for_workspace(workspace_id).await?;
             let target_workspace_id = workspace_id.clone();
@@ -146,7 +186,7 @@ pub async fn line_mode_search(
             let ref_file_pattern = file_pattern.clone();
             let ref_language = language.clone();
 
-            tokio::task::spawn_blocking(move || -> Result<Vec<LineMatch>> {
+            tokio::task::spawn_blocking(move || -> Result<(Vec<LineMatch>, bool)> {
                 let si_arc = match si_arc {
                     Some(si) => si,
                     None => {
@@ -166,13 +206,13 @@ pub async fn line_mode_search(
                     file_pattern: ref_file_pattern.clone(),
                     exclude_tests: false,
                 };
-                let file_results = ref_index
-                    .search_content(&query_clone, &ref_filter, fetch_limit)?
-                    .results;
+                let content_results = ref_index.search_content(&query_clone, &ref_filter, fetch_limit)?;
+                let relaxed = content_results.relaxed;
+                let file_results = content_results.results;
                 drop(ref_index);
 
                 if file_results.is_empty() {
-                    return Ok(Vec::new());
+                    return Ok((Vec::new(), relaxed));
                 }
 
                 let ref_db = db_arc
@@ -184,21 +224,18 @@ pub async fn line_mode_search(
                         break;
                     }
 
-                    // Apply file_pattern filter BEFORE expensive DB content retrieval
-                    if let Some(ref pattern) = ref_file_pattern {
-                        if !matches_glob_pattern(&file_result.file_path, pattern) {
-                            continue;
-                        }
+                    if let Some(ref pattern) = ref_file_pattern
+                        && !matches_glob_pattern(&file_result.file_path, pattern)
+                    {
+                        continue;
                     }
 
-                    // Apply language filter BEFORE DB lookup
-                    if let Some(ref lang) = ref_language {
-                        if !file_matches_language(&file_result.file_path, lang) {
-                            continue;
-                        }
+                    if let Some(ref lang) = ref_language
+                        && !file_matches_language(&file_result.file_path, lang)
+                    {
+                        continue;
                     }
 
-                    // Skip test files when exclude_tests is set
                     if exclude_test_files
                         && crate::search::scoring::is_test_path(&file_result.file_path)
                     {
@@ -216,15 +253,13 @@ pub async fn line_mode_search(
                     }
                 }
 
-                Ok(matches)
+                Ok((matches, relaxed))
             })
             .await
             .map_err(|e| anyhow::anyhow!("Failed to spawn target workspace search: {}", e))??
         }
     };
 
-    // Defense-in-depth: post-filter by language, file_pattern, and test exclusion
-    // (primary filtering now happens inside the collection loop above)
     let filtered_matches: Vec<LineMatch> = all_line_matches
         .into_iter()
         .filter(|line_match| {
@@ -232,67 +267,62 @@ pub async fn line_mode_search(
                 .as_ref()
                 .map(|lang| file_matches_language(&line_match.file_path, lang))
                 .unwrap_or(true);
-
             let file_match = file_pattern
                 .as_ref()
                 .map(|pattern| matches_glob_pattern(&line_match.file_path, pattern))
                 .unwrap_or(true);
-
             let test_match = if exclude_test_files {
                 !crate::search::scoring::is_test_path(&line_match.file_path)
             } else {
                 true
             };
-
             language_match && file_match && test_match
         })
         .collect();
 
-    if filtered_matches.is_empty() {
-        let message = format!(
-            "🔍 No lines found matching: '{}'\n\
-            💡 Try search_target=\"definitions\" if looking for a symbol name, or broaden file_pattern/language filters",
-            query
-        );
-        return Ok(CallToolResult::text_content(vec![Content::text(message)]));
-    }
+    Ok(LineModeSearchResult {
+        matches: filtered_matches,
+        relaxed,
+        strategy: match_strategy,
+        workspace_label,
+    })
+}
 
-    // Format results (single workspace search)
-    let header = match &match_strategy {
+pub(crate) fn format_line_mode_output(query: &str, result: &LineModeSearchResult) -> String {
+    let header = match &result.strategy {
         LineMatchStrategy::FileLevel { .. } => {
-            let file_count = filtered_matches
+            let file_count = result
+                .matches
                 .iter()
                 .map(|m| &m.file_path)
                 .collect::<std::collections::HashSet<_>>()
                 .len();
             format!(
                 "📄 File-level search in [{}]: '{}' (found {} lines across {} files)",
-                workspace_label,
+                result.workspace_label,
                 query,
-                filtered_matches.len(),
+                result.matches.len(),
                 file_count
             )
         }
         _ => format!(
             "📄 Line-level search in [{}]: '{}' (found {} lines)",
-            workspace_label,
+            result.workspace_label,
             query,
-            filtered_matches.len()
+            result.matches.len()
         ),
     };
     let mut lines = vec![header];
     lines.push(String::new());
 
-    for entry in &filtered_matches {
+    for entry in &result.matches {
         lines.push(format!(
             "{}:{}:{}",
             entry.file_path, entry.line_number, entry.line_content
         ));
     }
 
-    Ok(CallToolResult::text_content(vec![Content::text(
-        lines.join("\n"),
-    )]))
+    lines.join("\n")
 }
 
 /// Check if a file path matches the given language filter by extension.

--- a/src/tools/search/mod.rs
+++ b/src/tools/search/mod.rs
@@ -15,12 +15,14 @@ pub use self::query_preprocessor::{
 pub use self::types::{LineMatch, LineMatchStrategy};
 
 // Internal modules
+pub(crate) mod execution;
 pub(crate) mod formatting; // Exposed for testing
 mod line_mode;
 mod nl_embeddings;
 pub(crate) mod query;
 pub mod query_preprocessor; // Public for testing
 pub mod text_search;
+pub(crate) mod trace;
 mod types;
 
 use crate::mcp_compat::{CallToolResult, CallToolResultExt, Content};
@@ -112,8 +114,20 @@ impl Default for FastSearchTool {
     }
 }
 
+pub(crate) struct FastSearchExecution {
+    pub result: CallToolResult,
+    pub execution: Option<trace::SearchExecutionResult>,
+}
+
 impl FastSearchTool {
     pub async fn call_tool(&self, handler: &JulieServerHandler) -> Result<CallToolResult> {
+        self.execute_with_trace(handler).await.map(|run| run.result)
+    }
+
+    pub(crate) async fn execute_with_trace(
+        &self,
+        handler: &JulieServerHandler,
+    ) -> Result<FastSearchExecution> {
         debug!(
             "🔍 Fast search: {} (target: {})",
             self.query, self.search_target
@@ -144,7 +158,10 @@ impl FastSearchTool {
                         && handler.get_workspace().await?.is_none()
                     {
                         let message = "Workspace not indexed yet. Run manage_workspace(operation=\"index\") first.";
-                        return Ok(CallToolResult::text_content(vec![Content::text(message)]));
+                        return Ok(FastSearchExecution {
+                            result: CallToolResult::text_content(vec![Content::text(message)]),
+                            execution: None,
+                        });
                     }
 
                     let primary_id = handler.require_primary_workspace_identity()?;
@@ -163,7 +180,10 @@ impl FastSearchTool {
                         } else {
                             "Definition search requires a Tantivy index for the current primary workspace. Run manage_workspace(operation=\"refresh\") first.".to_string()
                         };
-                        return Ok(CallToolResult::text_content(vec![Content::text(message)]));
+                        return Ok(FastSearchExecution {
+                            result: CallToolResult::text_content(vec![Content::text(message)]),
+                            execution: None,
+                        });
                     }
                 }
 
@@ -188,7 +208,10 @@ impl FastSearchTool {
                                 target_workspace_id, target_workspace_id
                             )
                         };
-                        return Ok(CallToolResult::text_content(vec![Content::text(message)]));
+                        return Ok(FastSearchExecution {
+                            result: CallToolResult::text_content(vec![Content::text(message)]),
+                            execution: None,
+                        });
                     }
                 }
 
@@ -198,7 +221,10 @@ impl FastSearchTool {
                     );
                 } else {
                     let message = "Workspace not indexed yet. Run manage_workspace(operation=\"index\") first.";
-                    return Ok(CallToolResult::text_content(vec![Content::text(message)]));
+                    return Ok(FastSearchExecution {
+                        result: CallToolResult::text_content(vec![Content::text(message)]),
+                        execution: None,
+                    });
                 }
             }
             SystemStatus::SqliteOnly { symbol_count } => {
@@ -210,6 +236,15 @@ impl FastSearchTool {
         }
 
         // Route: content search → line mode, definition search → symbol mode
+        let execution_workspaces = match &workspace_target {
+            WorkspaceTarget::Primary => vec![execution::SearchExecutionWorkspace::primary(
+                handler.require_primary_workspace_identity()?,
+            )],
+            WorkspaceTarget::Target(id) => {
+                vec![execution::SearchExecutionWorkspace::target(id.clone())]
+            }
+        };
+
         if use_line_mode {
             match &workspace_target {
                 WorkspaceTarget::Primary => {
@@ -220,7 +255,10 @@ impl FastSearchTool {
                         .is_none()
                     {
                         let message = "Line-level content search requires a Tantivy index for the current primary workspace. Run manage_workspace(operation=\"refresh\") first.";
-                        return Ok(CallToolResult::text_content(vec![Content::text(message)]));
+                        return Ok(FastSearchExecution {
+                            result: CallToolResult::text_content(vec![Content::text(message)]),
+                            execution: None,
+                        });
                     }
                 }
                 WorkspaceTarget::Target(id) => {
@@ -230,21 +268,70 @@ impl FastSearchTool {
                             "Line-level content search requires a Tantivy index for workspace '{}'. Run manage_workspace(operation=\"refresh\", workspace_id=\"{}\") first.",
                             id, id
                         );
-                        return Ok(CallToolResult::text_content(vec![Content::text(message)]));
+                        return Ok(FastSearchExecution {
+                            result: CallToolResult::text_content(vec![Content::text(message)]),
+                            execution: None,
+                        });
                     }
                 }
             }
 
-            return line_mode::line_mode_search(
-                &self.query,
-                &self.language,
-                &self.file_pattern,
-                self.limit,
-                self.exclude_tests,
-                &workspace_target,
+            let execution = execution::execute_search(
+                execution::SearchExecutionParams {
+                    query: &self.query,
+                    language: &self.language,
+                    file_pattern: &self.file_pattern,
+                    limit: self.limit,
+                    search_target: &self.search_target,
+                    context_lines: self.context_lines,
+                    exclude_tests: self.exclude_tests,
+                },
+                &execution_workspaces,
                 handler,
             )
-            .await;
+            .await?;
+
+            if execution.hits.is_empty() {
+                let message = format!(
+                    "🔍 No lines found matching: '{}'\n\
+                    💡 Try search_target=\"definitions\" if looking for a symbol name, or broaden file_pattern/language filters",
+                    self.query
+                );
+                return Ok(FastSearchExecution {
+                    result: CallToolResult::text_content(vec![Content::text(message)]),
+                    execution: Some(execution),
+                });
+            }
+
+            let line_mode_result = match &execution.kind {
+                trace::SearchExecutionKind::Content {
+                    workspace_label,
+                    file_level,
+                } => line_mode::LineModeSearchResult {
+                    matches: execution
+                        .hits
+                        .iter()
+                        .filter_map(|hit| hit.as_line_match().cloned())
+                        .collect(),
+                    relaxed: execution.relaxed,
+                    strategy: if *file_level {
+                        types::LineMatchStrategy::FileLevel {
+                            terms: vec![self.query.clone()],
+                        }
+                    } else {
+                        types::LineMatchStrategy::Substring(self.query.clone())
+                    },
+                    workspace_label: workspace_label
+                        .clone()
+                        .unwrap_or_else(|| "multiple".to_string()),
+                },
+                trace::SearchExecutionKind::Definitions => unreachable!("content search kind"),
+            };
+            let output = line_mode::format_line_mode_output(&self.query, &line_mode_result);
+            return Ok(FastSearchExecution {
+                result: CallToolResult::text_content(vec![Content::text(output)]),
+                execution: Some(execution),
+            });
         }
 
         // Definition search → Tantivy symbol mode
@@ -257,7 +344,10 @@ impl FastSearchTool {
                     .is_none()
                 {
                     let message = "Definition search requires a Tantivy index for the current primary workspace. Run manage_workspace(operation=\"refresh\") first.";
-                    return Ok(CallToolResult::text_content(vec![Content::text(message)]));
+                    return Ok(FastSearchExecution {
+                        result: CallToolResult::text_content(vec![Content::text(message)]),
+                        execution: None,
+                    });
                 }
             }
             WorkspaceTarget::Target(id) => {
@@ -267,7 +357,10 @@ impl FastSearchTool {
                         "Definition search requires a Tantivy index for workspace '{}'. Run manage_workspace(operation=\"refresh\", workspace_id=\"{}\") first.",
                         id, id
                     );
-                    return Ok(CallToolResult::text_content(vec![Content::text(message)]));
+                    return Ok(FastSearchExecution {
+                        result: CallToolResult::text_content(vec![Content::text(message)]),
+                        execution: None,
+                    });
                 }
             }
         }
@@ -286,31 +379,31 @@ impl FastSearchTool {
                     "Definition search requires a Tantivy index for workspace '{}'. Run manage_workspace(operation=\"refresh\", workspace_id=\"{}\") first.",
                     target_workspace_id, target_workspace_id
                 );
-                return Ok(CallToolResult::text_content(vec![Content::text(message)]));
+                return Ok(FastSearchExecution {
+                    result: CallToolResult::text_content(vec![Content::text(message)]),
+                    execution: None,
+                });
             }
         }
 
-        // Convert WorkspaceTarget to Option<Vec<String>> for text_search_impl
-        let workspace_ids = match workspace_target {
-            WorkspaceTarget::Primary => Some(vec![handler.require_primary_workspace_identity()?]),
-            WorkspaceTarget::Target(id) => Some(vec![id]),
-        };
-        let (symbols, relaxed, pre_trunc_total) = text_search::text_search_impl(
-            &self.query,
-            &self.language,
-            &self.file_pattern,
-            self.limit,
-            workspace_ids,
-            &self.search_target,
-            self.context_lines,
-            self.exclude_tests,
+        let execution = execution::execute_search(
+            execution::SearchExecutionParams {
+                query: &self.query,
+                language: &self.language,
+                file_pattern: &self.file_pattern,
+                limit: self.limit,
+                search_target: &self.search_target,
+                context_lines: self.context_lines,
+                exclude_tests: self.exclude_tests,
+            },
+            &execution_workspaces,
             handler,
         )
         .await?;
 
-        let symbols = formatting::truncate_code_context(symbols, self.context_lines);
+        let symbols = execution.definition_symbols();
 
-        let optimized = OptimizedResponse::with_total(symbols, pre_trunc_total);
+        let optimized = OptimizedResponse::with_total(symbols, execution.total_results);
 
         if optimized.results.is_empty() {
             let message = format!(
@@ -318,28 +411,32 @@ impl FastSearchTool {
                 Try search_target=\"content\" for line-level search, or a broader query",
                 self.query
             );
-            return Ok(CallToolResult::text_content(vec![Content::text(message)]));
+            return Ok(FastSearchExecution {
+                result: CallToolResult::text_content(vec![Content::text(message)]),
+                execution: Some(execution),
+            });
         }
 
         // Locations-only mode: skip code context entirely (70-90% token savings)
         if self.return_format == "locations" {
             let mut locations_output = formatting::format_locations_only(&self.query, &optimized);
-            if relaxed {
+            if execution.relaxed {
                 locations_output = format!(
                     "NOTE: Relaxed search (showing partial matches — no results matched all terms)\n\n{}",
                     locations_output
                 );
             }
-            return Ok(CallToolResult::text_content(vec![Content::text(
-                locations_output,
-            )]));
+            return Ok(FastSearchExecution {
+                result: CallToolResult::text_content(vec![Content::text(locations_output)]),
+                execution: Some(execution),
+            });
         }
 
         // Definition search: use promoted formatting (exact matches get "Definition found:" header)
         let lean_output = formatting::format_definition_search_results(&self.query, &optimized);
 
         // Prepend relaxed-match indicator when OR fallback was used
-        let lean_output = if relaxed {
+        let lean_output = if execution.relaxed {
             format!(
                 "NOTE: Relaxed search (showing partial matches — no results matched all terms)\n\n{}",
                 lean_output
@@ -352,11 +449,12 @@ impl FastSearchTool {
             "✅ Returning lean search results ({} chars, {} results, relaxed: {})",
             lean_output.len(),
             optimized.results.len(),
-            relaxed,
+            execution.relaxed,
         );
-        Ok(CallToolResult::text_content(vec![Content::text(
-            lean_output,
-        )]))
+        Ok(FastSearchExecution {
+            result: CallToolResult::text_content(vec![Content::text(lean_output)]),
+            execution: Some(execution),
+        })
     }
 
     /// Resolve workspace filtering parameter to a WorkspaceTarget.

--- a/src/tools/search/trace.rs
+++ b/src/tools/search/trace.rs
@@ -1,0 +1,191 @@
+use serde::Serialize;
+
+use crate::extractors::Symbol;
+
+use super::types::LineMatch;
+
+#[derive(Debug, Clone)]
+pub enum SearchHitBacking {
+    Symbol(Symbol),
+    LineMatch(LineMatch),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchHit {
+    pub name: String,
+    pub file: String,
+    pub line: Option<u32>,
+    pub kind: String,
+    pub language: String,
+    pub score: f32,
+    pub snippet: Option<String>,
+    pub workspace: String,
+    pub symbol_id: Option<String>,
+    #[serde(skip_serializing)]
+    pub backing: SearchHitBacking,
+}
+
+impl SearchHit {
+    pub fn from_symbol(symbol: Symbol, workspace: String) -> Self {
+        let line = Some(symbol.start_line);
+        let score = symbol.confidence.unwrap_or(0.0);
+        let snippet = symbol
+            .signature
+            .clone()
+            .or(symbol.doc_comment.clone())
+            .or(symbol.code_context.clone());
+        let symbol_id = Some(symbol.id.clone());
+        let name = symbol.name.clone();
+        let file = symbol.file_path.clone();
+        let kind = symbol.kind.to_string();
+        let language = symbol.language.clone();
+
+        Self {
+            name,
+            file,
+            line,
+            kind,
+            language,
+            score,
+            snippet,
+            workspace,
+            symbol_id,
+            backing: SearchHitBacking::Symbol(symbol),
+        }
+    }
+
+    pub fn from_line_match(
+        line_match: LineMatch,
+        workspace: String,
+        language: String,
+        score: f32,
+    ) -> Self {
+        let filename = line_match
+            .file_path
+            .rsplit('/')
+            .next()
+            .unwrap_or(&line_match.file_path)
+            .to_string();
+        let file = line_match.file_path.clone();
+        let line = Some(line_match.line_number as u32);
+        let snippet = Some(line_match.line_content.clone());
+
+        Self {
+            name: filename,
+            file,
+            line,
+            kind: "line".to_string(),
+            language,
+            score,
+            snippet,
+            workspace,
+            symbol_id: None,
+            backing: SearchHitBacking::LineMatch(line_match),
+        }
+    }
+
+    pub fn as_symbol(&self) -> Option<&Symbol> {
+        match &self.backing {
+            SearchHitBacking::Symbol(symbol) => Some(symbol),
+            SearchHitBacking::LineMatch(_) => None,
+        }
+    }
+
+    pub fn as_line_match(&self) -> Option<&LineMatch> {
+        match &self.backing {
+            SearchHitBacking::Symbol(_) => None,
+            SearchHitBacking::LineMatch(line_match) => Some(line_match),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchHitSummary {
+    pub rank: usize,
+    pub symbol_id: Option<String>,
+    pub name: String,
+    pub kind: String,
+    pub file: String,
+    pub line: Option<u32>,
+    pub score: f32,
+    pub workspace: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchTrace {
+    pub strategy_id: String,
+    pub result_count: usize,
+    pub top_hits: Vec<SearchHitSummary>,
+}
+
+impl SearchTrace {
+    pub fn from_hits(strategy_id: impl Into<String>, hits: &[SearchHit]) -> Self {
+        let strategy_id = strategy_id.into();
+        let top_hits = hits
+            .iter()
+            .take(3)
+            .enumerate()
+            .map(|(idx, hit)| SearchHitSummary {
+                rank: idx + 1,
+                symbol_id: hit.symbol_id.clone(),
+                name: hit.name.clone(),
+                kind: hit.kind.clone(),
+                file: hit.file.clone(),
+                line: hit.line,
+                score: hit.score,
+                workspace: hit.workspace.clone(),
+            })
+            .collect();
+
+        Self {
+            strategy_id,
+            result_count: hits.len(),
+            top_hits,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum SearchExecutionKind {
+    Definitions,
+    Content {
+        workspace_label: Option<String>,
+        file_level: bool,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchExecutionResult {
+    pub hits: Vec<SearchHit>,
+    pub relaxed: bool,
+    pub total_results: usize,
+    pub trace: SearchTrace,
+    #[serde(skip_serializing)]
+    pub kind: SearchExecutionKind,
+}
+
+impl SearchExecutionResult {
+    pub fn new(
+        hits: Vec<SearchHit>,
+        relaxed: bool,
+        total_results: usize,
+        strategy_id: impl Into<String>,
+        kind: SearchExecutionKind,
+    ) -> Self {
+        let trace = SearchTrace::from_hits(strategy_id, &hits);
+        Self {
+            hits,
+            relaxed,
+            total_results,
+            trace,
+            kind,
+        }
+    }
+
+    pub fn definition_symbols(&self) -> Vec<Symbol> {
+        self.hits
+            .iter()
+            .filter_map(|hit| hit.as_symbol().cloned())
+            .collect()
+    }
+}

--- a/src/tools/workspace/indexing/embeddings.rs
+++ b/src/tools/workspace/indexing/embeddings.rs
@@ -265,5 +265,3 @@ pub(crate) async fn spawn_workspace_embedding(
 
     total_symbols
 }
-
-


### PR DESCRIPTION
## Summary

- Reworked `/search/analysis` from a chronological episode feed into a diagnostic tool with first-try success rate, problem queries ranked by failure frequency, reformulation pairs, and filtered episode feed
- Added canonical key grouping for query aggregation (handles CamelCase/snake_case/qualified name variants), recall-vs-ranking triage signal, and file-aware disambiguation
- Fixed episode builder to split on workspace_id change (cross-workspace searches no longer merge)
- Widened SearchEpisodeQuery with Option trace fields from existing telemetry

## External review

Codex (gpt-5.4, xhigh): 3 findings, all fixed.
1. **(high)** Triage now compares file paths alongside symbol names
2. **(medium)** Zero-result values render as '0' instead of '-' (Tera `is number`)
3. **(medium)** Reformulation pairs filtered to overlapping queries only

Full report: `.memories/autonomous-run-2026-04-20-search-analysis-diagnostic-rework.md`

## Test plan

- [x] Dev tier: 10/10 buckets pass
- [x] 22 search analysis unit tests (canonical key, aggregation, triage, pairs, edge cases)
- [x] Dashboard integration: all pages return 200
- [x] Null trace handling (pre-telemetry calls)
- [x] Zero-episode empty states
- [ ] Manual: rebuild release, check `/search/analysis` with live data