### PR TITLE
refactor(dashboard): rework search analysis into trace viewer

### DIFF
--- a/.memories/autonomous-run-2026-04-20-search-analysis-workbench.md
+++ b/.memories/autonomous-run-2026-04-20-search-analysis-workbench.md
@@ -1,0 +1,64 @@
+# Autonomous Run Report: Search Analysis Workbench
+
+**Status:** Complete
+**Branch:** `search-analysis-workbench`
+**Base:** `main`
+**Plan:** `docs/plans/2026-04-20-search-analysis-workbench-implementation-plan.md`
+**Design:** `docs/plans/2026-04-20-search-analysis-workbench-design.md`
+**Date:** 2026-04-20
+
+## What shipped
+
+Reworked `/search/analysis` from a misleading metrics dashboard into a search observability workbench. The previous page computed first-try success rate and problem queries from inferred episode classifications, but live testing proved the inferences were unreliable (a session where every search worked correctly showed 29% success).
+
+The new page:
+- **Summary cards**: episode count, zero-hit count/rate, median top-hit score, repeat-query count/rate (observational, not judgmental)
+- **Friction flags**: per-episode signals (zero_hits, repeat_query, low_score, no_follow_up, relaxed) replacing success/failure classification
+- **Flag filter buttons**: click a flag to see only episodes with that signal
+- **Trace table**: expandable episode rows with per-query detail (query, intent, target, score, result count)
+- **Aggregated row values**: best_score and min_result_count across all queries (not just first query)
+
+Deleted ~300 lines of aggregation code (canonical_key, aggregate_problems, extract_reformulation_pairs, QueryProblem, ReformulationPair, and all supporting types).
+
+## Commits
+
+1. `3c02e0ed` refactor(dashboard): replace search analysis metrics with friction flags
+2. `fab98226` feat(dashboard): rework search analysis into trace viewer
+3. `19daed92` fix(dashboard): address codex review findings on trace viewer
+
+## Files changed
+
+| File | Lines |
+|------|-------|
+| `src/dashboard/search_analysis.rs` | -322/+97 (net -225) |
+| `src/dashboard/routes/search_analysis.rs` | rewritten |
+| `dashboard/templates/search_analysis.html` | rewritten |
+| `dashboard/templates/partials/search_episode_table.html` | rewritten |
+| `src/tests/dashboard/search_analysis.rs` | -179/+173 (replaced aggregation tests with flag/summary tests) |
+
+## Tests
+
+- Dev tier: 10/10 buckets pass (268s)
+- Search analysis unit tests: 16/16 pass
+- Dashboard integration: all pass
+
+## External review
+
+**Reviewer:** codex (gpt-5.4, xhigh reasoning)
+**Verdict:** needs-attention (2 findings)
+**Findings fixed:** 2/2
+
+| # | Severity | Title | Classification | Action |
+|---|----------|-------|---------------|--------|
+| 1 | high | Compare button targets endpoint that ignores query param | real-bug | Fixed: removed dead button |
+| 2 | medium | Collapsed rows show first query data when flags triggered by later queries | real-improvement | Fixed: added best_score/min_result_count aggregates |
+
+## Blockers hit
+
+None.
+
+## Next steps
+
+- Add GET query param support to the search playground so trace viewer can link "try this query"
+- Add "Promote to dogfood case" action once the pipeline for adding test cases is designed
+- Consider adding annotation support (good/bad/expected) for manual labeling

--- a/dashboard/templates/partials/search_episode_table.html
+++ b/dashboard/templates/partials/search_episode_table.html
@@ -77,10 +77,10 @@
           {% endfor %}
         </td>
         <td style="text-align: right;" class="mono">
-          {% if episode.queries.0.top_hit_score is number %}{{ episode.queries.0.top_hit_score | round(precision=1) }}{% else %}-{% endif %}
+          {% if episode.best_score is number %}{{ episode.best_score | round(precision=1) }}{% else %}-{% endif %}
         </td>
         <td style="text-align: right;" class="mono">
-          {% if episode.queries.0.result_count is number %}{{ episode.queries.0.result_count }}{% else %}-{% endif %}
+          {% if episode.min_result_count is number %}{{ episode.min_result_count }}{% else %}-{% endif %}
         </td>
         <td class="mono" style="color: var(--julie-text-muted);">
           {{ episode.downstream_tool | default(value="-") }}
@@ -88,9 +88,7 @@
         <td class="mono" style="color: var(--julie-text-muted); font-size: 0.8rem;">
           {{ episode.workspace_id }}
         </td>
-        <td>
-          <a href="/search/compare?query={{ episode.queries.0.query | urlencode }}" class="button is-small is-dark" title="Open in Compare" style="font-size: 0.7rem;">Compare</a>
-        </td>
+        <td></td>
       </tr>
       {% endfor %}
     </tbody>

--- a/dashboard/templates/partials/search_episode_table.html
+++ b/dashboard/templates/partials/search_episode_table.html
@@ -2,58 +2,98 @@
 {% if total_episode_count is defined %}
 <div style="margin-bottom: 0.75rem; color: var(--julie-text-muted); font-size: 0.85rem;">
   {% if show_all %}
-    Showing all {{ episodes | length }} episodes.
-    <a href="/search/analysis?{{ window_param }}">Show flagged only</a>
+    Showing all {{ episodes | length }} of {{ total_episode_count }} episodes.
+    <a href="/search/analysis?{{ window_param }}{% if active_flag %}&flag={{ active_flag }}{% endif %}">Show flagged only</a>
   {% else %}
-    Showing {{ episodes | length }} flagged of {{ total_episode_count }} total episodes.
-    <a href="/search/analysis?{{ window_param }}&show_all=true">Show all</a>
+    Showing {{ episodes | length }} flagged of {{ total_episode_count }} total.
+    <a href="/search/analysis?{{ window_param }}&show_all=true{% if active_flag %}&flag={{ active_flag }}{% endif %}">Show all</a>
   {% endif %}
 </div>
 {% endif %}
 
 {% if episodes | length == 0 %}
 <div class="julie-card" style="text-align: center; padding: 2rem; color: var(--julie-text-muted);">
-  <p>No search episodes to show.</p>
+  <p>No episodes to show.</p>
 </div>
 {% else %}
-{% for episode in episodes %}
-<div class="julie-card" style="margin-bottom: 0.75rem; padding: 1rem;">
-  <div style="display: flex; justify-content: space-between; gap: 1rem; align-items: start;">
-    <div>
-      <div style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;">
-        <span class="mono" style="color: var(--julie-text); font-weight: 600;">{{ episode.outcome }}</span>
-        {% if episode.suspicious %}
-        <span class="tag is-warning is-light">Flagged</span>
-        {% endif %}
-        <span class="mono" style="color: var(--julie-text-muted);">{{ episode.search_count }} search{{ episode.search_count | pluralize }}</span>
-        <span class="mono" style="color: var(--julie-text-muted);">{{ episode.workspace_id }}</span>
-      </div>
-      <div style="margin-top: 0.5rem;">
-        {% for query in episode.queries %}
-        <div style="margin-top: 0.35rem;">
-          <span class="mono" style="color: var(--julie-text);">{{ query.query }}</span>
-          <span style="color: var(--julie-text-muted);">({{ query.intent }}, {{ query.search_target }})</span>
-          {% if query.top_hit_score is number %}
-          <span class="tag is-dark is-small" style="margin-left: 0.25rem;" title="Top hit score">{{ query.top_hit_score | round(precision=2) }}</span>
+<div class="julie-card" style="padding: 0.5rem;">
+  <table class="table is-fullwidth is-narrow" style="background: transparent; font-size: 0.85rem;">
+    <thead>
+      <tr style="color: var(--julie-text-muted);">
+        <th>Queries</th>
+        <th style="text-align: right; width: 50px;">#</th>
+        <th>Flags</th>
+        <th style="text-align: right; width: 70px;">Score</th>
+        <th style="text-align: right; width: 70px;">Results</th>
+        <th>Downstream</th>
+        <th>Workspace</th>
+        <th style="width: 60px;"></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for episode in episodes %}
+      <tr style="color: var(--julie-text);">
+        <td>
+          {% if episode.search_count > 1 %}
+          <details>
+            <summary class="mono" style="cursor: pointer;">{{ episode.queries.0.query }}</summary>
+            <div style="padding: 0.5rem 0; font-size: 0.8rem;">
+              {% for query in episode.queries %}
+              <div style="margin-top: 0.35rem; padding-left: 0.5rem; border-left: 2px solid var(--julie-border);">
+                <span class="mono" style="color: var(--julie-text);">{{ query.query }}</span>
+                <span style="color: var(--julie-text-muted);">({{ query.intent }}, {{ query.search_target }})</span>
+                {% if query.top_hit_score is number %}
+                <span class="tag is-dark is-small" style="margin-left: 0.25rem;">{{ query.top_hit_score | round(precision=1) }}</span>
+                {% endif %}
+                {% if query.top_hit_name %}
+                <div style="color: var(--julie-text-muted);">
+                  top: <span class="mono">{{ query.top_hit_name }}</span>
+                  {% if query.top_hit_file %} in <span class="mono">{{ query.top_hit_file }}</span>{% endif %}
+                  {% if query.result_count is number %} ({{ query.result_count }} results){% endif %}
+                </div>
+                {% elif query.result_count is number and query.result_count == 0 %}
+                <div style="color: var(--julie-danger);">0 results</div>
+                {% endif %}
+              </div>
+              {% endfor %}
+            </div>
+          </details>
+          {% else %}
+          <span class="mono">{{ episode.queries.0.query }}</span>
           {% endif %}
-          {% if query.top_hit_name %}
-          <div style="color: var(--julie-text-muted); font-size: 0.85rem;">top hit: <span class="mono">{{ query.top_hit_name }}</span>{% if query.top_hit_file %} in <span class="mono">{{ query.top_hit_file }}</span>{% endif %}</div>
-          {% endif %}
-        </div>
-        {% endfor %}
-      </div>
-    </div>
-    <div style="min-width: 15rem;">
-      <p class="label-text" style="margin-bottom: 0.35rem;">Downstream</p>
-      <p class="mono" style="color: var(--julie-text);">{{ episode.downstream_tool | default(value="none") }}</p>
-      {% if episode.target_symbol_name %}
-      <p style="margin-top: 0.35rem; color: var(--julie-text-muted);">symbol: <span class="mono">{{ episode.target_symbol_name }}</span></p>
-      {% endif %}
-      {% if episode.target_file_path %}
-      <p style="color: var(--julie-text-muted);">file: <span class="mono">{{ episode.target_file_path }}</span></p>
-      {% endif %}
-    </div>
-  </div>
+        </td>
+        <td style="text-align: right;" class="mono">{{ episode.search_count }}</td>
+        <td>
+          {% for flag in episode.flags %}
+            {% if flag == "zero_hits" %}
+            <span class="tag is-danger is-light is-small">{{ flag }}</span>
+            {% elif flag == "low_score" %}
+            <span class="tag is-warning is-light is-small">{{ flag }}</span>
+            {% elif flag == "repeat_query" %}
+            <span class="tag is-info is-light is-small">{{ flag }}</span>
+            {% else %}
+            <span class="tag is-dark is-small">{{ flag }}</span>
+            {% endif %}
+          {% endfor %}
+        </td>
+        <td style="text-align: right;" class="mono">
+          {% if episode.queries.0.top_hit_score is number %}{{ episode.queries.0.top_hit_score | round(precision=1) }}{% else %}-{% endif %}
+        </td>
+        <td style="text-align: right;" class="mono">
+          {% if episode.queries.0.result_count is number %}{{ episode.queries.0.result_count }}{% else %}-{% endif %}
+        </td>
+        <td class="mono" style="color: var(--julie-text-muted);">
+          {{ episode.downstream_tool | default(value="-") }}
+        </td>
+        <td class="mono" style="color: var(--julie-text-muted); font-size: 0.8rem;">
+          {{ episode.workspace_id }}
+        </td>
+        <td>
+          <a href="/search/compare?query={{ episode.queries.0.query | urlencode }}" class="button is-small is-dark" title="Open in Compare" style="font-size: 0.7rem;">Compare</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
 </div>
-{% endfor %}
 {% endif %}

--- a/dashboard/templates/search_analysis.html
+++ b/dashboard/templates/search_analysis.html
@@ -5,7 +5,7 @@
 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
   <div>
     <h1 class="title" style="color: var(--julie-text); margin-bottom: 0.25rem;">Search Analysis</h1>
-    <p style="color: var(--julie-text-muted);">First-try success and failure patterns from tool call history.</p>
+    <p style="color: var(--julie-text-muted);">Search traces with friction flags. Quality judgments belong on the Compare page.</p>
   </div>
   <div style="display: flex; gap: 0.5rem;">
     <a class="button is-small" href="/search">Playground</a>
@@ -23,145 +23,51 @@
   <a href="/search/analysis?days=30" class="button is-small {% if window_label == '30d' %}is-primary{% else %}is-dark{% endif %}">30d</a>
 </div>
 
-{# Section 1: Headline Metrics #}
+{# Summary cards #}
 <div class="julie-card" style="margin-bottom: 1.5rem;">
   <div style="display: flex; gap: 2rem; flex-wrap: wrap; align-items: baseline;">
     <div>
-      <p class="label-text">First-Try Success</p>
-      <p class="mono" style="font-size: 1.6rem; color: var(--julie-accent);">{{ (episode_stats.first_try_rate * 100) | round(precision=1) }}%</p>
+      <p class="label-text">Episodes</p>
+      <p class="mono" style="font-size: 1.3rem; color: var(--julie-text);">{{ summary.episode_count }}</p>
     </div>
     <div>
-      <p class="label-text">One-Shot</p>
-      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.one_shot_count }}</p>
+      <p class="label-text">Zero-Hit</p>
+      <p class="mono" style="font-size: 1.3rem; color: {% if summary.zero_hit_count > 0 %}var(--julie-danger){% else %}var(--julie-text){% endif %};">
+        {{ summary.zero_hit_count }}
+        <span style="font-size: 0.85rem; color: var(--julie-text-muted);">{{ (summary.zero_hit_rate * 100) | round(precision=0) }}%</span>
+      </p>
     </div>
     <div>
-      <p class="label-text">Reformulated</p>
-      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.reformulation_count }}</p>
+      <p class="label-text">Median Score</p>
+      <p class="mono" style="font-size: 1.3rem; color: var(--julie-text);">
+        {% if summary.median_top_score is number %}{{ summary.median_top_score | round(precision=1) }}{% else %}-{% endif %}
+      </p>
     </div>
     <div>
-      <p class="label-text">Stalled</p>
-      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.stall_count }}</p>
-    </div>
-    <div>
-      <p class="label-text">Exploratory</p>
-      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ episode_stats.exploratory_count }}</p>
+      <p class="label-text">Repeat Query</p>
+      <p class="mono" style="font-size: 1.3rem; color: var(--julie-text);">
+        {{ summary.repeat_query_count }}
+        <span style="font-size: 0.85rem; color: var(--julie-text-muted);">{{ (summary.repeat_query_rate * 100) | round(precision=0) }}%</span>
+      </p>
     </div>
     <div>
       <p class="label-text">Window</p>
-      <p class="mono" style="font-size: 1.1rem; color: var(--julie-text);">{{ window_label }}</p>
+      <p class="mono" style="font-size: 1.3rem; color: var(--julie-text);">{{ window_label }}</p>
     </div>
   </div>
 </div>
 
-{# Section 2: Problem Queries #}
-<div class="julie-card" style="margin-bottom: 1.5rem;">
-  <h2 class="subtitle" style="color: var(--julie-text); margin-bottom: 0.75rem;">Problem Queries</h2>
-  {% if problems | length == 0 %}
-  <p style="color: var(--julie-text-muted); text-align: center; padding: 1rem;">
-    No problem queries detected. Either search is working well or there isn't enough data yet.
-  </p>
-  {% else %}
-  <div style="overflow-x: auto;">
-    <table class="table is-fullwidth is-narrow" style="background: transparent; font-size: 0.85rem;">
-      <thead>
-        <tr style="color: var(--julie-text-muted);">
-          <th>Query</th>
-          <th>Variants</th>
-          <th style="text-align: right;">Failures</th>
-          <th>Triage</th>
-          <th style="text-align: right;">Avg Score</th>
-          <th style="text-align: right;">Avg Results</th>
-          <th>Last Seen</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for problem in problems %}
-        <tr style="color: var(--julie-text);">
-          <td class="mono">{{ problem.representative_query }}</td>
-          <td>
-            {% for v in problem.variants %}
-            <span class="tag is-dark is-small" style="margin: 1px;">{{ v }}</span>
-            {% endfor %}
-          </td>
-          <td style="text-align: right;" class="mono">
-            {{ problem.failure_count }}
-            <span style="color: var(--julie-text-muted); font-size: 0.8rem;">
-              ({{ problem.stall_count }}s / {{ problem.reformulation_count }}r)
-            </span>
-          </td>
-          <td>
-            {% if problem.triage_signal == "recall_gap" %}
-            <span class="tag is-danger is-light is-small">recall</span>
-            {% elif problem.triage_signal == "ranking_problem" %}
-            <span class="tag is-warning is-light is-small">ranking</span>
-            {% elif problem.triage_signal == "mixed" %}
-            <span class="tag is-dark is-small">mixed</span>
-            {% else %}
-            <span class="tag is-dark is-small" style="color: var(--julie-text-muted);">no data</span>
-            {% endif %}
-          </td>
-          <td style="text-align: right;" class="mono">
-            {% if problem.avg_top_score is number %}{{ problem.avg_top_score | round(precision=1) }}{% else %}-{% endif %}
-          </td>
-          <td style="text-align: right;" class="mono">
-            {% if problem.avg_result_count is number %}{{ problem.avg_result_count | round(precision=0) }}{% else %}-{% endif %}
-          </td>
-          <td class="mono" style="color: var(--julie-text-muted); font-size: 0.85rem;">
-            {{ problem.last_seen_display }}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  {% endif %}
+{# Flag filter buttons #}
+<div class="is-flex" style="gap: 0.25rem; margin-bottom: 1rem;">
+  <a href="/search/analysis?{{ window_param }}" class="button is-small {% if active_flag == '' %}is-primary{% else %}is-dark{% endif %}">All</a>
+  <a href="/search/analysis?{{ window_param }}&flag=zero_hits" class="button is-small {% if active_flag == 'zero_hits' %}is-danger{% else %}is-dark{% endif %}">zero_hits</a>
+  <a href="/search/analysis?{{ window_param }}&flag=repeat_query" class="button is-small {% if active_flag == 'repeat_query' %}is-info{% else %}is-dark{% endif %}">repeat_query</a>
+  <a href="/search/analysis?{{ window_param }}&flag=low_score" class="button is-small {% if active_flag == 'low_score' %}is-warning{% else %}is-dark{% endif %}">low_score</a>
+  <a href="/search/analysis?{{ window_param }}&flag=no_follow_up" class="button is-small {% if active_flag == 'no_follow_up' %}is-primary{% else %}is-dark{% endif %}">no_follow_up</a>
+  <a href="/search/analysis?{{ window_param }}&flag=relaxed" class="button is-small {% if active_flag == 'relaxed' %}is-primary{% else %}is-dark{% endif %}">relaxed</a>
 </div>
 
-{# Section 3: Reformulation Pairs #}
-<div class="julie-card" style="margin-bottom: 1.5rem;">
-  <h2 class="subtitle" style="color: var(--julie-text); margin-bottom: 0.75rem;">Reformulation Pairs</h2>
-  {% if reformulations | length == 0 %}
-  <p style="color: var(--julie-text-muted); text-align: center; padding: 1rem;">
-    No reformulation patterns detected.
-  </p>
-  {% else %}
-  <div style="overflow-x: auto;">
-    <table class="table is-fullwidth is-narrow" style="background: transparent; font-size: 0.85rem;">
-      <thead>
-        <tr style="color: var(--julie-text-muted);">
-          <th>Initial Query</th>
-          <th></th>
-          <th>Successful Query</th>
-          <th>Target</th>
-          <th style="text-align: right;">Occurrences</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for pair in reformulations %}
-        <tr style="color: var(--julie-text);">
-          <td class="mono">{{ pair.initial_query }}</td>
-          <td style="color: var(--julie-text-muted);">&rarr;</td>
-          <td class="mono">{{ pair.successful_query }}</td>
-          <td>
-            {% if pair.target_name %}
-            <span class="mono" style="color: var(--julie-text);">{{ pair.target_name }}</span>
-            {% if pair.target_file %}
-            <span style="color: var(--julie-text-muted); font-size: 0.8rem;"> @ {{ pair.target_file }}</span>
-            {% endif %}
-            {% else %}
-            <span style="color: var(--julie-text-muted);">-</span>
-            {% endif %}
-          </td>
-          <td style="text-align: right;" class="mono">{{ pair.occurrences }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  {% endif %}
-</div>
-
-{# Section 4: Episode Feed #}
+{# Episode trace table #}
 {% include "partials/search_episode_table.html" %}
 
 {% endblock %}

--- a/docs/plans/2026-04-20-search-analysis-workbench-design.md
+++ b/docs/plans/2026-04-20-search-analysis-workbench-design.md
@@ -1,0 +1,174 @@
+# Search Analysis Workbench
+
+## Problem
+
+The search analysis page (`/search/analysis`) computes quality metrics (first-try success rate, problem queries, reformulation pairs) from inferred episode classifications. Testing with live searches proved the inferences are unreliable:
+
+- "Stalled" episodes (no downstream tool call) are counted as failures, but many are successes where the user read search results directly
+- "Reformulations" (multiple similar queries) are counted as failures, but many are natural scope-narrowing
+- The page reported a 29% success rate on a session where every search worked correctly
+
+The root cause: we have no ground truth about whether a search was successful. We only have the query, results, and what happened next. Inferring quality from downstream behavior produces misleading metrics.
+
+## Goal
+
+Transform the analysis page from a misleading scorecard into a search observability workbench. The page becomes a discovery surface: show raw search traces with filters and friction flags, let the operator spot patterns, and funnel discoveries into the compare page (direct measurement) or dogfood test suite (regression guard).
+
+**Quality judgment stays with:**
+- Dogfood test suite (`search_quality` bucket): curated queries with expected results, deterministic pass/fail
+- Compare page (`/search/compare`): run same query with different strategies, see results side by side
+
+**The analysis page provides:** visibility into what agents are searching for, what they're getting back, and which episodes have friction signals worth investigating.
+
+## Design
+
+### Remove
+
+**Headline KPI cards:**
+- First-try success rate percentage
+- Outcome breakdown (one-shot, reformulated, stalled, exploratory counts)
+
+**Aggregation tables:**
+- Problem queries table (grouped by canonical key, triage signal)
+- Reformulation pairs table (adjacent transitions)
+
+**Backend code to delete:**
+- `QueryProblem` struct
+- `ReformulationPair` struct
+- `aggregate_problems` function
+- `extract_reformulation_pairs` function
+- `canonical_key` function and `split_camel_case` helper
+- `FILLER_TOKENS` constant
+- `ProblemGroup` struct and impl
+- `ReformulationPairBuilder` struct
+- `pair_queries_overlap` function
+- `format_relative_time` function (move inline to route or keep as utility if needed)
+
+**Keep the dead code removal clean:** `EpisodeStats` loses the outcome breakdown fields (`one_shot_count`, `reformulation_count`, `stall_count`, `exploratory_count`, `first_try_rate`). Keep `convergence_rate` and `stall_rate` only if the compare page still uses them; check and remove if not.
+
+### Keep
+
+- `analyze_tool_calls` (episode builder) with workspace_id boundary fix
+- `SearchEpisodeQuery` with trace fields (top_hit_score, result_count, strategy, relaxed)
+- `SearchEpisode` struct
+- `has_trace_data` filter
+- Time range selector (1h, 6h, 1d, 7d, 30d)
+- `parse_search_query`, `parse_metadata`, `queries_overlap`, `token_set`
+- Pre-telemetry filtering in the route
+
+### Add
+
+#### 1. Observational Summary Cards
+
+Replace the KPI row with metrics that describe what's happening without judging quality:
+
+| Card | Computation | Why useful |
+|------|-------------|-----------|
+| Episodes | `traced_episodes.len()` | Volume indicator |
+| Zero-Hit | Count of episodes where all queries have `result_count == Some(0)` or `result_count.is_none()` with no `top_hit_name` | Genuine signal: search returned nothing |
+| Median Score | Median of all `top_hit_score` values across all queries in all episodes | Distributional health; sudden drops indicate index problems |
+| Repeat Query | Count of episodes flagged `repeat_query` | Friction indicator (not failure indicator) |
+
+These are observations, not judgments. A high repeat-query rate might mean friction, or it might mean agents are thorough. The operator decides.
+
+#### 2. Friction Flags
+
+Replace the success/failure outcome classification with neutral descriptive flags. An episode can have multiple flags.
+
+| Flag | Condition | What it signals |
+|------|-----------|----------------|
+| `zero_hits` | Any query in the episode has `result_count == Some(0)` | Search found nothing for this query |
+| `repeat_query` | `queries_overlap` returns true (existing logic) | Agent rephrased a similar query |
+| `low_score` | Top hit score of any query < 5.0 (configurable threshold) | Results existed but scored poorly |
+| `no_follow_up` | No downstream tool call after search | Agent didn't act on results (ambiguous) |
+| `relaxed` | Any query has `relaxed == Some(true)` | Search widened the query to find results |
+
+Implementation: add `pub flags: Vec<String>` to `SearchEpisode`. Compute flags in a new `compute_flags` function called from the route (not in the episode builder, which stays pure). The episode builder's existing `outcome` and `suspicious` fields can stay for backward compat with the compare page, or be removed if unused.
+
+#### 3. Episode Trace Table
+
+Replace the card-based feed with a tabular layout. More scannable, filterable.
+
+**Columns:**
+| Column | Content |
+|--------|---------|
+| Queries | First query text, with expand to show all queries in the episode |
+| Count | Number of searches in the episode |
+| Flags | Colored tags for each friction flag |
+| Top Score | Highest `top_hit_score` across queries in the episode |
+| Results | Total `result_count` from first query |
+| Downstream | Tool called after search (or "-") |
+| Workspace | workspace_id |
+
+**Filtering:** A row of flag toggle buttons above the table. Click a flag to filter to only episodes with that flag. "All" shows everything. State managed via query params (`?flag=zero_hits&hours=1`).
+
+**Expansion:** Clicking a row expands it to show all queries in the episode with per-query detail: query text, intent, search_target, top_hit_name, top_hit_file, score, result_count, strategy, relaxed.
+
+#### 4. Episode Actions
+
+Each episode row has a small action link:
+
+- **"Compare"** — links to `/search/compare?query=<first_query_text>` (pre-fills the compare page with the episode's first query)
+
+No backend changes needed for this; it's a template-only link.
+
+### Route Changes
+
+`src/dashboard/routes/search_analysis.rs`:
+
+- Accept `flag` query param for filtering: `pub flag: Option<String>`
+- After building episodes and filtering pre-telemetry, call `compute_flags` on each episode
+- Compute summary stats (episode count, zero-hit count, median score, repeat-query count)
+- Filter by flag if param is set
+- Pass `episodes`, `summary`, `active_flag`, `window_label`, `window_param` to template
+- Remove imports for `aggregate_problems`, `extract_reformulation_pairs`
+
+### New Summary Stats Struct
+
+Replace `EpisodeStats` with `SearchSummary`:
+
+```rust
+pub struct SearchSummary {
+    pub episode_count: usize,
+    pub zero_hit_count: usize,
+    pub zero_hit_rate: f64,
+    pub median_top_score: Option<f32>,
+    pub repeat_query_count: usize,
+    pub repeat_query_rate: f64,
+}
+```
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `src/dashboard/search_analysis.rs` | Delete aggregation code (~250 lines). Add `compute_flags` fn, `SearchSummary` struct, `compute_summary` fn. Keep episode builder and helpers. |
+| `src/dashboard/routes/search_analysis.rs` | Remove aggregation calls. Add flag param, compute_flags call, summary computation, flag filtering. |
+| `dashboard/templates/search_analysis.html` | Replace KPI cards with summary cards. Replace problem queries and reformulation tables with episode trace table. Add flag filter buttons. |
+| `dashboard/templates/partials/search_episode_table.html` | Rewrite as trace table with expandable rows. Add per-query detail. Add Compare link. |
+| `src/tests/dashboard/search_analysis.rs` | Remove tests for deleted functions. Add tests for `compute_flags`, `compute_summary`. Keep episode builder tests. |
+
+### Files Unchanged
+
+- `src/daemon/database.rs`
+- `src/handler/search_telemetry.rs`
+- `src/tools/search/trace.rs`
+- `src/dashboard/search_compare.rs`
+
+### Acceptance Criteria
+
+- [ ] No "First-Try Success" or outcome breakdown on the page
+- [ ] No problem queries table
+- [ ] No reformulation pairs table
+- [ ] Summary cards show: episode count, zero-hit count/rate, median top score, repeat-query count/rate
+- [ ] Episodes displayed as a table with columns: Queries, Count, Flags, Top Score, Results, Downstream, Workspace
+- [ ] Friction flags computed per episode: zero_hits, repeat_query, low_score, no_follow_up, relaxed
+- [ ] Flag filter buttons above the table, controlled via `?flag=` query param
+- [ ] Each episode row expandable to show per-query detail
+- [ ] "Compare" action link on each episode row
+- [ ] Time range selector preserved (1h, 6h, 1d, 7d, 30d)
+- [ ] Pre-telemetry episode filtering preserved
+- [ ] Page renders correctly with zero episodes
+- [ ] Deleted aggregation code has no remaining callers
+- [ ] Tests for compute_flags and compute_summary
+- [ ] Existing episode builder tests still pass

--- a/docs/plans/2026-04-20-search-analysis-workbench-implementation-plan.md
+++ b/docs/plans/2026-04-20-search-analysis-workbench-implementation-plan.md
@@ -1,0 +1,149 @@
+# Search Analysis Workbench — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use razorback:executing-plans to implement this plan. Tasks are sequential (shared file prevents parallelism).
+
+**Goal:** Rework `/search/analysis` from a misleading metrics dashboard into a search observability workbench with friction flags, observational summary cards, and a filterable trace table.
+
+**Architecture:** Delete ~300 lines of aggregation code (canonical_key, aggregate_problems, extract_reformulation_pairs, and supporting types). Replace EpisodeStats headline fields with a new SearchSummary struct. Add compute_flags (per-episode friction signals) and compute_summary (observational stats). Rewrite templates from card feed to trace table.
+
+**Tech Stack:** Rust (axum, serde, tera), HTML (tera templates)
+
+**Design Spec:** `docs/plans/2026-04-20-search-analysis-workbench-design.md`
+
+---
+
+### Task 1: Backend — Delete Aggregation, Add Flags + Summary
+
+**Files:**
+- Modify: `src/dashboard/search_analysis.rs:51-60` (EpisodeStats — strip to compare-page-only fields)
+- Modify: `src/dashboard/search_analysis.rs:118-144` (episode_stats fn — simplify)
+- Delete: `src/dashboard/search_analysis.rs:275-579` (all aggregation code)
+- Modify: `src/tests/dashboard/search_analysis.rs` (delete aggregation tests, add new tests)
+
+**What to build:**
+
+1. **Delete aggregation code** (lines 275-579): `FILLER_TOKENS`, `canonical_key`, `split_camel_case`, `QueryProblem`, `aggregate_problems`, `ProblemGroup` + impl, `ReformulationPair`, `extract_reformulation_pairs`, `ReformulationPairBuilder`, `pair_queries_overlap`, `format_relative_time`. Move `has_trace_data` (currently at line 554) up to just after `episode_stats`, before the deleted block.
+
+2. **Strip EpisodeStats** to only what the compare page needs: keep `total_episodes`, `convergence_rate`, `stall_rate`. Remove `first_try_rate`, `one_shot_count`, `reformulation_count`, `stall_count`, `exploratory_count`. Simplify `episode_stats` accordingly.
+
+3. **Add `SearchSummary` struct** (new, public):
+   - `episode_count: usize`
+   - `zero_hit_count: usize`
+   - `zero_hit_rate: f64`
+   - `median_top_score: Option<f32>`
+   - `repeat_query_count: usize`
+   - `repeat_query_rate: f64`
+
+4. **Add `compute_summary(episodes: &[SearchEpisode]) -> SearchSummary`**: Count episodes. Count zero-hit episodes (all queries have `result_count == Some(0)` or `top_hit_name.is_none()`). Compute median of all `top_hit_score` values (collect into vec, sort, take middle). Count episodes where `queries_overlap` returns true. Compute rates as count / total.
+
+5. **Add `compute_flags(episode: &mut SearchEpisode)`**: Compute friction flags and store them in a new `pub flags: Vec<String>` field on `SearchEpisode`. Flags:
+   - `"zero_hits"` — any query has `result_count == Some(0)`
+   - `"repeat_query"` — `queries_overlap(&episode.queries)` returns true (existing function)
+   - `"low_score"` — any query has `top_hit_score < Some(5.0)`
+   - `"no_follow_up"` — `episode.downstream_tool.is_none()`
+   - `"relaxed"` — any query has `relaxed == Some(true)`
+
+   Add `flags: Vec<String>` field to `SearchEpisode`, initialized to empty vec in `EpisodeBuilder::finish`. The `compute_flags` function mutates it in place.
+
+6. **Update tests**: Delete all tests for `canonical_key`, `aggregate_problems`, `extract_reformulation_pairs` (lines 282-456 in test file). Remove those imports. Delete the `fast_search_row_with_hit` helper (only used by deleted tests). Remove `episode_stats` import if no longer tested (check). Add tests:
+   - `test_compute_flags_zero_hits` — episode with `result_count: Some(0)` gets `"zero_hits"` flag
+   - `test_compute_flags_no_follow_up` — episode with no downstream tool gets `"no_follow_up"` flag
+   - `test_compute_flags_repeat_query` — episode with overlapping queries gets `"repeat_query"` flag
+   - `test_compute_flags_low_score` — episode with `top_hit_score: Some(2.0)` gets `"low_score"` flag
+   - `test_compute_flags_relaxed` — episode with `relaxed: Some(true)` gets `"relaxed"` flag
+   - `test_compute_summary_zero_episodes` — empty input returns zeroed summary
+   - `test_compute_summary_counts` — verify episode_count, zero_hit_count, repeat_query_count, median_top_score
+
+**Approach:**
+- `compute_flags` takes `&mut SearchEpisode` (mutates in place). The route calls it on each episode after `analyze_tool_calls`.
+- For median score: collect all `Some` scores into a `Vec<f32>`, sort with `sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal))`, take middle element. Return `None` if empty.
+- The `std::time` import can be removed after `format_relative_time` is deleted.
+- The `std::collections::HashMap` import stays (used elsewhere? check — if not, remove).
+
+**Acceptance criteria:**
+- [ ] All aggregation code deleted (no `QueryProblem`, `ReformulationPair`, `canonical_key`, etc.)
+- [ ] `EpisodeStats` has only `total_episodes`, `convergence_rate`, `stall_rate`
+- [ ] `SearchSummary` struct with episode_count, zero_hit_count/rate, median_top_score, repeat_query_count/rate
+- [ ] `compute_flags` populates flags vec on SearchEpisode
+- [ ] `compute_summary` computes observational stats
+- [ ] `SearchEpisode` has `flags: Vec<String>` field
+- [ ] Aggregation tests deleted, flag and summary tests added
+- [ ] Existing episode builder tests still pass
+- [ ] Tests pass, committed
+
+---
+
+### Task 2: Route Update
+
+**Files:**
+- Modify: `src/dashboard/routes/search_analysis.rs`
+
+**What to build:** Rewire the route to use the new functions and support flag filtering.
+
+1. **Update imports**: Replace `aggregate_problems`, `extract_reformulation_pairs` with `compute_flags`, `compute_summary`. Keep `analyze_tool_calls`, `has_trace_data`.
+
+2. **Add `flag` query param** to `SearchAnalysisParams`: `pub flag: Option<String>`.
+
+3. **Rework handler logic**:
+   - After building episodes and filtering pre-telemetry, call `compute_flags` on each episode (mutable iteration).
+   - Call `compute_summary` on the flagged episodes.
+   - If `flag` param is set, filter episodes to only those whose `flags` vec contains the param value.
+   - Pass to template: `summary`, `episodes`, `active_flag` (the flag param or empty string), `window_label`, `window_param`, `show_all`, `total_episode_count`.
+
+4. **Remove `days` from context** — replaced by `window_label`.
+
+**Approach:**
+- Flag filtering: `episodes.retain(|e| e.flags.contains(&flag_value))`. Apply after compute_summary so summary reflects unfiltered data.
+- `active_flag` is used by the template to highlight which flag filter button is active.
+
+**Acceptance criteria:**
+- [ ] Route accepts `?flag=zero_hits` (or any flag name) and filters episodes
+- [ ] Summary computed from all episodes (before flag filtering)
+- [ ] No imports of deleted aggregation functions
+- [ ] Template receives summary, episodes, active_flag
+- [ ] Tests pass, committed
+
+---
+
+### Task 3: Templates
+
+**Files:**
+- Modify: `dashboard/templates/search_analysis.html` (full rewrite)
+- Modify: `dashboard/templates/partials/search_episode_table.html` (full rewrite)
+
+**What to build:** Replace the metrics dashboard layout with a trace viewer.
+
+1. **search_analysis.html**:
+   - Keep: header with title + Playground/Analysis/Compare nav buttons
+   - Keep: time range selector (1h, 6h, 1d, 7d, 30d buttons)
+   - **Summary cards** (replace old KPI row): Episodes count, Zero-Hit count with rate, Median Score, Repeat Query count with rate. Use `julie-card` wrapper, `label-text` + `mono` styling.
+   - **Flag filter buttons**: A row of small buttons, one per flag (`zero_hits`, `repeat_query`, `low_score`, `no_follow_up`, `relaxed`), plus an "All" button. Active flag gets `is-primary` class. Links use `?flag=<name>&<window_param>`.
+   - **Episode trace table**: `{% include "partials/search_episode_table.html" %}`
+   - Remove: problem queries table, reformulation pairs table
+
+2. **search_episode_table.html** (rewrite as trace table):
+   - Show/all toggle at top (keep existing pattern with `window_param`)
+   - Table with columns: Queries, Searches, Flags, Top Score, Results, Downstream, Workspace, Actions
+   - **Queries column**: Show first query's text. If `episode.search_count > 1`, add a `<details>` element that expands to show all queries with per-query detail (query text, intent, search_target, top_hit_name, top_hit_file, score, result_count).
+   - **Flags column**: Render each flag as a small tag. Color coding: `zero_hits` = `is-danger is-light`, `low_score` = `is-warning is-light`, `repeat_query` = `is-info is-light`, `no_follow_up` / `relaxed` = `is-dark`.
+   - **Actions column**: "Compare" link to `/search/compare?query=<first_query_text>`
+   - Empty state: "No episodes to show."
+
+**Approach:**
+- Follow existing dashboard table patterns from `dashboard/templates/partials/metrics_table.html` and `dashboard/templates/projects.html`.
+- Use `<details><summary>` for expandable query rows (native HTML, no JS needed).
+- URL-encode the query text in the Compare link using Tera's `urlencode` filter.
+- Flag filter buttons should preserve the current `window_param` and `show_all` state.
+
+**Acceptance criteria:**
+- [ ] No "First-Try Success" card or outcome breakdown
+- [ ] No problem queries table
+- [ ] No reformulation pairs table
+- [ ] Summary cards show: episode count, zero-hit count/rate, median score, repeat-query count/rate
+- [ ] Flag filter buttons filter the episode table
+- [ ] Episode table is tabular with correct columns
+- [ ] Multi-query episodes expandable via `<details>`
+- [ ] "Compare" action link on each row
+- [ ] Page renders with zero episodes (empty state)
+- [ ] Page renders with no trace data episodes (pre-telemetry filtered)
+- [ ] Tests pass, committed

--- a/src/dashboard/routes/search_analysis.rs
+++ b/src/dashboard/routes/search_analysis.rs
@@ -7,8 +7,7 @@ use tera::Context;
 use crate::dashboard::AppState;
 use crate::dashboard::render_template;
 use crate::dashboard::search_analysis::{
-    aggregate_problems, analyze_tool_calls, episode_stats, extract_reformulation_pairs,
-    has_trace_data,
+    analyze_tool_calls, compute_flags, compute_summary, has_trace_data,
 };
 
 #[derive(Debug, Deserialize, Default)]
@@ -16,6 +15,7 @@ pub struct SearchAnalysisParams {
     pub days: Option<u32>,
     pub hours: Option<u32>,
     pub show_all: Option<bool>,
+    pub flag: Option<String>,
 }
 
 pub async fn index(
@@ -31,27 +31,31 @@ pub async fn index(
     };
     let show_all = params.show_all.unwrap_or(false);
 
-    let episodes = state
+    let mut episodes: Vec<_> = state
         .dashboard
         .daemon_db()
         .and_then(|db| db.list_tool_calls_for_search_analysis(window_secs).ok())
         .map(|rows| analyze_tool_calls(&rows))
-        .unwrap_or_default();
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|e| has_trace_data(e))
+        .collect();
 
-    let traced_episodes: Vec<_> = episodes.into_iter().filter(|e| has_trace_data(e)).collect();
+    for ep in &mut episodes {
+        compute_flags(ep);
+    }
 
-    let stats = episode_stats(&traced_episodes);
-    let problems = aggregate_problems(&traced_episodes);
-    let reformulations = extract_reformulation_pairs(&traced_episodes);
+    let summary = compute_summary(&episodes);
+    let total_episode_count = episodes.len();
 
-    let total_episode_count = traced_episodes.len();
+    if let Some(ref flag) = params.flag {
+        episodes.retain(|e| e.flags.contains(flag));
+    }
+
     let filtered_episodes: Vec<_> = if show_all {
-        traced_episodes
+        episodes
     } else {
-        traced_episodes
-            .into_iter()
-            .filter(|e| e.suspicious)
-            .collect()
+        episodes.into_iter().filter(|e| !e.flags.is_empty()).collect()
     };
 
     let window_param = if params.hours.is_some() {
@@ -65,11 +69,10 @@ pub async fn index(
     context.insert("window_label", &window_label);
     context.insert("window_param", &window_param);
     context.insert("show_all", &show_all);
+    context.insert("active_flag", &params.flag.as_deref().unwrap_or(""));
     context.insert("episodes", &filtered_episodes);
     context.insert("total_episode_count", &total_episode_count);
-    context.insert("episode_stats", &stats);
-    context.insert("problems", &problems);
-    context.insert("reformulations", &reformulations);
+    context.insert("summary", &summary);
 
     render_template(&state, "search_analysis.html", context).await
 }

--- a/src/dashboard/search_analysis.rs
+++ b/src/dashboard/search_analysis.rs
@@ -45,6 +45,8 @@ pub struct SearchEpisode {
     pub outcome: String,
     pub suspicious: bool,
     pub flags: Vec<String>,
+    pub best_score: Option<f32>,
+    pub min_result_count: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -178,6 +180,12 @@ impl EpisodeBuilder {
             "exploratory_success".to_string()
         };
         let suspicious = matches!(outcome.as_str(), "stalled" | "reformulation_converged");
+        let best_score = self
+            .queries
+            .iter()
+            .filter_map(|q| q.top_hit_score)
+            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let min_result_count = self.queries.iter().filter_map(|q| q.result_count).min();
 
         SearchEpisode {
             session_id: self.session_id,
@@ -192,6 +200,8 @@ impl EpisodeBuilder {
             outcome,
             suspicious,
             flags: Vec::new(),
+            best_score,
+            min_result_count,
         }
     }
 }

--- a/src/dashboard/search_analysis.rs
+++ b/src/dashboard/search_analysis.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::cmp::Ordering;
 
 use serde::Serialize;
 use serde_json::Value;
@@ -45,6 +44,7 @@ pub struct SearchEpisode {
     pub target_file_path: Option<String>,
     pub outcome: String,
     pub suspicious: bool,
+    pub flags: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -52,11 +52,6 @@ pub struct EpisodeStats {
     pub total_episodes: usize,
     pub convergence_rate: f64,
     pub stall_rate: f64,
-    pub first_try_rate: f64,
-    pub one_shot_count: usize,
-    pub reformulation_count: usize,
-    pub stall_count: usize,
-    pub exploratory_count: usize,
 }
 
 pub fn analyze_tool_calls(rows: &[SearchToolCallRow]) -> Vec<SearchEpisode> {
@@ -117,29 +112,19 @@ pub fn analyze_tool_calls(rows: &[SearchToolCallRow]) -> Vec<SearchEpisode> {
 
 pub fn episode_stats(episodes: &[SearchEpisode]) -> EpisodeStats {
     let total = episodes.len().max(1) as f64;
-    let mut one_shot = 0usize;
-    let mut reformulated = 0usize;
-    let mut stalled = 0usize;
-    let mut exploratory = 0usize;
-
-    for episode in episodes {
-        match episode.outcome.as_str() {
-            "one_shot_success" => one_shot += 1,
-            "reformulation_converged" => reformulated += 1,
-            "stalled" => stalled += 1,
-            _ => exploratory += 1,
-        }
-    }
+    let reformulated = episodes
+        .iter()
+        .filter(|e| e.outcome == "reformulation_converged")
+        .count() as f64;
+    let stalled = episodes
+        .iter()
+        .filter(|e| e.outcome == "stalled")
+        .count() as f64;
 
     EpisodeStats {
         total_episodes: episodes.len(),
-        convergence_rate: reformulated as f64 / total,
-        stall_rate: stalled as f64 / total,
-        first_try_rate: one_shot as f64 / total,
-        one_shot_count: one_shot,
-        reformulation_count: reformulated,
-        stall_count: stalled,
-        exploratory_count: exploratory,
+        convergence_rate: reformulated / total,
+        stall_rate: stalled / total,
     }
 }
 
@@ -206,6 +191,7 @@ impl EpisodeBuilder {
             target_file_path: self.target_file_path,
             outcome,
             suspicious,
+            flags: Vec::new(),
         }
     }
 }
@@ -258,322 +244,81 @@ fn queries_overlap(queries: &[SearchEpisodeQuery]) -> bool {
     false
 }
 
-fn pair_queries_overlap(left: &str, right: &str) -> bool {
-    if left == right {
-        return true;
-    }
-    let left_tokens = token_set(left);
-    let right_tokens = token_set(right);
-    let overlap = left_tokens.intersection(&right_tokens).count();
-    overlap > 0 && overlap * 2 >= left_tokens.len().max(right_tokens.len())
-}
-
 fn token_set(text: &str) -> std::collections::BTreeSet<&str> {
     text.split_whitespace().collect()
 }
 
 // ---------------------------------------------------------------------------
-// Canonical key for query grouping
+// Friction flags + summary (observability workbench)
 // ---------------------------------------------------------------------------
 
-const FILLER_TOKENS: &[&str] = &[
-    "find", "get", "the", "a", "an", "for", "in", "of", "to", "with",
-];
-
-pub fn canonical_key(query: &str) -> Vec<String> {
-    let mut tokens = Vec::new();
-    for part in query.split(|c: char| c.is_whitespace() || c == ':' || c == '_' || c == '.') {
-        if part.is_empty() {
-            continue;
-        }
-        split_camel_case(part, &mut tokens);
-    }
-    tokens.retain(|t| !FILLER_TOKENS.contains(&t.as_str()));
-    tokens.sort();
-    tokens
-}
-
-fn split_camel_case(text: &str, out: &mut Vec<String>) {
-    let mut current = String::new();
-    let mut prev_lower = false;
-
-    for ch in text.chars() {
-        if ch.is_uppercase() && prev_lower {
-            if !current.is_empty() {
-                out.push(current.to_lowercase());
-                current.clear();
-            }
-        }
-        current.push(ch);
-        prev_lower = ch.is_lowercase();
-    }
-    if !current.is_empty() {
-        out.push(current.to_lowercase());
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Problem query aggregation
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, Serialize)]
-pub struct QueryProblem {
-    pub representative_query: String,
-    pub variants: Vec<String>,
-    pub failure_count: usize,
-    pub stall_count: usize,
-    pub reformulation_count: usize,
-    pub last_seen: i64,
-    pub last_seen_display: String,
-    pub avg_top_score: Option<f32>,
-    pub avg_result_count: Option<f32>,
-    pub triage_signal: String,
-}
-
-pub fn aggregate_problems(episodes: &[SearchEpisode]) -> Vec<QueryProblem> {
-    let mut groups: HashMap<Vec<String>, ProblemGroup> = HashMap::new();
-
-    for episode in episodes {
-        let is_stalled = episode.outcome == "stalled";
-        let is_reformulated = episode.outcome == "reformulation_converged";
-        if !is_stalled && !is_reformulated {
-            continue;
-        }
-
-        let candidate_queries: &[SearchEpisodeQuery] = if is_reformulated && episode.queries.len() > 1 {
-            &episode.queries[..episode.queries.len() - 1]
-        } else {
-            &episode.queries
-        };
-
-        let mut counted_groups: std::collections::HashSet<Vec<String>> =
-            std::collections::HashSet::new();
-
-        for query in candidate_queries {
-            let key = canonical_key(&query.query);
-            if key.is_empty() {
-                continue;
-            }
-            let group = groups.entry(key.clone()).or_insert_with(|| ProblemGroup {
-                queries: HashMap::new(),
-                stall_count: 0,
-                reformulation_count: 0,
-                failure_count: 0,
-                last_seen: 0,
-                scores: Vec::new(),
-                result_counts: Vec::new(),
-                ranking_hits: 0,
-                recall_misses: 0,
-            });
-
-            *group.queries.entry(query.query.clone()).or_insert(0) += 1;
-            if let Some(score) = query.top_hit_score {
-                group.scores.push(score);
-            }
-            if let Some(count) = query.result_count {
-                group.result_counts.push(count);
-            }
-            group.last_seen = group.last_seen.max(query.timestamp);
-
-            if is_reformulated {
-                if let Some(target_name) = &episode.target_symbol_name {
-                    let name_matches = query.top_hit_name.as_ref() == Some(target_name);
-                    let file_matches = match (&query.top_hit_file, &episode.target_file_path) {
-                        (Some(hit_file), Some(target_file)) => hit_file == target_file,
-                        _ => true,
-                    };
-                    if name_matches && file_matches {
-                        group.ranking_hits += 1;
-                    } else {
-                        group.recall_misses += 1;
-                    }
-                }
-            }
-
-            if counted_groups.insert(key) {
-                group.failure_count += 1;
-                if is_stalled {
-                    group.stall_count += 1;
-                } else {
-                    group.reformulation_count += 1;
-                }
-            }
-        }
-    }
-
-    let mut problems: Vec<QueryProblem> = groups
-        .into_values()
-        .map(|group| {
-            let (representative, variants) = group.representative_and_variants();
-            let avg_top_score = if group.scores.is_empty() {
-                None
-            } else {
-                Some(group.scores.iter().sum::<f32>() / group.scores.len() as f32)
-            };
-            let avg_result_count = if group.result_counts.is_empty() {
-                None
-            } else {
-                Some(
-                    group.result_counts.iter().sum::<usize>() as f32
-                        / group.result_counts.len() as f32,
-                )
-            };
-            let triage_signal = if group.ranking_hits == 0 && group.recall_misses == 0 {
-                "unknown"
-            } else if group.ranking_hits > 0 && group.recall_misses == 0 {
-                "ranking_problem"
-            } else if group.recall_misses > 0 && group.ranking_hits == 0 {
-                "recall_gap"
-            } else {
-                "mixed"
-            };
-
-            QueryProblem {
-                representative_query: representative,
-                variants,
-                failure_count: group.failure_count,
-                stall_count: group.stall_count,
-                reformulation_count: group.reformulation_count,
-                last_seen: group.last_seen,
-                last_seen_display: format_relative_time(group.last_seen),
-                avg_top_score,
-                avg_result_count,
-                triage_signal: triage_signal.to_string(),
-            }
-        })
-        .collect();
-
-    problems.sort_by(|a, b| b.failure_count.cmp(&a.failure_count));
-    problems.truncate(20);
-    problems
-}
-
-struct ProblemGroup {
-    queries: HashMap<String, usize>,
-    stall_count: usize,
-    reformulation_count: usize,
-    failure_count: usize,
-    last_seen: i64,
-    scores: Vec<f32>,
-    result_counts: Vec<usize>,
-    ranking_hits: usize,
-    recall_misses: usize,
-}
-
-impl ProblemGroup {
-    fn representative_and_variants(&self) -> (String, Vec<String>) {
-        let mut sorted: Vec<_> = self.queries.iter().collect();
-        sorted.sort_by(|a, b| b.1.cmp(a.1));
-        let representative = sorted
-            .first()
-            .map(|(q, _)| (*q).clone())
-            .unwrap_or_default();
-        let variants: Vec<String> = sorted
-            .iter()
-            .skip(1)
-            .map(|(q, _)| (*q).clone())
-            .collect();
-        (representative, variants)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Reformulation pair extraction
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, Serialize)]
-pub struct ReformulationPair {
-    pub initial_query: String,
-    pub successful_query: String,
-    pub target_name: Option<String>,
-    pub target_file: Option<String>,
-    pub occurrences: usize,
-}
-
-pub fn extract_reformulation_pairs(episodes: &[SearchEpisode]) -> Vec<ReformulationPair> {
-    let mut pair_map: HashMap<(Vec<String>, Vec<String>), ReformulationPairBuilder> =
-        HashMap::new();
-
-    for episode in episodes {
-        if episode.outcome != "reformulation_converged" || episode.queries.len() < 2 {
-            continue;
-        }
-
-        for window in episode.queries.windows(2) {
-            let initial_key = canonical_key(&window[0].query);
-            let successful_key = canonical_key(&window[1].query);
-            if initial_key.is_empty() || successful_key.is_empty() {
-                continue;
-            }
-            if !pair_queries_overlap(&window[0].normalized_query, &window[1].normalized_query) {
-                continue;
-            }
-
-            let map_key = (initial_key, successful_key);
-            let entry = pair_map.entry(map_key).or_insert_with(|| {
-                ReformulationPairBuilder {
-                    initial_query: window[0].query.clone(),
-                    successful_query: window[1].query.clone(),
-                    target_name: episode.target_symbol_name.clone(),
-                    target_file: episode.target_file_path.clone(),
-                    occurrences: 0,
-                }
-            });
-            entry.occurrences += 1;
-        }
-    }
-
-    let mut pairs: Vec<ReformulationPair> = pair_map
-        .into_values()
-        .map(|b| ReformulationPair {
-            initial_query: b.initial_query,
-            successful_query: b.successful_query,
-            target_name: b.target_name,
-            target_file: b.target_file,
-            occurrences: b.occurrences,
-        })
-        .collect();
-
-    pairs.sort_by(|a, b| b.occurrences.cmp(&a.occurrences));
-    pairs.truncate(15);
-    pairs
-}
-
-struct ReformulationPairBuilder {
-    initial_query: String,
-    successful_query: String,
-    target_name: Option<String>,
-    target_file: Option<String>,
-    occurrences: usize,
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+const LOW_SCORE_THRESHOLD: f32 = 5.0;
 
 pub fn has_trace_data(episode: &SearchEpisode) -> bool {
     episode.queries.iter().any(|q| q.strategy.is_some())
 }
 
-fn format_relative_time(unix_ts: i64) -> String {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
-    let delta = now - unix_ts;
-    if delta < 0 {
-        return "just now".to_string();
+pub fn compute_flags(episode: &mut SearchEpisode) {
+    if episode.queries.iter().any(|q| q.result_count == Some(0)) {
+        episode.flags.push("zero_hits".to_string());
     }
-    let minutes = delta / 60;
-    let hours = delta / 3600;
-    let days = delta / 86400;
-    if minutes < 1 {
-        "just now".to_string()
-    } else if minutes < 60 {
-        format!("{}m ago", minutes)
-    } else if hours < 24 {
-        format!("{}h ago", hours)
+    if queries_overlap(&episode.queries) {
+        episode.flags.push("repeat_query".to_string());
+    }
+    if episode
+        .queries
+        .iter()
+        .any(|q| q.top_hit_score.is_some_and(|s| s < LOW_SCORE_THRESHOLD))
+    {
+        episode.flags.push("low_score".to_string());
+    }
+    if episode.downstream_tool.is_none() {
+        episode.flags.push("no_follow_up".to_string());
+    }
+    if episode.queries.iter().any(|q| q.relaxed == Some(true)) {
+        episode.flags.push("relaxed".to_string());
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchSummary {
+    pub episode_count: usize,
+    pub zero_hit_count: usize,
+    pub zero_hit_rate: f64,
+    pub median_top_score: Option<f32>,
+    pub repeat_query_count: usize,
+    pub repeat_query_rate: f64,
+}
+
+pub fn compute_summary(episodes: &[SearchEpisode]) -> SearchSummary {
+    let total = episodes.len().max(1) as f64;
+    let zero_hit_count = episodes
+        .iter()
+        .filter(|e| e.flags.contains(&"zero_hits".to_string()))
+        .count();
+    let repeat_query_count = episodes
+        .iter()
+        .filter(|e| e.flags.contains(&"repeat_query".to_string()))
+        .count();
+
+    let mut scores: Vec<f32> = episodes
+        .iter()
+        .flat_map(|e| e.queries.iter())
+        .filter_map(|q| q.top_hit_score)
+        .collect();
+    scores.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+    let median_top_score = if scores.is_empty() {
+        None
     } else {
-        format!("{}d ago", days)
+        Some(scores[scores.len() / 2])
+    };
+
+    SearchSummary {
+        episode_count: episodes.len(),
+        zero_hit_count,
+        zero_hit_rate: zero_hit_count as f64 / total,
+        median_top_score,
+        repeat_query_count,
+        repeat_query_rate: repeat_query_count as f64 / total,
     }
 }

--- a/src/tests/dashboard/search_analysis.rs
+++ b/src/tests/dashboard/search_analysis.rs
@@ -1,7 +1,6 @@
 use crate::daemon::database::SearchToolCallRow;
 use crate::dashboard::search_analysis::{
-    aggregate_problems, analyze_tool_calls, canonical_key, episode_stats,
-    extract_reformulation_pairs,
+    analyze_tool_calls, compute_flags, compute_summary,
 };
 
 fn fast_search_row(
@@ -77,12 +76,42 @@ fn fast_search_row_no_trace(
     }
 }
 
-fn fast_search_row_with_hit(
+fn fast_search_row_zero_hits(
     id: i64,
     session_id: &str,
     timestamp: i64,
     query: &str,
-    top_hit_name: &str,
+) -> SearchToolCallRow {
+    SearchToolCallRow {
+        id,
+        workspace_id: "ws1".to_string(),
+        session_id: session_id.to_string(),
+        timestamp,
+        tool_name: "fast_search".to_string(),
+        metadata: Some(
+            serde_json::json!({
+                "query": query,
+                "normalized_query": query,
+                "intent": "code_investigation",
+                "search_target": "definitions",
+                "trace": {
+                    "strategy": "definitions_first",
+                    "result_count": 0,
+                    "returned_hit_count": 0,
+                    "relaxed": false,
+                    "top_hits": []
+                }
+            })
+            .to_string(),
+        ),
+    }
+}
+
+fn fast_search_row_low_score(
+    id: i64,
+    session_id: &str,
+    timestamp: i64,
+    query: &str,
 ) -> SearchToolCallRow {
     SearchToolCallRow {
         id,
@@ -103,9 +132,46 @@ fn fast_search_row_with_hit(
                     "relaxed": false,
                     "top_hits": [
                         {
-                            "name": top_hit_name,
-                            "file": "src/dashboard/routes/search.rs",
-                            "score": 8.0
+                            "name": "something",
+                            "file": "src/lib.rs",
+                            "score": 2.0
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+        ),
+    }
+}
+
+fn fast_search_row_relaxed(
+    id: i64,
+    session_id: &str,
+    timestamp: i64,
+    query: &str,
+) -> SearchToolCallRow {
+    SearchToolCallRow {
+        id,
+        workspace_id: "ws1".to_string(),
+        session_id: session_id.to_string(),
+        timestamp,
+        tool_name: "fast_search".to_string(),
+        metadata: Some(
+            serde_json::json!({
+                "query": query,
+                "normalized_query": query,
+                "intent": "code_investigation",
+                "search_target": "definitions",
+                "trace": {
+                    "strategy": "definitions_first",
+                    "result_count": 1,
+                    "returned_hit_count": 1,
+                    "relaxed": true,
+                    "top_hits": [
+                        {
+                            "name": "handler",
+                            "file": "src/lib.rs",
+                            "score": 6.0
                         }
                     ]
                 }
@@ -133,6 +199,10 @@ fn useful_action_row(id: i64, session_id: &str, timestamp: i64) -> SearchToolCal
         ),
     }
 }
+
+// ---------------------------------------------------------------------------
+// Episode builder tests (kept from prior iteration)
+// ---------------------------------------------------------------------------
 
 #[test]
 fn test_search_analysis_groups_nearby_searches_into_one_episode() {
@@ -249,208 +319,111 @@ fn test_search_analysis_trace_fields_populated() {
     assert_eq!(query.relaxed, Some(false));
 }
 
+// ---------------------------------------------------------------------------
+// compute_flags tests
+// ---------------------------------------------------------------------------
+
 #[test]
-fn test_episode_stats_computes_outcome_breakdown() {
+fn test_compute_flags_zero_hits() {
+    let rows = vec![fast_search_row_zero_hits(1, "sess-a", 100, "nonexistent")];
+    let mut episodes = analyze_tool_calls(&rows);
+    compute_flags(&mut episodes[0]);
+
+    assert!(episodes[0].flags.contains(&"zero_hits".to_string()));
+    assert!(episodes[0].flags.contains(&"no_follow_up".to_string()));
+}
+
+#[test]
+fn test_compute_flags_no_follow_up() {
+    let rows = vec![fast_search_row(1, "sess-a", 100, "handler", "handler")];
+    let mut episodes = analyze_tool_calls(&rows);
+    compute_flags(&mut episodes[0]);
+
+    assert!(episodes[0].flags.contains(&"no_follow_up".to_string()));
+    assert!(!episodes[0].flags.contains(&"zero_hits".to_string()));
+}
+
+#[test]
+fn test_compute_flags_repeat_query() {
     let rows = vec![
-        fast_search_row(1, "sess-a", 100, "handler", "handler"),
+        fast_search_row(1, "sess-a", 100, "search handler", "search handler"),
+        fast_search_row(2, "sess-a", 103, "handler search", "handler search"),
+        useful_action_row(3, "sess-a", 105),
+    ];
+    let mut episodes = analyze_tool_calls(&rows);
+    compute_flags(&mut episodes[0]);
+
+    assert!(episodes[0].flags.contains(&"repeat_query".to_string()));
+    assert!(!episodes[0].flags.contains(&"no_follow_up".to_string()));
+}
+
+#[test]
+fn test_compute_flags_low_score() {
+    let rows = vec![
+        fast_search_row_low_score(1, "sess-a", 100, "obscure thing"),
         useful_action_row(2, "sess-a", 102),
-        fast_search_row(3, "sess-b", 200, "search handler", "search handler"),
-        fast_search_row(4, "sess-b", 203, "handler search", "handler search"),
-        useful_action_row(5, "sess-b", 205),
-        fast_search_row(6, "sess-c", 300, "stalled query", "stalled query"),
-        fast_search_row(7, "sess-d", 400, "database pool", "database pool"),
-        fast_search_row(8, "sess-d", 403, "centrality badge", "centrality badge"),
-        useful_action_row(9, "sess-d", 405),
     ];
+    let mut episodes = analyze_tool_calls(&rows);
+    compute_flags(&mut episodes[0]);
 
-    let episodes = analyze_tool_calls(&rows);
-    let stats = episode_stats(&episodes);
-
-    assert_eq!(stats.total_episodes, 4);
-    assert_eq!(stats.one_shot_count, 1);
-    assert_eq!(stats.reformulation_count, 1);
-    assert_eq!(stats.stall_count, 1);
-    assert_eq!(stats.exploratory_count, 1);
-    assert!((stats.first_try_rate - 0.25).abs() < 0.01);
-}
-
-// ---------------------------------------------------------------------------
-// canonical_key tests
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_canonical_key_unifies_naming_conventions() {
-    assert_eq!(canonical_key("SearchHandler"), canonical_key("search_handler"));
-    assert_eq!(canonical_key("search_handler"), canonical_key("search::handler"));
-    assert_eq!(canonical_key("SearchHandler"), canonical_key("search handler"));
+    assert!(episodes[0].flags.contains(&"low_score".to_string()));
 }
 
 #[test]
-fn test_canonical_key_drops_filler_tokens() {
-    assert_eq!(canonical_key("find the handler"), canonical_key("handler"));
-    assert_eq!(canonical_key("get search results"), canonical_key("search results"));
-}
-
-#[test]
-fn test_canonical_key_sorts_alphabetically() {
-    assert_eq!(canonical_key("handler search"), canonical_key("search handler"));
-}
-
-#[test]
-fn test_canonical_key_empty_input() {
-    assert!(canonical_key("").is_empty());
-    assert!(canonical_key("the a an").is_empty());
-}
-
-// ---------------------------------------------------------------------------
-// aggregate_problems tests
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_aggregate_problems_excludes_terminal_successful_query() {
+fn test_compute_flags_relaxed() {
     let rows = vec![
-        fast_search_row(1, "sess-a", 100, "search handler", "search handler"),
-        fast_search_row(2, "sess-a", 103, "handler search", "handler search"),
-        useful_action_row(3, "sess-a", 105),
+        fast_search_row_relaxed(1, "sess-a", 100, "vague query"),
+        useful_action_row(2, "sess-a", 102),
     ];
+    let mut episodes = analyze_tool_calls(&rows);
+    compute_flags(&mut episodes[0]);
 
-    let episodes = analyze_tool_calls(&rows);
-    assert_eq!(episodes[0].outcome, "reformulation_converged");
-
-    let problems = aggregate_problems(&episodes);
-
-    let all_representative_queries: Vec<&str> = problems
-        .iter()
-        .map(|p| p.representative_query.as_str())
-        .collect();
-    assert!(
-        !all_representative_queries.contains(&"handler search"),
-        "terminal successful query should be excluded"
-    );
+    assert!(episodes[0].flags.contains(&"relaxed".to_string()));
 }
 
 #[test]
-fn test_aggregate_problems_counts_once_per_episode() {
-    let rows = vec![
-        fast_search_row(1, "sess-a", 100, "handler", "handler"),
-        fast_search_row(2, "sess-a", 103, "handler", "handler"),
-        fast_search_row(3, "sess-a", 106, "handler fixed", "handler fixed"),
-        useful_action_row(4, "sess-a", 108),
-    ];
-
-    let episodes = analyze_tool_calls(&rows);
-    let problems = aggregate_problems(&episodes);
-
-    let handler_problem = problems.iter().find(|p| {
-        canonical_key(&p.representative_query) == canonical_key("handler")
-    });
-    assert!(handler_problem.is_some());
-    assert_eq!(handler_problem.unwrap().failure_count, 1);
-}
-
-#[test]
-fn test_aggregate_problems_triage_ranking_problem() {
-    let rows = vec![
-        fast_search_row_with_hit(1, "sess-a", 100, "search handler", "search_handler"),
-        fast_search_row(2, "sess-a", 103, "handler search", "handler search"),
-        useful_action_row(3, "sess-a", 105),
-    ];
-
-    let episodes = analyze_tool_calls(&rows);
-    let problems = aggregate_problems(&episodes);
-
-    assert!(!problems.is_empty());
-    assert_eq!(problems[0].triage_signal, "ranking_problem");
-}
-
-#[test]
-fn test_aggregate_problems_triage_recall_gap() {
-    let rows = vec![
-        fast_search_row_with_hit(1, "sess-a", 100, "search handler", "wrong_symbol"),
-        fast_search_row(2, "sess-a", 103, "handler search", "handler search"),
-        useful_action_row(3, "sess-a", 105),
-    ];
-
-    let episodes = analyze_tool_calls(&rows);
-    let problems = aggregate_problems(&episodes);
-
-    assert!(!problems.is_empty());
-    assert_eq!(problems[0].triage_signal, "recall_gap");
-}
-
-#[test]
-fn test_aggregate_problems_empty_episodes() {
-    let problems = aggregate_problems(&[]);
-    assert!(problems.is_empty());
-}
-
-#[test]
-fn test_aggregate_problems_stalled_episode_includes_all_queries() {
-    let rows = vec![
-        fast_search_row(1, "sess-a", 100, "handler", "handler"),
-        fast_search_row(2, "sess-a", 103, "different topic", "different topic"),
-    ];
-
-    let episodes = analyze_tool_calls(&rows);
-    assert_eq!(episodes[0].outcome, "stalled");
-
-    let problems = aggregate_problems(&episodes);
-    assert_eq!(problems.len(), 2);
-}
-
-// ---------------------------------------------------------------------------
-// extract_reformulation_pairs tests
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_extract_reformulation_pairs_adjacent_transitions() {
-    let rows = vec![
-        fast_search_row(1, "sess-a", 100, "search handler", "search handler"),
-        fast_search_row(2, "sess-a", 103, "handler route", "handler route"),
-        fast_search_row(3, "sess-a", 106, "route handler", "route handler"),
-        useful_action_row(4, "sess-a", 108),
-    ];
-
-    let episodes = analyze_tool_calls(&rows);
-    let pairs = extract_reformulation_pairs(&episodes);
-
-    assert_eq!(pairs.len(), 2);
-}
-
-#[test]
-fn test_extract_reformulation_pairs_deduplication() {
-    let rows = vec![
-        fast_search_row(1, "sess-a", 100, "search handler", "search handler"),
-        fast_search_row(2, "sess-a", 103, "handler route", "handler route"),
-        useful_action_row(3, "sess-a", 105),
-        fast_search_row(4, "sess-b", 200, "handler search", "handler search"),
-        fast_search_row(5, "sess-b", 203, "route handler", "route handler"),
-        useful_action_row(6, "sess-b", 205),
-    ];
-
-    let episodes = analyze_tool_calls(&rows);
-    let pairs = extract_reformulation_pairs(&episodes);
-
-    assert_eq!(pairs.len(), 1);
-    assert_eq!(pairs[0].occurrences, 2);
-}
-
-#[test]
-fn test_extract_reformulation_pairs_empty_episodes() {
-    let pairs = extract_reformulation_pairs(&[]);
-    assert!(pairs.is_empty());
-}
-
-#[test]
-fn test_extract_reformulation_pairs_skips_non_reformulated() {
+fn test_compute_flags_clean_episode() {
     let rows = vec![
         fast_search_row(1, "sess-a", 100, "handler", "handler"),
         useful_action_row(2, "sess-a", 102),
     ];
+    let mut episodes = analyze_tool_calls(&rows);
+    compute_flags(&mut episodes[0]);
 
-    let episodes = analyze_tool_calls(&rows);
-    assert_eq!(episodes[0].outcome, "one_shot_success");
+    assert!(episodes[0].flags.is_empty());
+}
 
-    let pairs = extract_reformulation_pairs(&episodes);
-    assert!(pairs.is_empty());
+// ---------------------------------------------------------------------------
+// compute_summary tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_compute_summary_empty_episodes() {
+    let summary = compute_summary(&[]);
+    assert_eq!(summary.episode_count, 0);
+    assert_eq!(summary.zero_hit_count, 0);
+    assert!(summary.median_top_score.is_none());
+}
+
+#[test]
+fn test_compute_summary_counts() {
+    let rows = vec![
+        fast_search_row(1, "sess-a", 100, "handler", "handler"),
+        useful_action_row(2, "sess-a", 102),
+        fast_search_row_zero_hits(3, "sess-b", 200, "nonexistent"),
+        fast_search_row(4, "sess-c", 300, "search handler", "search handler"),
+        fast_search_row(5, "sess-c", 303, "handler search", "handler search"),
+        useful_action_row(6, "sess-c", 305),
+    ];
+
+    let mut episodes = analyze_tool_calls(&rows);
+    for ep in &mut episodes {
+        compute_flags(ep);
+    }
+    let summary = compute_summary(&episodes);
+
+    assert_eq!(summary.episode_count, 3);
+    assert_eq!(summary.zero_hit_count, 1);
+    assert_eq!(summary.repeat_query_count, 1);
+    assert!(summary.median_top_score.is_some());
 }


### PR DESCRIPTION
## Summary

- Replaced misleading quality metrics (first-try success rate, problem queries, reformulation pairs) with an observability workbench
- Summary cards now show episode count, zero-hit rate, median score, repeat-query rate (observations, not quality judgments)
- Added per-episode friction flags (zero_hits, repeat_query, low_score, no_follow_up, relaxed) with filter buttons
- Trace table with expandable rows showing per-query detail (scores, results, intent, top hits)
- Deleted ~300 lines of aggregation code that was built on unreliable inferences

## External review

Codex (gpt-5.4): 2 findings, both fixed.
1. **(high)** Removed dead Compare button (endpoint ignores query param)
2. **(medium)** Row aggregates now show best_score/min_result_count across all queries

Full report: `.memories/autonomous-run-2026-04-20-search-analysis-workbench.md`

## Test plan

- [x] Dev tier: 10/10 buckets pass
- [x] 16 search analysis unit tests (flags, summary, episode builder)
- [x] Dashboard integration: all pages return 200
- [ ] Manual: rebuild release, check `/search/analysis?hours=1` with live data