### PR TITLE
Test Intelligence Foundation and Signals Phase 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ test_*.rs
 !**/test_coverage_tests.rs
 !**/test_linkage.rs
 !**/test_linkage_tests.rs
+!**/test_roles.rs
+!**/test_roles_tests.rs
 test_*.exe
 debug_*.rs
 validate_*.rs

--- a/.memories/2026-04-24/160901_11bf.md
+++ b/.memories/2026-04-24/160901_11bf.md
@@ -1,0 +1,49 @@
+---
+id: checkpoint_11bf25e5
+timestamp: 2026-04-24T16:09:01.903Z
+tags:
+  - test-intelligence
+  - foundation
+  - phase-1
+git:
+  branch: feat/test-intelligence-foundation
+  commit: a4b804fe
+summary: "Test Intelligence Foundation: Phase 1 Complete (Tasks 1-3, 6)"
+briefId: julie-world-class-systems-program
+type: checkpoint
+symbols:
+  - TestRole
+  - TestAnnotationClasses
+  - TestRoleConfig
+  - classify_symbols_by_role
+  - classify_test_role
+  - is_scorable_test
+  - is_test_related
+  - TestEvidenceConfig
+  - compute_test_linkage
+  - format_test_quality_info
+next: "Task 4: Rewrite test_quality.rs with evidence model (identifier-based
+  assertion counting filtered on kind='Call')"
+---
+
+## Test Intelligence Foundation: Phase 1 Complete (Tasks 1-3, 6)
+
+### What
+Completed 4 of 8 tasks for the test intelligence foundation overhaul:
+- **Task 1:** TestRole enum (5 variants) in extractors crate, TestAnnotationClasses replacing flat test/fixture config, 5 language TOMLs updated with role taxonomy
+- **Task 2:** classify_symbols_by_role pipeline step, TestRoleConfig, is_scorable_test/is_test_related helpers, wired into indexing pipeline before DB write
+- **Task 3:** TestEvidenceConfig with framework-specific assertion/mock identifiers, test_linkage updated to filter on scorable tests (excludes fixtures from coverage), confidence carried through linkage aggregation
+- **Task 6:** All 4 server-side is_test consumers updated to use is_test_related(), deep_dive formatting shows test_role + confidence
+
+### Why
+Previous test quality data was unreliable (regex-based, conflated tests with fixtures). Foundation must be trustworthy before adding new signal surfaces.
+
+### How
+- Post-extraction classification (Option A revised) instead of OnceLock or signature threading
+- Extractors remain pure; pipeline step is authoritative
+- SQL filters use `test_role IN ('test_case', 'parameterized_test')` with is_test fallback for backward compat
+
+### Impact
+- Fixtures no longer create false test coverage in test_linkage
+- Quality scoring infrastructure ready for evidence model (Task 4)
+- Confidence flows end-to-end from test_quality through test_linkage to change_risk

--- a/.memories/2026-04-24/172453_8578.md
+++ b/.memories/2026-04-24/172453_8578.md
@@ -1,0 +1,39 @@
+---
+id: checkpoint_857889fe
+timestamp: 2026-04-24T17:24:53.259Z
+tags:
+  - test-intelligence
+  - complete
+  - pre-merge
+git:
+  branch: feat/test-intelligence-foundation
+  commit: 835bbdf6
+summary: "Test Intelligence Foundation: Complete"
+briefId: julie-world-class-systems-program
+type: checkpoint
+next: Create PR via finishing-a-development-branch
+---
+
+## Test Intelligence Foundation: Complete
+
+### What
+All 8 tasks implemented, pre-merge Codex review passed (3 bugs fixed, 2 dismissed as out-of-scope).
+
+### Summary of the branch (11 commits)
+1. TestRole enum (5 variants) in extractors crate
+2. TestAnnotationClasses replacing flat test/fixture in TOML config
+3. Post-extraction classify_symbols_by_role pipeline step
+4. is_scorable_test / is_test_related helpers
+5. TestEvidenceConfig with framework-specific assertion identifiers
+6. test_linkage updated: scorable test filter, confidence propagation
+7. test_quality rewritten: evidence model with identifier (kind=Call) + regex fallback
+8. change_risk: confidence-gated test_weakness_score
+9. Server consumers updated to use is_test_related helper
+10. Three new signals: SchedulerSignal, EntryPointLinkageGap, HighCentralityLinkageGap
+11. Pre-merge fixes: exact matching, empty evidence fallback, parent confidence
+
+### Impact
+- Fixtures no longer scored for assertion density (NotApplicable tier)
+- Unknown tier replaces false Stub for regex-found-nothing
+- Confidence flows end-to-end: test_quality -> test_linkage -> change_risk
+- 33 files changed, +3237/-436 lines

--- a/.memories/2026-04-24/221050_30e8.md
+++ b/.memories/2026-04-24/221050_30e8.md
@@ -1,0 +1,81 @@
+---
+id: checkpoint_30e8950e
+timestamp: 2026-04-24T22:10:50.847Z
+tags:
+  - test-intelligence
+  - review-fixes
+  - verification
+git:
+  branch: feat/test-intelligence-foundation
+  commit: e06af425
+  files:
+    - src/analysis/change_risk.rs
+    - src/analysis/early_warnings.rs
+    - src/analysis/test_quality.rs
+    - src/tests/analysis/change_risk_tests.rs
+    - src/tests/analysis/early_warning_report_tests.rs
+    - src/tests/analysis/test_linkage_tests.rs
+    - src/tests/analysis/test_quality_tests.rs
+    - src/tests/tools/deep_dive_tests.rs
+    - src/tools/deep_dive/formatting.rs
+summary: Fixed Test Intelligence Review Findings
+briefId: julie-world-class-systems-program
+type: checkpoint
+impact: Review findings are fixed with regression coverage. `cargo xtask test
+  dev` still times out in tools-misc despite the same bucket passing standalone.
+evidence:
+  - "cargo nextest run --lib
+    test_identifier_evidence_without_matches_falls_back_to_regex_body: passed"
+  - "cargo nextest run --lib test_compute_change_risk_scores: passed"
+  - "cargo nextest run --lib
+    early_warning_report_entry_point_with_test_coverage_is_not_a_gap: passed"
+  - "cargo nextest run --lib
+    early_warning_report_high_centrality_with_test_coverage_is_not_a_gap:
+    passed"
+  - "cargo nextest run --lib
+    early_warning_report_high_centrality_file_pattern_searches_past_unscoped_li\
+    mit: passed"
+  - "cargo nextest run --lib
+    early_warning_report_high_centrality_summary_counts_all_matching_gaps:
+    passed"
+  - "cargo nextest run --lib
+    test_quality_info_includes_stored_metrics_for_test_symbol_self: passed"
+  - "cargo fmt --check: passed"
+  - "git diff --check: passed"
+  - "cargo xtask test dev: cli, core-database, core-embeddings,
+    tools-get-context, tools-search, tools-workspace passed before tools-misc
+    timeout"
+  - "cargo nextest run --lib tests::tools::editing -- --skip search_quality: 87
+    passed"
+symbols:
+  - compute_test_quality_metrics
+  - compute_change_risk_scores
+  - generate_early_warning_report
+  - collect_high_centrality_linkage_gaps
+  - format_test_quality_info
+confidence: 4
+unknowns:
+  - "xtask bucket timeout appears harness-related: tools-misc and
+    tools-workspace pass standalone, but xtask timeout limits can trip on this
+    machine."
+---
+
+## Fixed Test Intelligence Review Findings
+
+### WHAT
+Resolved six review findings in the test intelligence branch:
+- Identifier evidence now falls back to regex scoring when configured call identifiers do not match assertion evidence.
+- Bare Python `assert` statements count in regex fallback.
+- Symbols with no linkage metadata receive the full untested risk penalty.
+- Early warning linkage gaps respect legacy `test_coverage` metadata.
+- Scoped high-centrality gaps scan past out-of-scope higher-score symbols and report full matching counts while returning capped rows.
+- `deep_dive` test output again includes stored assertion count, mock count, and assertion density.
+
+### WHY
+The review found places where test intelligence could understate risk, misclassify tests, or hide useful evidence from agents. Those defects would make downstream signals less trustworthy.
+
+### HOW
+Added regression tests first for each behavior, verified failures, then patched the focused production paths. Used serial targeted test runs, formatting checks, diff checks, and direct bucket reruns for xtask timeout cases.
+
+### IMPACT
+The branch now preserves regex evidence when identifier evidence is absent, keeps untested code risk high, aligns new warning signals with legacy coverage semantics, and restores richer deep_dive quality output.

--- a/.memories/autonomous-run-2026-04-24-test-intelligence-foundation.md
+++ b/.memories/autonomous-run-2026-04-24-test-intelligence-foundation.md
@@ -1,0 +1,82 @@
+# Autonomous Execution Report - Test Intelligence Foundation
+
+**Status:** Complete
+**Plan:** docs/plans/2026-04-24-test-intelligence-foundation.md
+**Design:** docs/plans/2026-04-24-test-intelligence-foundation-design.md
+**Branch:** feat/test-intelligence-foundation
+**PR:** (pending creation)
+**Phases:** 4/4 complete
+**Tasks:** 8/8 complete
+
+## What shipped
+- **Session 1:** TestRole enum (5 variants), TestAnnotationClasses replacing flat test/fixture config, post-extraction classify_symbols_by_role pipeline step, is_scorable_test/is_test_related helpers
+- **Session 2:** TestEvidenceConfig with framework-specific assertion identifiers, test_linkage updated to filter on scorable tests and carry confidence, test_quality rewritten with evidence model (identifier kind=Call + regex fallback)
+- **Session 3:** Confidence-gated change_risk (test_weakness_score takes confidence from test_linkage), all server-side consumers updated to use is_test_related helper, deep_dive displays test_role + confidence
+- **Session 4:** SchedulerSignal, EntryPointLinkageGap, HighCentralityLinkageGap signals added to early warning report, cache schema bumped to v2
+
+## Judgment calls (non-blocking decisions made)
+- `src/tools/workspace/indexing/pipeline.rs:72` - Used `LanguageConfigs::load_embedded()` per indexing run rather than caching on handler. Cheap (embedded strings) and avoids lifecycle complexity.
+- `src/analysis/early_warnings.rs:23` - Changed `EarlyWarningReport` from `PartialEq + Eq` to `PartialEq` only because `HighCentralityLinkageGap` contains `f64`. Necessary for compilation.
+- `src/analysis/early_warnings.rs:560` - Over-fetch by 4x for high-centrality gaps when file_pattern is set, then filter in Rust. Avoids complex SQL LIKE patterns.
+- `src/analysis/test_linkage.rs:103` - Used string interpolation for SQL scorable test filter rather than parameterized query. Safe because the filter is a compile-time constant, not user input.
+
+## External review (codex, adversarial)
+
+- **Findings:** 5
+- **Verified real, fixed:** 3 (commit: 835bbdf6)
+  - `has_identifier_evidence` too broad: languages with empty test_evidence entered identifier path with 0 matches, producing false high-confidence Stub. Fixed: require non-empty assertion_identifiers.
+  - Substring matching in `count_identifier_evidence`: `lower.contains()` matched "assertion_report" against "assert". Fixed: exact match only.
+  - Parent linkage aggregation missing `best_confidence`: parents got test_linkage without confidence, defaulting to 0.5. Fixed: added to SQL query, aggregation, and output.
+- **Dismissed:** 2
+  - Non-call identifiers in test linkage (high) - Out of scope. Pre-existing behavior in identifier linkage queries, not introduced by this branch. The plan modified only the test filter, not the identifier kind filter.
+  - Stale test_linkage metadata suppressing gap signals (medium) - Out of scope. Migration concern for existing workspaces. New code is correct for fresh indexing runs; versioning legacy metadata is future work.
+- **Flagged for your review:** 0
+
+## Tests
+- Dev tier: 6/7 buckets pass. tools-misc bucket times out (210s vs 60s expected) on pre-existing editing tests (all 87 individual tests pass, bucket calibration is too low). Not a regression from this branch.
+- All new tests: 110+ tests added across test_roles (27), test_quality (65+), test_linkage (18), change_risk (13), early_warnings (13)
+
+## Blockers hit
+- None
+
+## Files changed
+```
+ .gitignore                                       |   2 +
+ crates/julie-extractors/src/base/mod.rs          |   2 +-
+ crates/julie-extractors/src/base/types.rs        |  31 +
+ crates/julie-extractors/src/lib.rs               |   2 +-
+ languages/csharp.toml                            |  14 +-
+ languages/java.toml                              |  14 +-
+ languages/kotlin.toml                            |  14 +-
+ languages/python.toml                            |  14 +-
+ languages/rust.toml                              |   9 +-
+ src/analysis/change_risk.rs                      |  34 +-
+ src/analysis/early_warnings.rs                   | 162 ++++-
+ src/analysis/mod.rs                              |  10 +-
+ src/analysis/test_linkage.rs                     |  88 ++-
+ src/analysis/test_quality.rs                     | 507 +++++++++---
+ src/analysis/test_roles.rs                       | 179 +++++
+ src/cli_tools/output.rs                          |  76 +-
+ src/embeddings/metadata.rs                       |  15 +-
+ src/search/language_config.rs                    | 313 +++++++-
+ src/tests/analysis/change_risk_tests.rs          |  49 +-
+ src/tests/analysis/early_warning_report_tests.rs | 251 +++++-
+ src/tests/analysis/mod.rs                        |   2 +
+ src/tests/analysis/test_linkage_tests.rs         | 145 ++++
+ src/tests/analysis/test_quality_tests.rs         | 789 ++++++++++++------
+ src/tests/analysis/test_roles_tests.rs           | 468 +++++++++++
+ src/tests/core/early_warning_report_cache.rs     |   2 +-
+ src/tests/tools/deep_dive_tests.rs               |  49 +-
+ src/tools/deep_dive/data.rs                      |   8 +-
+ src/tools/deep_dive/formatting.rs                |  49 +-
+ src/tools/impact/mod.rs                          |   8 +-
+ src/tools/impact/ranking.rs                      |  10 +-
+ src/tools/workspace/indexing/pipeline.rs         |  16 +-
+ 33 files changed (+memories), ~3500 insertions, ~440 deletions
+```
+
+## Next steps
+- Review PR
+- The dismissed finding about non-call identifiers in test_linkage is worth considering for a future pass (filtering identifier linkage on kind='Call' for coverage computation)
+- The stale-metadata concern for existing workspaces could be addressed by versioning test_linkage metadata or adding a recompute trigger on schema changes
+- tools-misc bucket timeout needs calibration fix (bump expected time from 60s to 240s)

--- a/crates/julie-extractors/src/base/mod.rs
+++ b/crates/julie-extractors/src/base/mod.rs
@@ -29,5 +29,5 @@ pub use tree_methods::{find_child_by_type, find_child_by_types};
 pub use types::{
     AnnotationMarker, ContextConfig, ExtractionResults, Identifier, IdentifierKind,
     PendingRelationship, Relationship, RelationshipKind, Symbol, SymbolKind, SymbolOptions,
-    TypeInfo, Visibility,
+    TestRole, TypeInfo, Visibility,
 };

--- a/crates/julie-extractors/src/base/types.rs
+++ b/crates/julie-extractors/src/base/types.rs
@@ -10,6 +10,37 @@ use std::collections::HashMap;
 use super::relationship_resolution::StructuredPendingRelationship;
 use super::span::NormalizedSpan;
 
+/// Role classification for test-related symbols.
+///
+/// Distinguishes test cases (scorable for quality) from fixtures and containers
+/// (not scorable), preventing false "stub" classifications on setup/teardown methods.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TestRole {
+    TestCase,
+    ParameterizedTest,
+    FixtureSetup,
+    FixtureTeardown,
+    TestContainer,
+}
+
+impl TestRole {
+    /// Returns true for roles where quality scoring (assert density, stub detection) applies.
+    pub fn is_scorable(&self) -> bool {
+        matches!(self, TestRole::TestCase | TestRole::ParameterizedTest)
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TestRole::TestCase => "test_case",
+            TestRole::ParameterizedTest => "parameterized_test",
+            TestRole::FixtureSetup => "fixture_setup",
+            TestRole::FixtureTeardown => "fixture_teardown",
+            TestRole::TestContainer => "test_container",
+        }
+    }
+}
+
 /// Canonical annotation marker with display, match, and source text forms.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AnnotationMarker {

--- a/crates/julie-extractors/src/lib.rs
+++ b/crates/julie-extractors/src/lib.rs
@@ -81,7 +81,7 @@ pub mod zig;
 pub use base::{
     AnnotationMarker, ContextConfig, ExtractionResults, Identifier, IdentifierKind,
     PendingRelationship, Relationship, RelationshipKind, Symbol, SymbolKind, SymbolOptions,
-    TypeInfo, Visibility, normalize_annotations,
+    TestRole, TypeInfo, Visibility, normalize_annotations,
 };
 
 // Re-export the public API - canonical extraction functions

--- a/docs/plans/2026-04-24-test-intelligence-foundation-design.md
+++ b/docs/plans/2026-04-24-test-intelligence-foundation-design.md
@@ -113,8 +113,9 @@ test_case = [
 ]
 parameterized_test = [
     "parameterizedtest", # JUnit 5
-    "dataprovider",      # TestNG (on the data method; consumer has @Test)
 ]
+# Note: @DataProvider (TestNG) annotates the DATA-PROVIDING method, not the test itself.
+# It is not a test role; it is excluded from the taxonomy.
 fixture_setup = [
     "beforeeach",        # JUnit 5
     "beforeall",         # JUnit 5
@@ -148,7 +149,7 @@ test_case = [
 ]
 parameterized_test = [
     "parameterizedtest",
-    "dataprovider",
+    # @DataProvider excluded: annotates data method, not the test
 ]
 fixture_setup = [
     "beforeeach", "beforeall", "before", "beforeclass",
@@ -254,7 +255,7 @@ test_case = [
     "test",              # PHPUnit #[Test] or @test docblock
 ]
 parameterized_test = [
-    "dataprovider",      # PHPUnit #[DataProvider] or @dataProvider
+    # @DataProvider excluded: annotates data method, not the test      # PHPUnit #[DataProvider] or @dataProvider
 ]
 fixture_setup = [
     "before",            # PHPUnit #[Before] or @before
@@ -278,7 +279,7 @@ test_case = [
 ]
 parameterized_test = [
     "parameterizedtest",
-    "dataprovider",
+    # @DataProvider excluded: annotates data method, not the test
 ]
 fixture_setup = [
     "beforeeach", "beforeall", "before", "beforeclass",
@@ -343,55 +344,54 @@ Test detection for these languages remains in `is_test_symbol()` using name/path
 
 ### Architecture
 
-The extractors crate cannot access server-side TOML configs (it's a separate crate with no dependency on the server). Two options:
+The extractors crate cannot access server-side TOML configs (it's a separate crate with no dependency on the server). Three options were considered:
 
 **Option A: Post-extraction role classification in the indexing pipeline.**
-Extractors continue setting `metadata.is_test` via the current `is_test_symbol()` with its hardcoded lists. The indexing pipeline adds a new step that reads TOML configs and classifies `metadata.test_role` based on the symbol's annotation_keys. `test_quality` and downstream consumers use `test_role` instead of raw `is_test`.
+Extractors continue setting `metadata.is_test` via the current `is_test_symbol()` with its hardcoded lists. The indexing pipeline adds a new step that reads TOML configs and classifies `metadata.test_role` based on the symbol's annotation_keys. The pipeline step is authoritative and overrides extractor decisions. `test_quality` and downstream consumers use `test_role` instead of raw `is_test`.
 
 **Option B: Pass annotation role config into extractors.**
-Create a shared config module that both the extractors crate and the server crate can access. `is_test_symbol()` reads role definitions from this shared config instead of hardcoded arrays.
+Create a shared config module. `is_test_symbol()` reads role definitions from this shared config instead of hardcoded arrays. Requires changing 30+ function signatures in the extraction pipeline.
 
-**Recommendation: Option B.** Option A creates a two-pass system where the first pass (is_test_symbol with hardcoded lists) can disagree with the second pass (config-driven roles). Option B has a single source of truth. The shared config is a small struct passed into extractors at initialization; it doesn't require the extractors to depend on the full server.
+**Option C: OnceLock global in the extractors crate.**
+Store config in a process-global `OnceLock`, populated at startup. Extractors read from the global.
 
-The shared config struct:
+**Recommendation: Option A (revised).** Option B requires threading a parameter through 30+ function signatures across the extraction pipeline (registry entries, factory, pipeline, every language extractor). Option C creates hidden mutable global state in a previously-pure library crate, introduces test-order leakage, and risks silent stale config in daemon restart scenarios.
 
-```rust
-/// Passed into extractors at init time. Populated from TOML configs.
-pub struct TestRoleConfig {
-    pub test_case: HashSet<String>,
-    pub parameterized_test: HashSet<String>,
-    pub fixture_setup: HashSet<String>,
-    pub fixture_teardown: HashSet<String>,
-    pub test_container: HashSet<String>,
-}
-```
+Option A's original objection ("two passes can disagree") is resolved by making the pipeline step authoritative. The extractors' `is_test_symbol()` provides a reasonable first pass for convention-based languages (Go, Ruby, Swift, etc.). The pipeline step overrides with config-driven role classification for annotation-based languages. There is no disagreement because the pipeline step's output is what gets written to the database. Over time, `is_test_symbol()` can be simplified to convention-only detection.
 
-`is_test_symbol()` signature becomes:
+The classification function lives in the server crate (it has access to TOML configs):
 
 ```rust
 pub fn classify_test_role(
-    language: &str,
-    name: &str,
-    file_path: &str,
-    kind: &SymbolKind,
-    annotation_keys: &[String],
-    doc_comment: Option<&str>,
+    symbol: &Symbol,
     role_config: Option<&TestRoleConfig>,
 ) -> Option<TestRole>
 ```
 
-Returns `None` for non-test symbols, `Some(TestRole::TestCase)`, `Some(TestRole::FixtureSetup)`, etc. for test-related symbols. For languages without config (role_config is None), falls back to name/path heuristics and returns `TestRole::TestCase` for anything that matches (preserving current behavior for convention-based languages).
+This operates on fully-extracted `Symbol` structs with their annotations, name, kind, file_path, and doc_comment already populated. For symbols with annotations matching a TOML role, it returns the config-driven role. For symbols without matching annotations, it falls back to the extractor's `is_test` decision (returning `TestRole::TestCase` if `is_test` was set).
 
-The existing `is_test` metadata flag becomes derived: `is_test = test_role.is_some()`.
+The pipeline step runs after extraction, before `persist_batch` writes symbols to the database.
+
+### Accessor helpers
+
+New code must NOT use raw `metadata.is_test`. Instead, use typed helpers:
+
+- `is_test_related(symbol)`: true for any test-related symbol (test, fixture, container). Use for: excluding from production rankings, embeddings, search de-boosting.
+- `is_scorable_test(symbol)`: true only for `TestCase` and `ParameterizedTest`. Use for: quality scoring, test linkage coverage, risk assessment.
+- `test_role(symbol)`: returns `Option<TestRole>`. Use for: display, sorting, detailed classification.
+
+`metadata.is_test` continues to be set (derived from `test_role.is_some()`) for backward compat with existing SQL queries, but new Rust code must use the helpers.
 
 ### Migration
 
-1. Add `TestRoleConfig` and `TestRole` to the extractors crate
-2. Rename `is_test_symbol()` to `classify_test_role()` with the new signature
-3. Update all 16+ extractor call sites to pass the role config and store `test_role` in metadata
-4. Keep `is_test` as a derived field for backward compat with queries
-5. Update TOML configs with the new `[annotation_classes.test]` structure
-6. Remove hardcoded annotation lists from `test_detection.rs`
+1. Add `TestRole` enum to the extractors crate (shared type)
+2. Add `TestRoleConfig` to the server crate
+3. Add `classify_test_role()` to the server crate (operates on Symbol, reads TOML config)
+4. Add pipeline step after extraction, before DB write, that classifies roles
+5. Add `is_test_related()`, `is_scorable_test()`, `test_role()` helpers
+6. Update `test_linkage` to use `is_scorable_test()` instead of raw `is_test`
+7. Keep `is_test` as a derived field for backward compat with SQL queries
+8. `is_test_symbol()` in extractors remains unchanged (convention-based detection still works)
 
 ---
 
@@ -492,22 +492,21 @@ mock_identifiers = [
 ]
 ```
 
-The identifier query:
+The identifier query filters on `kind = 'Call'` to avoid false positives from variable names like `equal`, `setup`, `mock`:
 
 ```sql
-SELECT COUNT(*) FROM identifiers
+SELECT LOWER(name) FROM identifiers
 WHERE containing_symbol_id = ?test_id
-AND LOWER(name) IN (?assertion_identifiers)
+AND kind = 'Call'
 ```
+
+The results are matched against the framework-specific assertion identifier list from TOML config. Using `kind = 'Call'` is critical: names like `verify`, `mock`, `setup` appear as both function calls and variable references. Only call-site matches are meaningful assertion evidence.
+
+When `target_symbol_id` is present on an identifier, it provides even higher confidence (resolved reference vs. name-only match). The evidence model should prefer resolved identifiers where available.
 
 **Important caveat:** Identifier extraction coverage varies by language. Rust macro calls (`assert_eq!`) may not appear as identifiers depending on tree-sitter grammar handling. The design must verify identifier extraction for assertion calls per language before relying on it. Where identifier data is insufficient, the existing regex approach serves as a fallback with lower confidence.
 
-**Evidence source 3: Linkage breadth (from test_linkage)**
-- How many production symbols does this test reference?
-- A test that touches one function is narrower than one that exercises a full workflow
-- This data already exists in `test_linkage` metadata
-
-**Evidence source 4: Body presence**
+**Evidence source 3: Body presence**
 - Does the test have a code body at all?
 - A function with `pass`, `...`, `TODO`, or an empty body is definitively a stub
 - This check is simple and high-confidence
@@ -583,7 +582,11 @@ The `test_weakness_score` function maps quality tiers to scores, but does not co
 
 ### Design
 
-`test_weakness_score` incorporates confidence:
+**Confidence must flow end-to-end:** `test_quality` computes confidence per test, `test_linkage` aggregates confidence alongside `best_tier` when linking tests to production symbols, and `change_risk` consumes the aggregated confidence. The plan must NOT invent confidence from tier names at the change_risk level; that defeats the entire purpose.
+
+**test_linkage changes:** When storing test_linkage metadata on production symbols, include `best_confidence` aggregated from linked tests' `test_quality.confidence` values. Use the confidence of the best-tier linked test (not an average, since the best test is the most relevant signal).
+
+**change_risk formula:**
 
 ```rust
 pub fn test_weakness_score(best_tier: Option<&str>, confidence: f64) -> f64 {
@@ -592,20 +595,23 @@ pub fn test_weakness_score(best_tier: Option<&str>, confidence: f64) -> f64 {
         Some("stub") => 0.9,
         Some("thin") => 0.6,
         Some("adequate") => 0.3,
-        Some("thorough") => 0.0,
+        Some("thorough") => 0.1,      // Lower risk but not zero; static evidence has limits
         Some("unknown") => 0.5,       // Hedge: unknown is not great but not awful
         Some("n/a") => 0.5,           // Fixture-only coverage, uncertain
         _ => 0.5,
     };
+    let confidence = confidence.clamp(0.0, 1.0);
     // Scale by confidence: low confidence pulls the weakness toward neutral (0.5)
     let neutral = 0.5;
     neutral + (raw_weakness - neutral) * confidence
 }
 ```
 
+Note: `thorough` maps to `0.1`, not `0.0`. Static evidence should lower risk, not erase it entirely.
+
 When confidence is 1.0, the score is unmodified. When confidence is 0.0, the score collapses to 0.5 (neutral, neither hurting nor helping). This prevents low-confidence assessments from dominating the risk score.
 
-The W_TEST_WEAKNESS weight (0.30) stays the same. The gating happens at the evidence level, not the weight level. If we later prove that identifier-based quality assessment is highly reliable, the full 30% weight takes effect naturally.
+The W_TEST_WEAKNESS weight (0.30) stays the same. The gating happens at the evidence level, not the weight level.
 
 ---
 
@@ -623,7 +629,7 @@ Expand scheduler annotations for additional languages where applicable:
 - PHP: cron-related annotations if frameworks use them
 - C#: Hangfire `[AutomaticRetry]`, Quartz `[DisallowConcurrentExecution]` if applicable
 
-### 6B. Untested Entry Point Signal
+### 6B. Entry Point Linkage Gap Signal
 
 Cross-reference `EntryPointSignal` (already computed) with `test_linkage` metadata (already computed). Report entry points with no observed test linkage.
 
@@ -631,7 +637,7 @@ Signal framing: "These API endpoints have no observed test linkage. This does no
 
 Acceptance criteria: only surface when test_linkage pipeline has run successfully and the entry point's language has reasonable identifier extraction coverage. Do not surface for languages where test_linkage has low structural coverage.
 
-### 6C. High-Centrality Untested Signal
+### 6C. High-Centrality Linkage Gap Signal
 
 Top-N production symbols (by centrality score) with no test linkage. These are well-connected symbols where a bug has wide blast radius and no test safety net.
 
@@ -716,15 +722,17 @@ Pipeline
 ### Proposed flow
 
 ```
-Extractor
-  → classify_test_role(config-driven) → metadata.test_role = TestCase/FixtureSetup/...
-  → metadata.is_test = test_role.is_some()   (derived, backward compat)
+Extractor (unchanged)
+  → is_test_symbol(hardcoded lists) → metadata.is_test = true/false
   → extract annotations → AnnotationMarker[]
 
-Pipeline
+Pipeline (new step: classify_symbols_by_role)
+  → classify_symbols_by_role(config-driven, authoritative)
+      → metadata.test_role = TestCase/FixtureSetup/...
+      → metadata.is_test overridden if needed (derived, backward compat)
   → test_quality_evidence(role-aware, identifier + fallback regex)
       → metadata.test_quality.tier + confidence + evidence
-  → test_linkage(unchanged, uses is_test for gating)
+  → test_linkage(uses is_scorable_test, carries confidence)
   → change_risk(confidence-gated test_weakness) → metadata.change_risk
 ```
 
@@ -734,13 +742,15 @@ Pipeline
 |------|--------|
 | `src/search/language_config.rs` | Replace flat `test`/`fixture` with `TestAnnotationClasses` struct, add `TestEvidenceConfig` |
 | `languages/*.toml` | Update all applicable configs with role taxonomy and test_evidence |
-| `crates/julie-extractors/src/test_detection.rs` | Rename to `test_classification.rs`, `classify_test_role()` consuming `TestRoleConfig` |
-| `crates/julie-extractors/src/base/types.rs` | Add `TestRole` enum, `TestRoleConfig` struct |
-| All 16+ extractor files | Update call sites to pass role config, store `test_role` |
+| `crates/julie-extractors/src/base/types.rs` | Add `TestRole` enum (shared type) |
+| `crates/julie-extractors/src/test_detection.rs` | Unchanged (convention-based detection stays) |
+| Extractor files | Unchanged (no signature changes needed) |
+| `src/analysis/test_roles.rs` | Create: `classify_test_role()`, `classify_symbols_by_role()`, `is_scorable_test()`, `is_test_related()` |
 | `src/analysis/test_quality.rs` | Replace regex oracle with evidence model |
+| `src/analysis/test_linkage.rs` | Use `is_scorable_test()`, carry confidence in aggregation |
 | `src/analysis/change_risk.rs` | Add confidence gating to `test_weakness_score` |
-| `src/analysis/early_warnings.rs` | Add scheduler, untested entry point, high-centrality signals |
-| `src/tools/workspace/indexing/pipeline.rs` | Pass `TestRoleConfig` to extractors, pass evidence config to test_quality |
+| `src/analysis/early_warnings.rs` | Add scheduler, linkage gap signals; bump cache schema version |
+| `src/tools/workspace/indexing/pipeline.rs` | Add `classify_symbols_by_role` step before persist_batch |
 
 ---
 

--- a/docs/plans/2026-04-24-test-intelligence-foundation-design.md
+++ b/docs/plans/2026-04-24-test-intelligence-foundation-design.md
@@ -1,0 +1,817 @@
+# Test Intelligence Foundation and Signals Phase 2
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use razorback:subagent-driven-development when subagent delegation is available. Fall back to razorback:executing-plans for single-task, tightly-sequential, or no-delegation runs.
+
+**Goal:** Strengthen Julie's foundational test intelligence so that downstream consumers (change_risk, deep_dive, blast_radius, signals) operate on trustworthy data. Then extend the signals report with security and test coverage signals built on that foundation.
+
+**Architecture:** Test role classification moves from hardcoded per-language lists to config-driven TOML vocabulary. Test quality assessment replaces regex-over-text pattern counting with an evidence model using identifier data matched against framework-specific config. Quality tiers carry explicit confidence scores so downstream consumers can gate on reliability. Signal surfaces are added only after the foundation is proven.
+
+**Motivation:** Julie's previous attempt to surface test and security data (the codehealth skill) was scrapped because the data was unreliable. The current test intelligence chain has specific weaknesses: `is_test_symbol()` conflates tests and fixtures, `test_quality.rs` scores fixtures on assertion density (producing misleading tiers), and `change_risk.rs` gives 30% weight to quality tiers whose confidence is unassessed. Building new report surfaces on this foundation repeats the same mistake. Julie fills a niche between zero insight and dedicated security/test tooling. That niche only works if what Julie says is trustworthy.
+
+**Design consensus:** Two independent models (Claude Opus 4.6 and GPT-5.4 xhigh via Codex CLI) converged on the same diagnosis: the test/fixture conflation is the root bug, regex quality tiers carry too much authority for what they measure, and foundation must be fixed before adding surfaces.
+
+---
+
+## Non-Goals
+
+- **Not a security scanner.** Julie does not claim taint tracking, exploit reachability, or vulnerability detection. Signals are structural observations, not findings.
+- **Not a test coverage tool.** Julie does not run tests, measure line/branch coverage, or replace language-specific coverage tooling. "No test linkage observed" is not the same as "untested."
+- **Not exhaustive.** Some languages lack annotation syntax entirely (Go, C, Lua, Bash). Test detection there stays name/path-based. We do not invent annotation semantics for languages that don't have them.
+- **Not backward-compatible.** The annotation_classes config schema changes. Old TOML configs need updating. No shim layer.
+
+---
+
+## Part 1: Annotation Role Taxonomy
+
+### Problem
+
+`AnnotationClassesConfig` currently has two flat categories for test-related annotations:
+
+```rust
+pub test: Vec<String>,    // "things related to testing"
+pub fixture: Vec<String>, // "things related to fixtures"
+```
+
+These are too coarse. `is_test_symbol()` returns `true` for both `@Test` and `@BeforeEach`, which means:
+- `test_quality.rs` analyzes fixture functions for assertion density
+- A `@BeforeEach` setup method with zero asserts gets classified as "stub"
+- That "stub" tier feeds a 30% weight in `change_risk` scoring
+- The signal is wrong: a fixture with no asserts is correct, not deficient
+
+### Design
+
+Replace `test` and `fixture` with a role taxonomy that captures what annotations tell us about a symbol's purpose:
+
+```rust
+pub struct TestAnnotationClasses {
+    /// Functions that assert behavior: @Test, [Fact], #[test]
+    pub test_case: Vec<String>,
+
+    /// Data-driven test variants: [Theory], @ParameterizedTest, @TestCase
+    pub parameterized_test: Vec<String>,
+
+    /// Pre-test lifecycle: @BeforeEach, [SetUp], @pytest.fixture
+    pub fixture_setup: Vec<String>,
+
+    /// Post-test lifecycle: @AfterEach, [TearDown]
+    pub fixture_teardown: Vec<String>,
+
+    /// Classes/modules that hold tests: [TestFixture], @TestClass
+    pub test_container: Vec<String>,
+}
+```
+
+This replaces the existing `test` and `fixture` fields in `AnnotationClassesConfig`. The struct name `TestAnnotationClasses` is a nested struct within `AnnotationClassesConfig`:
+
+```rust
+pub struct AnnotationClassesConfig {
+    pub entrypoint: Vec<String>,
+    pub auth: Vec<String>,
+    pub auth_bypass: Vec<String>,
+    pub middleware: Vec<String>,
+    pub scheduler: Vec<String>,
+    pub test: TestAnnotationClasses,  // replaces flat Vec<String>
+}
+```
+
+TOML representation:
+
+```toml
+[annotation_classes.test]
+test_case = ["fact", "test", "testmethod"]
+parameterized_test = ["theory", "testcase", "datatestmethod"]
+fixture_setup = ["setup", "onetimesetup", "testinitialize", "classinitialize"]
+fixture_teardown = ["teardown", "onetimeteardown", "testcleanup", "classcleanup"]
+test_container = ["testfixture", "testclass", "collection"]
+```
+
+### Role Semantics
+
+| Role | Quality scoring? | What it means |
+|------|-----------------|---------------|
+| `test_case` | Yes | This function asserts behavior. Assertion evidence is meaningful. |
+| `parameterized_test` | Yes (adjusted) | Data-driven test. May have fewer explicit assertions per case because the framework iterates. |
+| `fixture_setup` | No | Sets up test state. Zero assertions is correct behavior, not a deficiency. |
+| `fixture_teardown` | No | Cleans up test state. Zero assertions is expected. |
+| `test_container` | No (aggregate only) | Holds tests. Quality is aggregated from children, not measured directly. |
+
+---
+
+## Part 2: TOML Config Expansion
+
+Every language with annotation syntax for test frameworks gets comprehensive role-classified entries. Languages without annotation-based test semantics (Go, Ruby, Swift, Elixir, JavaScript, TypeScript, C, C++, Lua, Zig, Bash, etc.) keep name/path-based detection unchanged.
+
+### Java (JUnit 4, JUnit 5, TestNG)
+
+```toml
+[annotation_classes.test]
+test_case = [
+    "test",              # JUnit 4/5, TestNG
+    "repeatedtest",      # JUnit 5
+    "testfactory",       # JUnit 5
+    "testtemplate",      # JUnit 5
+]
+parameterized_test = [
+    "parameterizedtest", # JUnit 5
+    "dataprovider",      # TestNG (on the data method; consumer has @Test)
+]
+fixture_setup = [
+    "beforeeach",        # JUnit 5
+    "beforeall",         # JUnit 5
+    "before",            # JUnit 4
+    "beforeclass",       # JUnit 4, TestNG
+    "beforemethod",      # TestNG
+    "beforesuite",       # TestNG
+]
+fixture_teardown = [
+    "aftereach",         # JUnit 5
+    "afterall",          # JUnit 5
+    "after",             # JUnit 4
+    "afterclass",        # JUnit 4, TestNG
+    "aftermethod",       # TestNG
+    "aftersuite",        # TestNG
+]
+test_container = [
+    "nested",            # JUnit 5
+]
+```
+
+### Kotlin (mirrors Java, plus kotlin.test)
+
+```toml
+[annotation_classes.test]
+test_case = [
+    "test",              # JUnit 4/5, TestNG, kotlin.test
+    "repeatedtest",
+    "testfactory",
+    "testtemplate",
+]
+parameterized_test = [
+    "parameterizedtest",
+    "dataprovider",
+]
+fixture_setup = [
+    "beforeeach", "beforeall", "before", "beforeclass",
+    "beforemethod", "beforesuite",
+    "beforetest",        # kotlin.test
+]
+fixture_teardown = [
+    "aftereach", "afterall", "after", "afterclass",
+    "aftermethod", "aftersuite",
+    "aftertest",         # kotlin.test
+]
+test_container = ["nested"]
+```
+
+### C# (xUnit, NUnit, MSTest)
+
+```toml
+[annotation_classes.test]
+test_case = [
+    "fact",              # xUnit
+    "test",              # NUnit
+    "testmethod",        # MSTest
+]
+parameterized_test = [
+    "theory",            # xUnit
+    "testcase",          # NUnit
+    "testcasesource",    # NUnit
+    "datatestmethod",    # MSTest
+]
+fixture_setup = [
+    "setup",             # NUnit
+    "onetimesetup",      # NUnit
+    "testinitialize",    # MSTest
+    "classinitialize",   # MSTest
+    "assemblyinitialize",# MSTest
+]
+fixture_teardown = [
+    "teardown",          # NUnit
+    "onetimeteardown",   # NUnit
+    "testcleanup",       # MSTest
+    "classcleanup",      # MSTest
+    "assemblycleanup",   # MSTest
+]
+test_container = [
+    "testfixture",       # NUnit
+    "testclass",         # MSTest
+    "collection",        # xUnit
+    "collectiondefinition", # xUnit
+]
+```
+
+### VB.NET (same frameworks as C#)
+
+```toml
+[annotation_classes.test]
+test_case = ["fact", "test", "testmethod"]
+parameterized_test = ["theory", "testcase", "testcasesource", "datatestmethod"]
+fixture_setup = ["setup", "onetimesetup", "testinitialize", "classinitialize", "assemblyinitialize"]
+fixture_teardown = ["teardown", "onetimeteardown", "testcleanup", "classcleanup", "assemblycleanup"]
+test_container = ["testfixture", "testclass", "collection", "collectiondefinition"]
+```
+
+### Python (pytest, unittest)
+
+```toml
+[annotation_classes.test]
+test_case = []
+# Python tests are detected by name convention (test_ prefix), not annotation.
+# pytest.mark.asyncio and pytest.mark.django_db are modifiers, not test markers.
+parameterized_test = [
+    "pytest.mark.parametrize",
+]
+fixture_setup = [
+    "pytest.fixture",
+]
+fixture_teardown = []
+# pytest fixtures handle teardown via yield/finalizer, no separate annotation.
+test_container = []
+```
+
+### Rust
+
+```toml
+[annotation_classes.test]
+test_case = [
+    "test",              # std
+    "tokio::test",       # tokio async tests
+    "rstest",            # rstest framework
+]
+parameterized_test = []
+# rstest handles parameterization but uses the same #[rstest] attribute.
+fixture_setup = []
+fixture_teardown = []
+test_container = []
+# Rust uses mod tests {} by convention, no annotation.
+```
+
+### PHP (PHPUnit)
+
+```toml
+[annotation_classes.test]
+test_case = [
+    "test",              # PHPUnit #[Test] or @test docblock
+]
+parameterized_test = [
+    "dataprovider",      # PHPUnit #[DataProvider] or @dataProvider
+]
+fixture_setup = [
+    "before",            # PHPUnit #[Before] or @before
+    "beforeclass",       # PHPUnit #[BeforeClass] or @beforeClass
+]
+fixture_teardown = [
+    "after",             # PHPUnit #[After] or @after
+    "afterclass",        # PHPUnit #[AfterClass] or @afterClass
+]
+test_container = [
+    "coversclass",       # PHPUnit #[CoversClass] (marks a test class)
+]
+```
+
+### Scala (JUnit, ScalaTest, MUnit)
+
+```toml
+[annotation_classes.test]
+test_case = [
+    "test",              # JUnit-style
+]
+parameterized_test = [
+    "parameterizedtest",
+    "dataprovider",
+]
+fixture_setup = [
+    "beforeeach", "beforeall", "before", "beforeclass",
+]
+fixture_teardown = [
+    "aftereach", "afterall", "after", "afterclass",
+]
+test_container = []
+# ScalaTest/MUnit use trait mixing, not annotations, for test containers.
+```
+
+### Dart
+
+```toml
+[annotation_classes.test]
+test_case = [
+    "istest",            # package:meta @isTest
+]
+parameterized_test = []
+fixture_setup = []
+fixture_teardown = []
+test_container = [
+    "istestgroup",       # package:meta @isTestGroup
+]
+```
+
+### Razor (inherits C#)
+
+```toml
+[annotation_classes.test]
+test_case = ["fact", "test", "testmethod"]
+parameterized_test = ["theory", "testcase", "datatestmethod"]
+fixture_setup = ["setup", "onetimesetup", "testinitialize", "classinitialize"]
+fixture_teardown = ["teardown", "onetimeteardown", "testcleanup", "classcleanup"]
+test_container = ["testfixture", "testclass", "collection"]
+```
+
+### Languages without test annotation support
+
+The following languages use convention-based test detection (name patterns, file paths) and do not need `[annotation_classes.test]` sections: Go, JavaScript, TypeScript, Ruby, Swift, Elixir, C, C++, Lua, Zig, GDScript, Vue, QML, R, SQL, HTML, CSS, Bash, PowerShell, Markdown, JSON, TOML, YAML.
+
+Test detection for these languages remains in `is_test_symbol()` using name/path heuristics, unchanged.
+
+---
+
+## Part 3: Config-Driven Test Classification
+
+### Problem
+
+`is_test_symbol()` in `crates/julie-extractors/src/test_detection.rs` hardcodes per-language annotation lists. The TOML configs define annotation_classes separately. Two sources of truth that don't talk to each other.
+
+### Design: Config owns vocabulary, code owns policy
+
+**TOML configs** define what annotations mean (vocabulary):
+- "The annotation key `fact` in C# means `test_case`"
+- "The annotation key `setup` in C# means `fixture_setup`"
+
+**`is_test_symbol()`** interprets vocabulary plus structural signals (policy):
+- "This symbol has a `test_case` annotation, so it's a test"
+- "This symbol is named `test_foo` and lives in a test directory, so it's a test"
+- "This symbol has a `fixture_setup` annotation, so it's test-related but not a test case"
+
+### Architecture
+
+The extractors crate cannot access server-side TOML configs (it's a separate crate with no dependency on the server). Two options:
+
+**Option A: Post-extraction role classification in the indexing pipeline.**
+Extractors continue setting `metadata.is_test` via the current `is_test_symbol()` with its hardcoded lists. The indexing pipeline adds a new step that reads TOML configs and classifies `metadata.test_role` based on the symbol's annotation_keys. `test_quality` and downstream consumers use `test_role` instead of raw `is_test`.
+
+**Option B: Pass annotation role config into extractors.**
+Create a shared config module that both the extractors crate and the server crate can access. `is_test_symbol()` reads role definitions from this shared config instead of hardcoded arrays.
+
+**Recommendation: Option B.** Option A creates a two-pass system where the first pass (is_test_symbol with hardcoded lists) can disagree with the second pass (config-driven roles). Option B has a single source of truth. The shared config is a small struct passed into extractors at initialization; it doesn't require the extractors to depend on the full server.
+
+The shared config struct:
+
+```rust
+/// Passed into extractors at init time. Populated from TOML configs.
+pub struct TestRoleConfig {
+    pub test_case: HashSet<String>,
+    pub parameterized_test: HashSet<String>,
+    pub fixture_setup: HashSet<String>,
+    pub fixture_teardown: HashSet<String>,
+    pub test_container: HashSet<String>,
+}
+```
+
+`is_test_symbol()` signature becomes:
+
+```rust
+pub fn classify_test_role(
+    language: &str,
+    name: &str,
+    file_path: &str,
+    kind: &SymbolKind,
+    annotation_keys: &[String],
+    doc_comment: Option<&str>,
+    role_config: Option<&TestRoleConfig>,
+) -> Option<TestRole>
+```
+
+Returns `None` for non-test symbols, `Some(TestRole::TestCase)`, `Some(TestRole::FixtureSetup)`, etc. for test-related symbols. For languages without config (role_config is None), falls back to name/path heuristics and returns `TestRole::TestCase` for anything that matches (preserving current behavior for convention-based languages).
+
+The existing `is_test` metadata flag becomes derived: `is_test = test_role.is_some()`.
+
+### Migration
+
+1. Add `TestRoleConfig` and `TestRole` to the extractors crate
+2. Rename `is_test_symbol()` to `classify_test_role()` with the new signature
+3. Update all 16+ extractor call sites to pass the role config and store `test_role` in metadata
+4. Keep `is_test` as a derived field for backward compat with queries
+5. Update TOML configs with the new `[annotation_classes.test]` structure
+6. Remove hardcoded annotation lists from `test_detection.rs`
+
+---
+
+## Part 4: Evidence-Based Quality Model
+
+### Problem
+
+`test_quality.rs` uses regex pattern matching on code body text to count assertions, mocks, and error-testing markers. Then it classifies tiers:
+
+- 3+ assertions and error testing: "thorough"
+- 2+ assertions: "adequate"
+- 1 assertion: "thin"
+- 0 assertions: "stub"
+
+This is framework-blind, cannot distinguish tests from fixtures, and treats its output as ground truth with no confidence signal. A `@pytest.fixture` with zero assertions gets labeled "stub." A `@BeforeEach` that initializes test data gets labeled "stub." Both are wrong.
+
+### Design: Evidence model with confidence
+
+Replace the regex oracle with multiple evidence sources, each contributing a signal and a confidence level:
+
+**Evidence source 1: Test role (from Part 3)**
+- Symbol's `test_role` determines whether quality scoring applies at all
+- `fixture_setup`, `fixture_teardown`, `test_container`: not scored for assertions. Quality is "n/a".
+- `test_case`, `parameterized_test`: scored for assertion evidence
+
+**Evidence source 2: Assertion evidence (from identifiers)**
+- Query the identifiers table for assertion function calls within the test symbol's scope
+- Match against framework-specific assertion identifiers from a new `[test_evidence]` TOML section:
+
+```toml
+[test_evidence]
+assertion_identifiers = [
+    "assert_eq", "assert_ne", "assert", "assert_matches",
+    "debug_assert", "debug_assert_eq",
+]
+error_assertion_identifiers = [
+    "should_err", "should_panic",
+]
+mock_identifiers = []
+```
+
+Per-language examples:
+
+```toml
+# Java
+[test_evidence]
+assertion_identifiers = [
+    "assertequals", "asserttrue", "assertfalse", "assertnull",
+    "assertnotnull", "assertthrows", "assertarrayequals",
+    "assertthat", "assertdoesnotthrow",
+    "verify", "verifynomoreinteractions",
+]
+error_assertion_identifiers = [
+    "assertthrows", "expectederror",
+]
+mock_identifiers = [
+    "mock", "spy", "when", "thenreturn", "verify",
+]
+```
+
+```toml
+# C#
+[test_evidence]
+assertion_identifiers = [
+    "assert.equal", "assert.true", "assert.false", "assert.null",
+    "assert.notnull", "assert.throws", "assert.throwsasync",
+    "assert.contains", "assert.empty", "assert.istype",
+    "assert.collection", "assert.single",
+    "assert.that", "assert.istrue", "assert.isfalse",
+    "assert.areequal", "assert.arenotequal",
+    "should", "shouldbe", "shouldcontain",
+]
+error_assertion_identifiers = [
+    "assert.throws", "assert.throwsasync",
+    "assert.catch", "assert.throwsany",
+]
+mock_identifiers = [
+    "mock", "substitute.for", "a.fake",
+    "setup", "returns", "verifiable",
+]
+```
+
+```toml
+# Python
+[test_evidence]
+assertion_identifiers = [
+    "assert", "assertequal", "asserttrue", "assertfalse",
+    "assertin", "assertnotin", "assertisnone", "assertisnotnone",
+    "assertraises", "assertwarns", "assertlogs",
+    "pytest.raises", "pytest.warns", "pytest.approx",
+]
+error_assertion_identifiers = [
+    "assertraises", "pytest.raises",
+]
+mock_identifiers = [
+    "mock", "magicmock", "patch", "mock_open",
+    "asyncmock", "create_autospec",
+]
+```
+
+The identifier query:
+
+```sql
+SELECT COUNT(*) FROM identifiers
+WHERE containing_symbol_id = ?test_id
+AND LOWER(name) IN (?assertion_identifiers)
+```
+
+**Important caveat:** Identifier extraction coverage varies by language. Rust macro calls (`assert_eq!`) may not appear as identifiers depending on tree-sitter grammar handling. The design must verify identifier extraction for assertion calls per language before relying on it. Where identifier data is insufficient, the existing regex approach serves as a fallback with lower confidence.
+
+**Evidence source 3: Linkage breadth (from test_linkage)**
+- How many production symbols does this test reference?
+- A test that touches one function is narrower than one that exercises a full workflow
+- This data already exists in `test_linkage` metadata
+
+**Evidence source 4: Body presence**
+- Does the test have a code body at all?
+- A function with `pass`, `...`, `TODO`, or an empty body is definitively a stub
+- This check is simple and high-confidence
+
+### Tier classification with confidence
+
+```rust
+pub struct TestQualityAssessment {
+    pub tier: TestQualityTier,
+    pub confidence: f32,       // 0.0 to 1.0
+    pub evidence: QualityEvidence,
+}
+
+pub enum TestQualityTier {
+    Thorough,   // Multiple assertions, error testing, good linkage breadth
+    Adequate,   // Some assertions, reasonable coverage
+    Thin,       // Minimal assertions
+    Stub,       // No body, empty, or placeholder
+    Unknown,    // Insufficient evidence to classify
+    NotApplicable, // Fixture, teardown, container (not scored)
+}
+
+pub struct QualityEvidence {
+    pub assertion_count: u32,
+    pub assertion_source: EvidenceSource,  // Identifier, Regex, None
+    pub has_error_testing: bool,
+    pub mock_count: u32,
+    pub body_lines: u32,
+    pub linkage_breadth: u32,
+}
+
+pub enum EvidenceSource {
+    Identifier,  // High confidence: matched against framework config
+    Regex,       // Medium confidence: regex pattern on code text (fallback)
+    None,        // No evidence available
+}
+```
+
+Classification rules:
+
+| Condition | Tier | Confidence |
+|-----------|------|------------|
+| Role is fixture/teardown/container | NotApplicable | 1.0 |
+| No code body or placeholder body | Stub | 1.0 |
+| No assertion evidence available | Unknown | 0.0 |
+| Identifier-based: 3+ assertions + error testing | Thorough | 0.9 |
+| Identifier-based: 2+ assertions | Adequate | 0.85 |
+| Identifier-based: 1 assertion | Thin | 0.8 |
+| Identifier-based: 0 assertions in test_case | Stub | 0.85 |
+| Regex-based: 3+ assertions + error testing | Thorough | 0.5 |
+| Regex-based: 2+ assertions | Adequate | 0.45 |
+| Regex-based: 1 assertion | Thin | 0.4 |
+| Regex-based: 0 assertions | Unknown | 0.3 |
+
+Key difference from current approach: regex with 0 assertions produces `Unknown`, not `Stub`. We admit we don't know rather than claiming the test is deficient.
+
+---
+
+## Part 5: Confidence-Gated Change Risk
+
+### Problem
+
+`change_risk.rs` gives 30% weight to test weakness:
+
+```rust
+const W_CENTRALITY: f64 = 0.35;
+const W_VISIBILITY: f64 = 0.25;
+const W_TEST_WEAKNESS: f64 = 0.30;
+const W_KIND: f64 = 0.10;
+```
+
+The `test_weakness_score` function maps quality tiers to scores, but does not consider confidence. A `Stub` tier from unreliable regex analysis gets the same treatment as a high-confidence `Stub` from an empty function body.
+
+### Design
+
+`test_weakness_score` incorporates confidence:
+
+```rust
+pub fn test_weakness_score(best_tier: Option<&str>, confidence: f64) -> f64 {
+    let raw_weakness = match best_tier {
+        None => 1.0,                  // No test linkage at all
+        Some("stub") => 0.9,
+        Some("thin") => 0.6,
+        Some("adequate") => 0.3,
+        Some("thorough") => 0.0,
+        Some("unknown") => 0.5,       // Hedge: unknown is not great but not awful
+        Some("n/a") => 0.5,           // Fixture-only coverage, uncertain
+        _ => 0.5,
+    };
+    // Scale by confidence: low confidence pulls the weakness toward neutral (0.5)
+    let neutral = 0.5;
+    neutral + (raw_weakness - neutral) * confidence
+}
+```
+
+When confidence is 1.0, the score is unmodified. When confidence is 0.0, the score collapses to 0.5 (neutral, neither hurting nor helping). This prevents low-confidence assessments from dominating the risk score.
+
+The W_TEST_WEAKNESS weight (0.30) stays the same. The gating happens at the evidence level, not the weight level. If we later prove that identifier-based quality assessment is highly reliable, the full 30% weight takes effect naturally.
+
+---
+
+## Part 6: Signals Phase 2 (After Foundation)
+
+These signal additions depend on Parts 1-5 being complete and validated. They are not implemented until the foundation is proven trustworthy.
+
+### 6A. Scheduler Signal
+
+New section in `EarlyWarningReport`: symbols with scheduler annotations (`@Scheduled`, `@celery.task`, `@periodic_task`, etc.). Already extracted and classified in TOML configs for Java, Kotlin, and Python. Structural fact, no guesswork.
+
+Signal framing: "These symbols execute on a schedule without a request context. Verify they do not access user-specific data or credentials without appropriate authorization."
+
+Expand scheduler annotations for additional languages where applicable:
+- PHP: cron-related annotations if frameworks use them
+- C#: Hangfire `[AutomaticRetry]`, Quartz `[DisallowConcurrentExecution]` if applicable
+
+### 6B. Untested Entry Point Signal
+
+Cross-reference `EntryPointSignal` (already computed) with `test_linkage` metadata (already computed). Report entry points with no observed test linkage.
+
+Signal framing: "These API endpoints have no observed test linkage. This does not mean they are untested; it means Julie's structural analysis found no test symbols that reference them."
+
+Acceptance criteria: only surface when test_linkage pipeline has run successfully and the entry point's language has reasonable identifier extraction coverage. Do not surface for languages where test_linkage has low structural coverage.
+
+### 6C. High-Centrality Untested Signal
+
+Top-N production symbols (by centrality score) with no test linkage. These are well-connected symbols where a bug has wide blast radius and no test safety net.
+
+Signal framing: "These high-centrality symbols have no observed test coverage. Changes to them affect many other symbols."
+
+---
+
+## Part 7: Test Evidence TOML Section
+
+Each language TOML gains a `[test_evidence]` section listing framework-specific function/method names used for assertions, error testing, and mocking. These are the identifiers that the evidence model matches against.
+
+**This section requires verification against actual identifier extraction per language.** Before populating a language's `[test_evidence]`, verify that the relevant assertion function calls appear in Julie's identifiers table for that language. If they don't (e.g., Rust macro calls may not be extracted as identifiers), note the gap and rely on regex fallback with lower confidence.
+
+### Verification approach
+
+For each language with test_evidence entries:
+
+1. Index a project that uses the framework
+2. Find a test function that calls assertion functions
+3. Query `SELECT name FROM identifiers WHERE containing_symbol_id = ?test_id`
+4. Confirm that assertion function names appear in the results
+5. If they don't, investigate whether the tree-sitter grammar or extractor needs adjustment, or flag the language for regex fallback
+
+### Example entries (to be verified during implementation)
+
+```toml
+# rust.toml
+[test_evidence]
+assertion_identifiers = ["assert_eq", "assert_ne", "assert", "assert_matches", "debug_assert"]
+error_assertion_identifiers = ["should_err", "should_panic"]
+mock_identifiers = []
+
+# python.toml
+[test_evidence]
+assertion_identifiers = [
+    "assert", "assertequal", "asserttrue", "assertfalse",
+    "assertin", "assertisnone", "assertraises",
+]
+error_assertion_identifiers = ["assertraises", "pytest.raises"]
+mock_identifiers = ["mock", "magicmock", "patch", "mock_open"]
+
+# java.toml
+[test_evidence]
+assertion_identifiers = [
+    "assertequals", "asserttrue", "assertfalse", "assertnull",
+    "assertnotnull", "assertthrows", "assertthat",
+]
+error_assertion_identifiers = ["assertthrows"]
+mock_identifiers = ["mock", "spy", "when", "verify"]
+
+# csharp.toml
+[test_evidence]
+assertion_identifiers = [
+    "equal", "true", "false", "null", "notnull",
+    "throws", "throwsasync", "contains", "empty",
+    "istype", "collection", "single",
+    "istrue", "isfalse", "areequal",
+]
+error_assertion_identifiers = ["throws", "throwsasync", "catch"]
+mock_identifiers = ["mock", "setup", "returns", "verifiable"]
+```
+
+Note: C# assertion identifiers are listed without the `Assert.` prefix because Julie's identifier extraction typically captures the method name (`Equal`) rather than the qualified call (`Assert.Equal`). This must be verified during implementation.
+
+---
+
+## Architecture Summary
+
+### Current flow
+
+```
+Extractor
+  → is_test_symbol(hardcoded lists) → metadata.is_test = true/false
+  → extract annotations → AnnotationMarker[]
+
+Pipeline
+  → test_quality(regex on code body) → metadata.test_quality.quality_tier
+  → test_linkage(relationships + identifiers) → metadata.test_linkage
+  → change_risk(centrality + visibility + test_weakness + kind) → metadata.change_risk
+```
+
+### Proposed flow
+
+```
+Extractor
+  → classify_test_role(config-driven) → metadata.test_role = TestCase/FixtureSetup/...
+  → metadata.is_test = test_role.is_some()   (derived, backward compat)
+  → extract annotations → AnnotationMarker[]
+
+Pipeline
+  → test_quality_evidence(role-aware, identifier + fallback regex)
+      → metadata.test_quality.tier + confidence + evidence
+  → test_linkage(unchanged, uses is_test for gating)
+  → change_risk(confidence-gated test_weakness) → metadata.change_risk
+```
+
+### File changes
+
+| File | Change |
+|------|--------|
+| `src/search/language_config.rs` | Replace flat `test`/`fixture` with `TestAnnotationClasses` struct, add `TestEvidenceConfig` |
+| `languages/*.toml` | Update all applicable configs with role taxonomy and test_evidence |
+| `crates/julie-extractors/src/test_detection.rs` | Rename to `test_classification.rs`, `classify_test_role()` consuming `TestRoleConfig` |
+| `crates/julie-extractors/src/base/types.rs` | Add `TestRole` enum, `TestRoleConfig` struct |
+| All 16+ extractor files | Update call sites to pass role config, store `test_role` |
+| `src/analysis/test_quality.rs` | Replace regex oracle with evidence model |
+| `src/analysis/change_risk.rs` | Add confidence gating to `test_weakness_score` |
+| `src/analysis/early_warnings.rs` | Add scheduler, untested entry point, high-centrality signals |
+| `src/tools/workspace/indexing/pipeline.rs` | Pass `TestRoleConfig` to extractors, pass evidence config to test_quality |
+
+---
+
+## Implementation Sequence
+
+1. **Annotation role taxonomy and TOML expansion** (Parts 1-2)
+   - Define `TestAnnotationClasses`, `TestRole`, `TestRoleConfig`
+   - Update all applicable language TOML configs
+   - This is config and type work; no behavioral change yet
+
+2. **Config-driven test classification** (Part 3)
+   - Implement `classify_test_role()` replacing `is_test_symbol()`
+   - Wire config through extractors
+   - Verify: existing `is_test` behavior preserved, `test_role` added
+
+3. **Evidence-based quality model** (Part 4)
+   - Verify identifier extraction for assertion calls per language
+   - Add `[test_evidence]` TOML sections for verified languages
+   - Replace regex oracle with evidence model
+   - Add confidence to quality tiers
+   - Verify: fixtures no longer scored, `Unknown` replaces false `Stub`
+
+4. **Confidence-gated change risk** (Part 5)
+   - Update `test_weakness_score` to incorporate confidence
+   - Verify: low-confidence tiers don't dominate risk scores
+
+5. **Signal surfaces** (Part 6, after foundation validated)
+   - Scheduler signal
+   - Untested entry point signal
+   - High-centrality untested signal
+
+---
+
+## Acceptance Criteria
+
+### Part 1-2: Role Taxonomy and TOML Expansion
+- [ ] `AnnotationClassesConfig` uses `TestAnnotationClasses` struct with five role fields
+- [ ] All 10 applicable language TOMLs have comprehensive `[annotation_classes.test]` sections
+- [ ] All three major C# frameworks (xUnit, NUnit, MSTest) fully represented
+- [ ] All three major Java frameworks (JUnit 4, JUnit 5, TestNG) fully represented
+- [ ] Python pytest.fixture classified as `fixture_setup`, not `test`
+- [ ] Existing tests pass (TOML config parsing, annotation classification)
+
+### Part 3: Config-Driven Classification
+- [ ] `classify_test_role()` replaces `is_test_symbol()` across all extractor call sites
+- [ ] `TestRoleConfig` populated from TOML configs and passed to extractors
+- [ ] `metadata.test_role` set on all test-related symbols
+- [ ] `metadata.is_test` derived from `test_role.is_some()` (backward compat)
+- [ ] Languages without annotation config fall back to name/path heuristics
+- [ ] Hardcoded annotation lists removed from `test_detection.rs`
+- [ ] Existing test detection accuracy preserved (no regressions in fixture DB)
+
+### Part 4: Evidence-Based Quality
+- [ ] Identifier extraction verified for assertion calls in at least Rust, Python, Java, C#
+- [ ] `[test_evidence]` sections added for verified languages
+- [ ] `test_quality` skips fixture_setup, fixture_teardown, test_container roles
+- [ ] `test_quality` produces `TestQualityAssessment` with tier + confidence + evidence
+- [ ] `Unknown` tier used when evidence is insufficient (not false `Stub`)
+- [ ] Regex fallback used for languages without verified identifier extraction
+- [ ] deep_dive displays confidence alongside tier
+- [ ] blast_radius respects new tier semantics
+
+### Part 5: Confidence-Gated Risk
+- [ ] `test_weakness_score` accepts confidence parameter
+- [ ] Low-confidence tiers converge toward neutral (0.5)
+- [ ] change_risk scores stable for high-confidence tiers
+- [ ] No behavioral change for symbols with no test linkage (confidence irrelevant)
+
+### Part 6: Signal Surfaces
+- [ ] SchedulerSignal section in EarlyWarningReport with symbols bearing scheduler annotations
+- [ ] Untested entry point signal cross-referencing entry points with test_linkage
+- [ ] High-centrality untested signal for top-N production symbols
+- [ ] All signal framing uses honest language: "observed," "no linkage found," not "untested" or "vulnerable"
+- [ ] Signals only surface for languages with reasonable structural coverage

--- a/docs/plans/2026-04-24-test-intelligence-foundation.md
+++ b/docs/plans/2026-04-24-test-intelligence-foundation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace Julie's test/fixture conflation and regex-based quality oracle with config-driven role classification and evidence-based quality assessment, then add security and test coverage signals on the trustworthy foundation.
 
-**Architecture:** `TestRole` enum and `TestRoleConfig` stored via `OnceLock` in the extractors crate, populated from TOML language configs at server startup. `classify_test_role()` replaces `is_test_symbol()`, setting `metadata.test_role` alongside backward-compat `metadata.is_test`. Evidence-based quality model queries identifier data against framework-specific `[test_evidence]` TOML config, with regex fallback at lower confidence. Quality tiers carry confidence scores that gate the 30% test_weakness weight in change_risk.
+**Architecture:** Extractors remain pure (no config changes). A new `classify_symbols_by_role` pipeline step runs post-extraction, before DB write, using TOML-driven `TestRoleConfig` to classify test roles authoritatively. `TestRole` enum is a shared type in the extractors crate; classification logic and `TestRoleConfig` live in the server crate. Evidence-based quality model queries identifier data (filtered on `kind = 'Call'`) against framework-specific `[test_evidence]` TOML config, with regex fallback at lower confidence. Quality tiers carry confidence scores that flow through test_linkage aggregation and gate the 30% test_weakness weight in change_risk. New helpers `is_scorable_test()` and `is_test_related()` replace raw `metadata.is_test` checks.
 
 **Tech Stack:** Rust, serde, tree-sitter, TOML configs, SQLite (identifiers table), existing Julie pipeline infrastructure
 
@@ -14,126 +14,47 @@
 
 ## Session 1: Foundation Types & Config
 
-### Task 1: Define TestRole, TestRoleConfig, and global config store
+### Task 1: Define TestRole enum and TestAnnotationClasses config
 
 **Files:**
-- Create: `crates/julie-extractors/src/test_roles.rs`
-- Modify: `crates/julie-extractors/src/lib.rs:41` (add module + re-export)
-- Test: `crates/julie-extractors/src/tests/test_detection.rs` (add role tests at bottom)
+- Modify: `crates/julie-extractors/src/base/types.rs` (add `TestRole` enum)
+- Modify: `crates/julie-extractors/src/lib.rs` (re-export `TestRole`)
+- Modify: `src/search/language_config.rs:73-88` (replace flat test/fixture with `TestAnnotationClasses`)
+- Test: `src/search/language_config.rs` (update existing tests)
 
-**What to build:** The core types that everything else depends on. A `TestRole` enum, a `TestRoleConfig` struct holding annotation-key sets per role, and a `OnceLock`-backed global store so extractors can access role configs without signature changes to the 30+ function extraction pipeline.
+**What to build:** `TestRole` enum as a shared type in the extractors crate. `TestAnnotationClasses` struct replacing the flat `test: Vec<String>` / `fixture: Vec<String>` in `AnnotationClassesConfig`. No behavioral changes yet; this is type and config plumbing.
 
-**Step 1: Write failing tests**
+**Step 1: Write failing test**
 
-Add to `crates/julie-extractors/src/tests/test_detection.rs`:
+Add to `src/search/language_config.rs` tests:
 
 ```rust
-// --- Test role classification ---
-
-use crate::test_roles::{TestRole, TestRoleConfig, init_test_role_configs, classify_test_role};
-use std::collections::{HashMap, HashSet};
-
-fn make_csharp_role_config() -> TestRoleConfig {
-    TestRoleConfig {
-        test_case: HashSet::from(["fact".into(), "test".into(), "testmethod".into()]),
-        parameterized_test: HashSet::from(["theory".into(), "testcase".into(), "datatestmethod".into()]),
-        fixture_setup: HashSet::from(["setup".into(), "onetimesetup".into(), "testinitialize".into()]),
-        fixture_teardown: HashSet::from(["teardown".into(), "onetimeteardown".into(), "testcleanup".into()]),
-        test_container: HashSet::from(["testfixture".into(), "testclass".into()]),
-    }
-}
-
 #[test]
-fn classify_csharp_fact_as_test_case() {
-    let config = make_csharp_role_config();
-    let role = classify_test_role(
-        "csharp", "MyTest", "src/Tests/MyTests.cs",
-        &SymbolKind::Method, &[s("fact")], None, Some(&config),
-    );
-    assert_eq!(role, Some(TestRole::TestCase));
-}
+fn test_annotation_classes_use_role_taxonomy() {
+    let configs = LanguageConfigs::load_embedded();
+    let csharp = configs.get("csharp").expect("csharp config");
 
-#[test]
-fn classify_csharp_setup_as_fixture() {
-    let config = make_csharp_role_config();
-    let role = classify_test_role(
-        "csharp", "SetUp", "src/Tests/MyTests.cs",
-        &SymbolKind::Method, &[s("setup")], None, Some(&config),
-    );
-    assert_eq!(role, Some(TestRole::FixtureSetup));
-}
-
-#[test]
-fn classify_csharp_theory_as_parameterized() {
-    let config = make_csharp_role_config();
-    let role = classify_test_role(
-        "csharp", "DataTest", "src/Tests/MyTests.cs",
-        &SymbolKind::Method, &[s("theory")], None, Some(&config),
-    );
-    assert_eq!(role, Some(TestRole::ParameterizedTest));
-}
-
-#[test]
-fn classify_csharp_teardown_as_fixture_teardown() {
-    let config = make_csharp_role_config();
-    let role = classify_test_role(
-        "csharp", "Cleanup", "src/Tests/MyTests.cs",
-        &SymbolKind::Method, &[s("teardown")], None, Some(&config),
-    );
-    assert_eq!(role, Some(TestRole::FixtureTeardown));
-}
-
-#[test]
-fn classify_go_test_without_config_falls_back() {
-    let role = classify_test_role(
-        "go", "TestFoo", "pkg/handler_test.go",
-        &SymbolKind::Function, &[], None, None,
-    );
-    assert_eq!(role, Some(TestRole::TestCase));
-}
-
-#[test]
-fn classify_regular_function_returns_none() {
-    let config = make_csharp_role_config();
-    let role = classify_test_role(
-        "csharp", "ProcessData", "src/Services/DataService.cs",
-        &SymbolKind::Method, &[], None, Some(&config),
-    );
-    assert_eq!(role, None);
-}
-
-#[test]
-fn classify_class_returns_none_not_callable() {
-    let config = make_csharp_role_config();
-    let role = classify_test_role(
-        "csharp", "TestFixture", "src/Tests/MyTests.cs",
-        &SymbolKind::Class, &[s("testfixture")], None, Some(&config),
-    );
-    // test_container applies to classes, but classify_test_role gates on callable kinds
-    // for test_case/parameterized/fixture roles. test_container is the exception.
-    assert_eq!(role, Some(TestRole::TestContainer));
+    // xUnit
+    assert!(csharp.annotation_classes.test.test_case.contains(&"fact".to_string()));
+    // NUnit
+    assert!(csharp.annotation_classes.test.test_case.contains(&"test".to_string()));
+    // Fixtures are in fixture_setup, not test_case
+    assert!(!csharp.annotation_classes.test.test_case.contains(&"setup".to_string()));
+    assert!(csharp.annotation_classes.test.fixture_setup.contains(&"setup".to_string()));
+    // Teardown
+    assert!(csharp.annotation_classes.test.fixture_teardown.contains(&"teardown".to_string()));
+    // Parameterized
+    assert!(csharp.annotation_classes.test.parameterized_test.contains(&"theory".to_string()));
+    // Containers
+    assert!(csharp.annotation_classes.test.test_container.contains(&"testfixture".to_string()));
 }
 ```
 
-**Step 2: Run tests, verify they fail**
+**Step 2: Add TestRole to extractors crate**
 
-```bash
-cargo nextest run --lib classify_csharp_fact 2>&1 | tail -5
-```
-Expected: compilation error (module doesn't exist yet)
-
-**Step 3: Implement test_roles.rs**
-
-Create `crates/julie-extractors/src/test_roles.rs`:
+In `crates/julie-extractors/src/base/types.rs`, after the `AnnotationMarker` struct:
 
 ```rust
-use std::collections::{HashMap, HashSet};
-use std::sync::OnceLock;
-
-use serde::{Deserialize, Serialize};
-
-use crate::base::SymbolKind;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TestRole {
@@ -159,352 +80,17 @@ impl TestRole {
         }
     }
 }
-
-#[derive(Debug, Clone, Default)]
-pub struct TestRoleConfig {
-    pub test_case: HashSet<String>,
-    pub parameterized_test: HashSet<String>,
-    pub fixture_setup: HashSet<String>,
-    pub fixture_teardown: HashSet<String>,
-    pub test_container: HashSet<String>,
-}
-
-impl TestRoleConfig {
-    pub fn classify_annotation(&self, annotation_key: &str) -> Option<TestRole> {
-        if self.test_case.contains(annotation_key) {
-            Some(TestRole::TestCase)
-        } else if self.parameterized_test.contains(annotation_key) {
-            Some(TestRole::ParameterizedTest)
-        } else if self.fixture_setup.contains(annotation_key) {
-            Some(TestRole::FixtureSetup)
-        } else if self.fixture_teardown.contains(annotation_key) {
-            Some(TestRole::FixtureTeardown)
-        } else if self.test_container.contains(annotation_key) {
-            Some(TestRole::TestContainer)
-        } else {
-            None
-        }
-    }
-
-    pub fn is_test_related(&self, annotation_key: &str) -> bool {
-        self.classify_annotation(annotation_key).is_some()
-    }
-}
-
-static TEST_ROLE_CONFIGS: OnceLock<HashMap<String, TestRoleConfig>> = OnceLock::new();
-
-pub fn init_test_role_configs(configs: HashMap<String, TestRoleConfig>) {
-    TEST_ROLE_CONFIGS.set(configs).ok();
-}
-
-pub fn get_role_config(language: &str) -> Option<&'static TestRoleConfig> {
-    TEST_ROLE_CONFIGS.get()?.get(language)
-}
-
-fn is_callable(kind: &SymbolKind) -> bool {
-    matches!(
-        kind,
-        SymbolKind::Function | SymbolKind::Method | SymbolKind::Constructor
-    )
-}
-
-fn is_container_kind(kind: &SymbolKind) -> bool {
-    matches!(
-        kind,
-        SymbolKind::Class | SymbolKind::Struct | SymbolKind::Module | SymbolKind::Namespace
-    )
-}
-
-pub fn classify_test_role(
-    language: &str,
-    name: &str,
-    file_path: &str,
-    kind: &SymbolKind,
-    annotation_keys: &[String],
-    doc_comment: Option<&str>,
-    role_config: Option<&TestRoleConfig>,
-) -> Option<TestRole> {
-    // Try config-driven classification first
-    if let Some(config) = role_config {
-        // Check annotations against role config
-        for key in annotation_keys {
-            if let Some(role) = config.classify_annotation(key) {
-                // test_container applies to container kinds
-                if role == TestRole::TestContainer {
-                    if is_container_kind(kind) {
-                        return Some(role);
-                    }
-                    continue;
-                }
-                // All other roles require callable kinds
-                if is_callable(kind) {
-                    return Some(role);
-                }
-            }
-        }
-    }
-
-    // Fall back to name/path heuristics for convention-based languages
-    if is_callable(kind) {
-        if let Some(role) = detect_by_convention(language, name, file_path, annotation_keys, doc_comment) {
-            return Some(role);
-        }
-    }
-
-    None
-}
-
-fn detect_by_convention(
-    language: &str,
-    name: &str,
-    file_path: &str,
-    annotation_keys: &[String],
-    doc_comment: Option<&str>,
-) -> Option<TestRole> {
-    // Delegate to language-specific convention detection
-    // These cover languages without annotation-based test frameworks
-    let is_test = match language {
-        "go" => detect_go(name, file_path),
-        "javascript" | "typescript" => detect_js_ts(name, file_path),
-        "ruby" => detect_ruby(name, file_path),
-        "swift" => detect_swift(name, file_path),
-        "elixir" => detect_elixir(name, file_path),
-        "php" => detect_php_convention(name, file_path, doc_comment),
-        "python" => detect_python_convention(name),
-        "scala" => detect_scala_convention(name, file_path),
-        _ => detect_generic(name, file_path),
-    };
-    if is_test { Some(TestRole::TestCase) } else { None }
-}
-
-// Convention-based detectors (moved from test_detection.rs, unchanged logic)
-
-fn is_test_path(file_path: &str) -> bool {
-    for segment in file_path.split('/') {
-        match segment {
-            "test" | "tests" | "Test" | "Tests" | "spec" | "Spec" | "__tests__" | "autotests" => {
-                return true;
-            }
-            _ => {}
-        }
-        if segment.ends_with(".Tests") || segment.ends_with(".Test") {
-            return true;
-        }
-    }
-    let file_name = file_path.rsplit('/').next().unwrap_or(file_path);
-    if file_name.ends_with("_test.go")
-        || file_name.contains(".test.")
-        || file_name.contains(".spec.")
-        || file_name.starts_with("test_")
-        || file_name.starts_with("tst_")
-    {
-        return true;
-    }
-    false
-}
-
-fn detect_go(name: &str, file_path: &str) -> bool {
-    let file_name = file_path.rsplit('/').next().unwrap_or(file_path);
-    (name.starts_with("Test") || name.starts_with("Fuzz") || name.starts_with("Example"))
-        && file_name.ends_with("_test.go")
-}
-
-fn detect_js_ts(name: &str, file_path: &str) -> bool {
-    let is_test_fn = matches!(name, "describe" | "it" | "test");
-    let file_name = file_path.rsplit('/').next().unwrap_or(file_path);
-    let in_test_file =
-        file_name.contains(".test.") || file_name.contains(".spec.") || is_test_path(file_path);
-    is_test_fn && in_test_file
-}
-
-fn detect_ruby(name: &str, file_path: &str) -> bool {
-    name.starts_with("test_") && is_test_path(file_path)
-}
-
-fn detect_swift(name: &str, file_path: &str) -> bool {
-    is_test_path(file_path)
-        && (name.starts_with("test")
-            || matches!(
-                name,
-                "setUp" | "tearDown" | "setUpWithError" | "tearDownWithError"
-            ))
-}
-
-fn detect_elixir(name: &str, file_path: &str) -> bool {
-    name.starts_with("test_") || name.starts_with("test ") || is_test_path(file_path)
-}
-
-fn detect_php_convention(name: &str, file_path: &str, doc_comment: Option<&str>) -> bool {
-    if let Some(doc) = doc_comment {
-        if doc.contains("@test") {
-            return true;
-        }
-    }
-    name.starts_with("test") && is_test_path(file_path)
-}
-
-fn detect_python_convention(name: &str) -> bool {
-    if matches!(name, "setUp" | "tearDown" | "setUpClass" | "tearDownClass") {
-        return true;
-    }
-    name.starts_with("test_")
-}
-
-fn detect_scala_convention(name: &str, file_path: &str) -> bool {
-    if is_test_path(file_path) {
-        return true;
-    }
-    name.starts_with("test")
-}
-
-fn detect_generic(name: &str, file_path: &str) -> bool {
-    let has_test_name = name.starts_with("test_") || name.starts_with("Test");
-    has_test_name && is_test_path(file_path)
-}
 ```
 
-**Step 4: Wire up the module**
-
-In `crates/julie-extractors/src/lib.rs`, add after line 41 (`pub mod test_detection`):
+Add to `crates/julie-extractors/src/lib.rs` re-exports:
 
 ```rust
-pub mod test_roles;
+pub use base::TestRole;
 ```
 
-And add to the re-exports (after line 90):
+**Step 3: Replace AnnotationClassesConfig**
 
-```rust
-pub use test_roles::{TestRole, TestRoleConfig, classify_test_role, init_test_role_configs, get_role_config};
-```
-
-**Step 5: Run tests, verify they pass**
-
-```bash
-cargo nextest run --lib classify_csharp 2>&1 | tail -10
-cargo nextest run --lib classify_go_test 2>&1 | tail -5
-cargo nextest run --lib classify_regular 2>&1 | tail -5
-```
-
-**Step 6: Commit**
-
-```bash
-git add crates/julie-extractors/src/test_roles.rs crates/julie-extractors/src/lib.rs crates/julie-extractors/src/tests/test_detection.rs
-git commit -m "feat(extractors): add TestRole enum, TestRoleConfig, and classify_test_role
-
-Introduces config-driven test role classification with five roles:
-TestCase, ParameterizedTest, FixtureSetup, FixtureTeardown, TestContainer.
-
-Uses OnceLock global for config storage to avoid threading through
-30+ extraction pipeline function signatures. Falls back to
-convention-based detection for languages without annotation configs."
-```
-
----
-
-### Task 2: Update AnnotationClassesConfig and all language TOMLs
-
-**Files:**
-- Modify: `src/search/language_config.rs:73-88` (replace flat test/fixture with TestAnnotationClasses)
-- Modify: `src/search/language_config.rs:248-456` (update tests)
-- Modify: `languages/java.toml`
-- Modify: `languages/kotlin.toml`
-- Modify: `languages/csharp.toml`
-- Modify: `languages/python.toml`
-- Modify: `languages/rust.toml`
-- Modify: `languages/typescript.toml`
-- Modify: `languages/javascript.toml`
-- Modify: `languages/php.toml` (if exists, otherwise create section)
-- Modify: `languages/scala.toml` (if exists, otherwise create section)
-- Modify: `languages/dart.toml` (if exists, otherwise create section)
-- Modify: `languages/vbnet.toml` (if exists, otherwise create section)
-- Modify: `languages/razor.toml` (if exists, otherwise create section)
-
-**Step 1: Write failing test**
-
-Update `src/search/language_config.rs` test `test_embedded_language_configs_include_expected_annotation_classes` to expect the new structure:
-
-```rust
-#[test]
-fn test_annotation_classes_use_role_taxonomy() {
-    let configs = LanguageConfigs::load_embedded();
-    let csharp = configs.get("csharp").expect("csharp config");
-
-    // xUnit
-    assert!(csharp.annotation_classes.test.test_case.contains(&"fact".to_string()));
-    // NUnit
-    assert!(csharp.annotation_classes.test.test_case.contains(&"test".to_string()));
-    // MSTest
-    assert!(csharp.annotation_classes.test.test_case.contains(&"testmethod".to_string()));
-
-    // Fixtures are NOT in test_case
-    assert!(!csharp.annotation_classes.test.test_case.contains(&"setup".to_string()));
-
-    // Fixtures are in fixture_setup
-    assert!(csharp.annotation_classes.test.fixture_setup.contains(&"setup".to_string()));
-    assert!(csharp.annotation_classes.test.fixture_setup.contains(&"onetimesetup".to_string()));
-
-    // Teardown
-    assert!(csharp.annotation_classes.test.fixture_teardown.contains(&"teardown".to_string()));
-
-    // Parameterized
-    assert!(csharp.annotation_classes.test.parameterized_test.contains(&"theory".to_string()));
-
-    // Containers
-    assert!(csharp.annotation_classes.test.test_container.contains(&"testfixture".to_string()));
-}
-
-#[test]
-fn test_java_role_taxonomy_covers_junit4_and_5() {
-    let configs = LanguageConfigs::load_embedded();
-    let java = configs.get("java").expect("java config");
-
-    // JUnit 5
-    assert!(java.annotation_classes.test.test_case.contains(&"test".to_string()));
-    assert!(java.annotation_classes.test.test_case.contains(&"repeatedtest".to_string()));
-    assert!(java.annotation_classes.test.parameterized_test.contains(&"parameterizedtest".to_string()));
-
-    // JUnit 4 fixtures
-    assert!(java.annotation_classes.test.fixture_setup.contains(&"before".to_string()));
-    assert!(java.annotation_classes.test.fixture_setup.contains(&"beforeclass".to_string()));
-
-    // JUnit 5 fixtures
-    assert!(java.annotation_classes.test.fixture_setup.contains(&"beforeeach".to_string()));
-    assert!(java.annotation_classes.test.fixture_setup.contains(&"beforeall".to_string()));
-
-    // Teardown (both versions)
-    assert!(java.annotation_classes.test.fixture_teardown.contains(&"aftereach".to_string()));
-    assert!(java.annotation_classes.test.fixture_teardown.contains(&"after".to_string()));
-}
-
-#[test]
-fn test_python_fixture_classified_correctly() {
-    let configs = LanguageConfigs::load_embedded();
-    let python = configs.get("python").expect("python config");
-
-    // pytest.fixture is fixture_setup, not test_case
-    assert!(python.annotation_classes.test.fixture_setup.contains(&"pytest.fixture".to_string()));
-    assert!(!python.annotation_classes.test.test_case.contains(&"pytest.fixture".to_string()));
-}
-
-#[test]
-fn test_languages_without_test_annotations_have_empty_sections() {
-    let configs = LanguageConfigs::load_embedded();
-    let go = configs.get("go").expect("go config");
-
-    assert!(go.annotation_classes.test.test_case.is_empty());
-    assert!(go.annotation_classes.test.fixture_setup.is_empty());
-}
-```
-
-**Step 2: Run test, verify it fails**
-
-```bash
-cargo nextest run --lib test_annotation_classes_use_role 2>&1 | tail -5
-```
-
-**Step 3: Update AnnotationClassesConfig in language_config.rs**
-
-Replace `AnnotationClassesConfig` at `src/search/language_config.rs:73-88`:
+In `src/search/language_config.rs`, replace the flat `test`/`fixture` fields:
 
 ```rust
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -540,382 +126,277 @@ pub struct AnnotationClassesConfig {
 
 **Step 4: Update all language TOML files**
 
-Replace `[annotation_classes]` sections. Each language's complete `[annotation_classes]` and `[annotation_classes.test]` sections are specified in the design doc at `docs/plans/2026-04-24-test-intelligence-foundation-design.md` Part 2. Copy them verbatim.
+Replace `[annotation_classes]` sections with role-classified entries per the design doc Part 2. Key changes:
+- `test` and `fixture` flat lists become `[annotation_classes.test]` table with five role fields
+- `@DataProvider` excluded from all languages (annotates data method, not test)
+- See design doc for complete per-language specifications
 
-For languages that currently have flat `test = [...]` and `fixture = [...]` fields, these must be replaced with the nested `[annotation_classes.test]` table.
+**Step 5: Fix existing tests**
 
-Example for `languages/csharp.toml` - replace existing annotation_classes:
+Update tests that reference `config.annotation_classes.test` (was `Vec<String>`, now `TestAnnotationClasses`) and `config.annotation_classes.fixture` (removed, split into fixture_setup/fixture_teardown).
 
-```toml
-[annotation_classes]
-entrypoint = [
-    "apicontroller",
-    "route",
-    "httpget",
-    "httppost",
-    "httpput",
-    "httpdelete",
-    "httppatch",
-]
-auth = ["authorize"]
-auth_bypass = ["allowanonymous"]
-
-[annotation_classes.test]
-test_case = ["fact", "test", "testmethod"]
-parameterized_test = ["theory", "testcase", "testcasesource", "datatestmethod"]
-fixture_setup = ["setup", "onetimesetup", "testinitialize", "classinitialize", "assemblyinitialize"]
-fixture_teardown = ["teardown", "onetimeteardown", "testcleanup", "classcleanup", "assemblycleanup"]
-test_container = ["testfixture", "testclass", "collection", "collectiondefinition"]
-```
-
-For languages WITHOUT test annotations (go, c, cpp, lua, zig, etc.), no `[annotation_classes.test]` section is needed; the `#[serde(default)]` produces empty vecs.
-
-**Step 5: Update existing tests in language_config.rs**
-
-The existing test `test_language_config_defaults_empty_annotation_sections` checks `config.annotation_classes.test.is_empty()` which won't compile since `test` is now `TestAnnotationClasses`, not `Vec<String>`. Update:
-
-```rust
-assert!(config.annotation_classes.test.test_case.is_empty());
-assert!(config.annotation_classes.test.fixture_setup.is_empty());
-```
-
-The test `test_language_config_loads_populated_annotation_sections` and `test_embedded_language_configs_include_expected_annotation_classes` need similar updates. Replace assertions that check the old flat `test`/`fixture` fields with assertions against the new role fields.
-
-**Step 6: Fix early_warnings.rs annotation_sets function**
-
-The `annotation_sets` function in `src/analysis/early_warnings.rs:318-340` reads `config.annotation_classes.test` and `config.annotation_classes.fixture`. It only uses these fields indirectly through `AnnotationSets.auth` (not test/fixture). Verify it doesn't reference the old flat fields. Currently it does NOT read test/fixture, so no change needed here.
-
-**Step 7: Run tests, verify they pass**
+**Step 6: Run tests, commit**
 
 ```bash
 cargo nextest run --lib test_annotation_classes 2>&1 | tail -10
-cargo nextest run --lib test_java_role 2>&1 | tail -5
-cargo nextest run --lib test_python_fixture 2>&1 | tail -5
 cargo nextest run --lib test_language_config 2>&1 | tail -10
 ```
 
-**Step 8: Commit**
-
 ```bash
-git add src/search/language_config.rs languages/*.toml
-git commit -m "feat(config): replace flat test/fixture with role taxonomy
+git add crates/julie-extractors/src/base/types.rs crates/julie-extractors/src/lib.rs \
+       src/search/language_config.rs languages/*.toml
+git commit -m "feat: add TestRole enum and role-classified annotation config
 
-AnnotationClassesConfig.test is now TestAnnotationClasses with five
-role fields: test_case, parameterized_test, fixture_setup,
-fixture_teardown, test_container.
-
-All 10 applicable language TOMLs updated with comprehensive
-framework-specific role classifications covering xUnit/NUnit/MSTest
-(C#), JUnit 4/5/TestNG (Java/Kotlin), pytest (Python), PHPUnit,
-and framework-specific annotations for Rust, Scala, Dart, VB.NET."
+TestRole (TestCase, ParameterizedTest, FixtureSetup, FixtureTeardown,
+TestContainer) as shared type in extractors crate. AnnotationClassesConfig
+replaces flat test/fixture with TestAnnotationClasses. All applicable
+language TOMLs updated with comprehensive framework coverage."
 ```
 
 ---
 
-### Task 3: Build TestRoleConfig from LanguageConfigs and init at startup
+### Task 2: Add TestRoleConfig and build from LanguageConfigs
 
 **Files:**
-- Modify: `src/search/language_config.rs` (add `build_test_role_configs` method)
-- Modify: `src/handler.rs` or `src/tools/workspace/indexing/pipeline.rs` (call init at startup)
-- Test: `src/search/language_config.rs` (test the builder)
+- Create: `src/analysis/test_roles.rs` (TestRoleConfig, classify_test_role, helpers)
+- Modify: `src/analysis/mod.rs` (add module)
+- Modify: `src/search/language_config.rs` (add build_test_role_configs)
+- Test: new test file or inline tests
 
-**Step 1: Write failing test**
+**What to build:** `TestRoleConfig` struct (annotation-key sets per role), a builder that constructs configs from `LanguageConfigs`, and the `classify_test_role()` function that operates on fully-extracted `Symbol` structs.
+
+**Step 1: Write failing tests**
 
 ```rust
 #[test]
-fn test_build_test_role_configs_from_language_configs() {
-    let configs = LanguageConfigs::load_embedded();
-    let role_configs = configs.build_test_role_configs();
+fn test_classify_csharp_fact_as_test_case() {
+    let config = make_csharp_role_config();
+    let symbol = make_symbol("MyTest", SymbolKind::Method, "src/Tests/Test.cs",
+        vec![annotation_marker("fact")]);
+    let role = classify_test_role(&symbol, Some(&config));
+    assert_eq!(role, Some(TestRole::TestCase));
+}
 
-    let csharp = role_configs.get("csharp").expect("csharp role config");
-    assert!(csharp.test_case.contains("fact"));
-    assert!(csharp.fixture_setup.contains("setup"));
-    assert!(!csharp.test_case.contains("setup"));
+#[test]
+fn test_classify_setup_as_fixture() {
+    let config = make_csharp_role_config();
+    let symbol = make_symbol("SetUp", SymbolKind::Method, "src/Tests/Test.cs",
+        vec![annotation_marker("setup")]);
+    let role = classify_test_role(&symbol, Some(&config));
+    assert_eq!(role, Some(TestRole::FixtureSetup));
+}
 
-    let java = role_configs.get("java").expect("java role config");
-    assert!(java.test_case.contains("test"));
-    assert!(java.fixture_setup.contains("beforeeach"));
-    assert!(java.fixture_teardown.contains("aftereach"));
+#[test]
+fn test_classify_regular_method_returns_none() {
+    let config = make_csharp_role_config();
+    let symbol = make_symbol("Process", SymbolKind::Method, "src/Service.cs", vec![]);
+    let role = classify_test_role(&symbol, Some(&config));
+    assert_eq!(role, None);
+}
 
-    // Go has no test annotations, should have empty config
-    let go = role_configs.get("go").expect("go role config");
-    assert!(go.test_case.is_empty());
+#[test]
+fn test_convention_fallback_for_go() {
+    let symbol = make_symbol("TestFoo", SymbolKind::Function, "pkg/handler_test.go", vec![]);
+    // No config for Go; falls back to is_test_symbol convention detection
+    let role = classify_test_role(&symbol, None);
+    assert_eq!(role, Some(TestRole::TestCase));
+}
+
+#[test]
+fn test_is_scorable_true_for_test_case() {
+    assert!(TestRole::TestCase.is_scorable());
+    assert!(TestRole::ParameterizedTest.is_scorable());
+}
+
+#[test]
+fn test_is_scorable_false_for_fixture() {
+    assert!(!TestRole::FixtureSetup.is_scorable());
+    assert!(!TestRole::FixtureTeardown.is_scorable());
+    assert!(!TestRole::TestContainer.is_scorable());
 }
 ```
 
-**Step 2: Implement build_test_role_configs**
-
-Add to `LanguageConfigs` impl in `src/search/language_config.rs`:
+**Step 2: Implement src/analysis/test_roles.rs**
 
 ```rust
-pub fn build_test_role_configs(&self) -> HashMap<String, julie_extractors::TestRoleConfig> {
-    self.configs
-        .iter()
-        .map(|(lang, config)| {
-            let tc = &config.annotation_classes.test;
-            let role_config = julie_extractors::TestRoleConfig {
-                test_case: tc.test_case.iter().cloned().collect(),
-                parameterized_test: tc.parameterized_test.iter().cloned().collect(),
-                fixture_setup: tc.fixture_setup.iter().cloned().collect(),
-                fixture_teardown: tc.fixture_teardown.iter().cloned().collect(),
-                test_container: tc.test_container.iter().cloned().collect(),
-            };
-            (lang.clone(), role_config)
-        })
-        .collect()
+use std::collections::HashSet;
+use crate::extractors::{Symbol, SymbolKind, TestRole};
+
+#[derive(Debug, Clone, Default)]
+pub struct TestRoleConfig {
+    pub test_case: HashSet<String>,
+    pub parameterized_test: HashSet<String>,
+    pub fixture_setup: HashSet<String>,
+    pub fixture_teardown: HashSet<String>,
+    pub test_container: HashSet<String>,
 }
-```
 
-**Step 3: Init at server startup**
+impl TestRoleConfig {
+    pub fn classify_annotation(&self, annotation_key: &str) -> Option<TestRole> {
+        if self.test_case.contains(annotation_key) {
+            Some(TestRole::TestCase)
+        } else if self.parameterized_test.contains(annotation_key) {
+            Some(TestRole::ParameterizedTest)
+        } else if self.fixture_setup.contains(annotation_key) {
+            Some(TestRole::FixtureSetup)
+        } else if self.fixture_teardown.contains(annotation_key) {
+            Some(TestRole::FixtureTeardown)
+        } else if self.test_container.contains(annotation_key) {
+            Some(TestRole::TestContainer)
+        } else {
+            None
+        }
+    }
+}
 
-Find where `LanguageConfigs::load_embedded()` is called in the server (likely `handler.rs` or during `JulieServerHandler` construction). After loading, add:
+fn is_callable(kind: &SymbolKind) -> bool {
+    matches!(kind, SymbolKind::Function | SymbolKind::Method | SymbolKind::Constructor)
+}
 
-```rust
-let role_configs = language_configs.build_test_role_configs();
-julie_extractors::init_test_role_configs(role_configs);
-```
+fn is_container_kind(kind: &SymbolKind) -> bool {
+    matches!(kind, SymbolKind::Class | SymbolKind::Struct | SymbolKind::Module | SymbolKind::Namespace)
+}
 
-Use `deep_dive(symbol="load_embedded")` to find the exact call site and add the init there.
+pub fn classify_test_role(
+    symbol: &Symbol,
+    role_config: Option<&TestRoleConfig>,
+) -> Option<TestRole> {
+    // Config-driven classification from annotations
+    if let Some(config) = role_config {
+        for annotation in &symbol.annotations {
+            if let Some(role) = config.classify_annotation(&annotation.annotation_key) {
+                if role == TestRole::TestContainer && is_container_kind(&symbol.kind) {
+                    return Some(role);
+                }
+                if role != TestRole::TestContainer && is_callable(&symbol.kind) {
+                    return Some(role);
+                }
+            }
+        }
+    }
 
-**Step 4: Run tests, verify pass**
+    // Fall back to extractor's is_test decision (convention-based languages)
+    let extractor_says_test = symbol.metadata.as_ref()
+        .and_then(|m| m.get("is_test"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
-```bash
-cargo nextest run --lib test_build_test_role 2>&1 | tail -10
-```
+    if extractor_says_test && is_callable(&symbol.kind) {
+        return Some(TestRole::TestCase);
+    }
 
-**Step 5: Commit**
+    None
+}
 
-```bash
-git add src/search/language_config.rs src/handler.rs
-git commit -m "feat(config): build TestRoleConfig from TOML and init at startup
-
-LanguageConfigs::build_test_role_configs() converts TOML role
-taxonomy into the extractors crate's TestRoleConfig format.
-Initialized via OnceLock at server startup."
-```
-
----
-
-## Session 2: Config-Driven Classification
-
-### Task 4: Replace is_test_symbol with classify_test_role in all extractors
-
-**Files:**
-- Modify: 21 extractor files (see list below)
-- Modify: `crates/julie-extractors/src/test_detection.rs` (deprecate, re-export compat shim)
-- Test: existing tests in `crates/julie-extractors/src/tests/test_detection.rs`
-
-**Extractor files to update** (each has `use crate::test_detection::is_test_symbol` and 1-3 call sites):
-
-1. `crates/julie-extractors/src/bash/functions.rs:6,27`
-2. `crates/julie-extractors/src/java/methods.rs:4,84,155`
-3. `crates/julie-extractors/src/php/functions.rs:5,99`
-4. `crates/julie-extractors/src/swift/callables.rs:2,81`
-5. `crates/julie-extractors/src/lua/functions.rs:10,98`
-6. `crates/julie-extractors/src/gdscript/functions.rs:4,109`
-7. `crates/julie-extractors/src/vue/script.rs:11,95`
-8. `crates/julie-extractors/src/javascript/functions.rs:7,70,149`
-9. `crates/julie-extractors/src/python/functions.rs:6,77`
-10. `crates/julie-extractors/src/rust/functions.rs:12,118`
-11. `crates/julie-extractors/src/ruby/symbols.rs:6,161`
-12. `crates/julie-extractors/src/scala/declarations.rs:7,90`
-13. `crates/julie-extractors/src/go/functions.rs:2,61,164`
-14. `crates/julie-extractors/src/csharp/members.rs:5,73,135,187`
-15. `crates/julie-extractors/src/kotlin/declarations.rs:8,109,189`
-16. `crates/julie-extractors/src/dart/functions.rs:11,99,200,298`
-17. `crates/julie-extractors/src/qml/mod.rs:216`
-18. `crates/julie-extractors/src/elixir/calls.rs:120`
-19. `crates/julie-extractors/src/razor/csharp.rs:258`
-20. `crates/julie-extractors/src/razor/stubs.rs:145`
-21. `crates/julie-extractors/src/zig/functions.rs:40`
-
-**The pattern for each file is identical.** Here's the transformation using `rust/functions.rs` as the example:
-
-Before:
-```rust
-use crate::test_detection::is_test_symbol;
-// ...
-if is_test_symbol(
-    "rust",
-    &name,
-    &base.file_path,
-    &kind,
-    &annotation_keys,
-    None,
+/// Classify all symbols in a batch and set metadata.test_role + metadata.is_test.
+/// This is the authoritative classification step; it overrides extractor decisions.
+pub fn classify_symbols_by_role(
+    symbols: &mut [Symbol],
+    role_configs: &std::collections::HashMap<String, TestRoleConfig>,
 ) {
-    metadata.insert("is_test".to_string(), Value::Bool(true));
+    for symbol in symbols.iter_mut() {
+        let config = role_configs.get(symbol.language.as_str());
+        let role = classify_test_role(symbol, config);
+
+        let metadata = symbol.metadata.get_or_insert_with(Default::default);
+
+        if let Some(role) = role {
+            metadata.insert("test_role".into(), serde_json::Value::String(role.as_str().into()));
+            metadata.insert("is_test".into(), serde_json::Value::Bool(true));
+        } else {
+            metadata.remove("test_role");
+            // Only clear is_test if extractor didn't set it either
+            // (preserves convention-based detection for edge cases)
+        }
+    }
 }
-```
 
-After:
-```rust
-use crate::test_roles::{classify_test_role, get_role_config};
-// ...
-if let Some(role) = classify_test_role(
-    "rust",
-    &name,
-    &base.file_path,
-    &kind,
-    &annotation_keys,
-    None,
-    get_role_config("rust"),
-) {
-    metadata.insert("is_test".to_string(), Value::Bool(true));
-    metadata.insert("test_role".to_string(), Value::String(role.as_str().to_string()));
+/// True for any test-related symbol (test, fixture, container).
+/// Use for: excluding from production rankings, embeddings, search de-boosting.
+pub fn is_test_related(symbol: &Symbol) -> bool {
+    symbol.metadata.as_ref()
+        .and_then(|m| m.get("test_role"))
+        .is_some()
+    || symbol.metadata.as_ref()
+        .and_then(|m| m.get("is_test"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
 }
-```
 
-Apply this transformation to all 21 files. The language string passed to `get_role_config` must match the language string passed as the first argument (already present in each call site).
-
-**For files that pass `doc_comment`** (php/functions.rs), keep passing it:
-
-```rust
-if let Some(role) = classify_test_role(
-    "php",
-    &name,
-    &base.file_path,
-    &kind,
-    &annotation_keys,
-    doc_comment.as_deref(),
-    get_role_config("php"),
-) {
-```
-
-**Step: Add backward-compat shim to test_detection.rs**
-
-Keep `test_detection.rs` but replace the body with a delegation:
-
-```rust
-use crate::base::SymbolKind;
-use crate::test_roles::{classify_test_role, get_role_config};
-
-pub fn is_test_symbol(
-    language: &str,
-    name: &str,
-    file_path: &str,
-    kind: &SymbolKind,
-    annotation_keys: &[String],
-    doc_comment: Option<&str>,
-) -> bool {
-    classify_test_role(
-        language,
-        name,
-        file_path,
-        kind,
-        annotation_keys,
-        doc_comment,
-        get_role_config(language),
-    )
-    .is_some()
-}
-```
-
-This preserves backward compatibility for any code that still calls `is_test_symbol` (server-side `is_test_symbol_for_embedding`, etc.) while delegating to the new classify_test_role.
-
-**Step: Run full test suite for extractors**
-
-```bash
-cargo nextest run --lib tests::test_detection 2>&1 | tail -20
-```
-
-All existing tests should pass since `classify_test_role` preserves the same detection behavior.
-
-**Step: Commit**
-
-```bash
-git add crates/julie-extractors/
-git commit -m "refactor(extractors): replace is_test_symbol with classify_test_role
-
-All 21 extractor files now call classify_test_role and store both
-metadata.is_test (backward compat) and metadata.test_role (new).
-is_test_symbol retained as thin shim delegating to classify_test_role.
-Config-driven annotation classification for languages with TOML
-configs, convention-based fallback for others."
-```
-
----
-
-### Task 5: Update server-side is_test consumers and verify pipeline
-
-**Files:**
-- Modify: `src/tools/impact/mod.rs:448` (add test_role awareness)
-- Modify: `src/tools/impact/ranking.rs:106` (add test_role awareness)
-- Modify: `src/tools/deep_dive/data.rs:322` (add test_role awareness)
-- Modify: `src/tools/deep_dive/formatting.rs:186` (display test_role)
-- Test: existing tests + new integration test
-
-**What to build:** Server-side consumers currently read `metadata["is_test"]`. They continue to work unchanged (backward compat). But add `test_role` awareness where it matters:
-
-- `deep_dive` formatting: show the role (e.g., "[test_case]" or "[fixture_setup]") instead of generic "[test]"
-- `impact/ranking.rs`: separate test_case from fixture in impact sorting
-
-**Step 1: Update deep_dive formatting**
-
-In `src/tools/deep_dive/formatting.rs`, find `format_test_quality_info` (line 186). Update to include role:
-
-```rust
-fn format_test_quality_info(metadata: &serde_json::Value) -> Option<String> {
-    let tier = metadata
-        .get("test_quality")
-        .and_then(|tq| tq.get("quality_tier"))
-        .and_then(|v| v.as_str())?;
-    let role = metadata
-        .get("test_role")
+/// True only for TestCase and ParameterizedTest.
+/// Use for: quality scoring, test linkage coverage, risk assessment.
+pub fn is_scorable_test(symbol: &Symbol) -> bool {
+    symbol.metadata.as_ref()
+        .and_then(|m| m.get("test_role"))
         .and_then(|v| v.as_str())
-        .unwrap_or("test");
-    Some(format!("  [{}] [{}]", role, tier))
+        .map(|role| matches!(role, "test_case" | "parameterized_test"))
+        .unwrap_or(false)
 }
 ```
 
-**Step 2: Verify pipeline end-to-end**
+**Step 3: Add build_test_role_configs to LanguageConfigs**
 
-Write an integration test or use the fixture database to verify:
-1. Index a file containing test functions and fixtures
-2. Verify `metadata.test_role` is set correctly on extracted symbols
-3. Verify `metadata.is_test` is still set for backward compat
+In `src/search/language_config.rs`:
 
-**Step 3: Run `cargo xtask test changed`**
-
-```bash
-cargo xtask test changed 2>&1 | tail -20
+```rust
+pub fn build_test_role_configs(&self) -> HashMap<String, crate::analysis::test_roles::TestRoleConfig> {
+    self.configs.iter().map(|(lang, config)| {
+        let tc = &config.annotation_classes.test;
+        let role_config = crate::analysis::test_roles::TestRoleConfig {
+            test_case: tc.test_case.iter().cloned().collect(),
+            parameterized_test: tc.parameterized_test.iter().cloned().collect(),
+            fixture_setup: tc.fixture_setup.iter().cloned().collect(),
+            fixture_teardown: tc.fixture_teardown.iter().cloned().collect(),
+            test_container: tc.test_container.iter().cloned().collect(),
+        };
+        (lang.clone(), role_config)
+    }).collect()
+}
 ```
 
-**Step 4: Commit**
+**Step 4: Wire into pipeline**
+
+In `src/tools/workspace/indexing/pipeline.rs`, in `persist_batch` or just before it, add:
+
+```rust
+let language_configs = handler.language_configs();
+let role_configs = language_configs.build_test_role_configs();
+crate::analysis::test_roles::classify_symbols_by_role(&mut batch.all_symbols, &role_configs);
+```
+
+Use `deep_dive(symbol="persist_batch")` to find the exact insertion point. The classification must happen AFTER extraction populates annotations and BEFORE symbols are written to the database.
+
+**Step 5: Run tests, commit**
 
 ```bash
-git add src/tools/
-git commit -m "feat(tools): add test_role awareness to deep_dive and impact
+cargo nextest run --lib test_classify 2>&1 | tail -10
+cargo nextest run --lib test_is_scorable 2>&1 | tail -10
+```
 
-deep_dive displays test role alongside quality tier.
-Server-side is_test consumers continue working via backward-compat
-metadata.is_test field."
+```bash
+git add src/analysis/test_roles.rs src/analysis/mod.rs src/search/language_config.rs \
+       src/tools/workspace/indexing/pipeline.rs
+git commit -m "feat(analysis): add post-extraction test role classification
+
+classify_symbols_by_role runs in the pipeline after extraction, before
+DB write. Config-driven role classification from TOML annotations,
+with convention-based fallback from is_test_symbol. Adds is_scorable_test
+and is_test_related helpers for downstream consumers."
 ```
 
 ---
 
-## Session 3: Evidence-Based Quality Model
+## Session 2: Quality Model & Linkage
 
-### Task 6: Add TestEvidenceConfig to language configs and TOML files
+### Task 3: Add TestEvidenceConfig and update test_linkage
 
 **Files:**
-- Modify: `src/search/language_config.rs` (add TestEvidenceConfig struct)
-- Modify: `languages/rust.toml`, `languages/python.toml`, `languages/java.toml`, `languages/csharp.toml`, `languages/kotlin.toml` (add `[test_evidence]` sections)
+- Modify: `src/search/language_config.rs` (add TestEvidenceConfig)
+- Modify: `languages/*.toml` (add `[test_evidence]` sections for verified languages)
+- Modify: `src/analysis/test_linkage.rs` (use is_scorable_test, carry confidence)
+- Test: new tests for evidence config loading, test_linkage with roles
 
-**Step 1: Write failing test**
-
-```rust
-#[test]
-fn test_evidence_config_loads_from_toml() {
-    let configs = LanguageConfigs::load_embedded();
-    let rust = configs.get("rust").expect("rust config");
-    assert!(!rust.test_evidence.assertion_identifiers.is_empty());
-    assert!(rust.test_evidence.assertion_identifiers.contains(&"assert_eq".to_string()));
-}
-```
-
-**Step 2: Add TestEvidenceConfig**
-
-In `src/search/language_config.rs`, after `EarlyWarningConfig`:
+**Step 1: Add TestEvidenceConfig**
 
 ```rust
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -930,55 +411,82 @@ pub struct TestEvidenceConfig {
 ```
 
 Add to `LanguageConfig`:
-
 ```rust
 #[serde(default)]
 pub test_evidence: TestEvidenceConfig,
 ```
 
-**Step 3: Populate TOML files**
+**Step 2: Populate TOML files with test_evidence sections**
 
-Add `[test_evidence]` sections per the design doc Part 7. Start with the 5 most-used languages. Before populating each language, verify identifier extraction:
+Per design doc Part 7. Before adding each language, verify identifier extraction:
 
 ```bash
-# Verify Rust assertion identifiers are extracted
-./target/debug/julie-server search "assert_eq" --target definitions --workspace . --standalone --json 2>/dev/null | head -5
+# Verify assertion identifiers appear as Call-kind identifiers
+./target/debug/julie-server search "assert_eq" --workspace . --standalone --json 2>/dev/null | head -5
 ```
 
-The verification step is critical: if `assert_eq` doesn't appear as an identifier for Rust (it's a macro), document this gap and use regex fallback for Rust.
+**Step 3: Update test_linkage to use is_scorable_test**
 
-**Step 4: Commit**
+In `src/analysis/test_linkage.rs`, the SQL queries filter on `json_extract(s_test.metadata, '$.is_test') = 1`. Update to also check `test_role`:
+
+```sql
+WHERE (json_extract(s_test.metadata, '$.test_role') IN ('test_case', 'parameterized_test')
+       OR (json_extract(s_test.metadata, '$.is_test') = 1
+           AND json_extract(s_test.metadata, '$.test_role') IS NULL))
+```
+
+This uses scorable tests for linkage while maintaining backward compat for symbols without test_role (convention-based languages where is_test_symbol set is_test but no role classification happened).
+
+**Step 4: Carry confidence through test_linkage**
+
+When `test_linkage` aggregates quality info for a production symbol, include confidence:
+
+```rust
+let linkage_info = serde_json::json!({
+    "test_count": test_count,
+    "best_tier": best_tier,
+    "worst_tier": worst_tier,
+    "best_confidence": best_confidence,  // NEW: from test_quality.confidence
+    "linked_tests": names,
+    "linked_test_paths": paths,
+    "evidence_sources": evidence_sources,
+});
+```
+
+Read `best_confidence` from the linked test's `metadata.test_quality.confidence`. If not present (old data), default to `0.5`.
+
+**Step 5: Run tests, commit**
 
 ```bash
-git add src/search/language_config.rs languages/*.toml
-git commit -m "feat(config): add test_evidence TOML sections for assertion identifiers
+cargo nextest run --lib test_evidence_config 2>&1 | tail -5
+cargo nextest run --lib test_linkage 2>&1 | tail -10
+```
 
-TestEvidenceConfig with assertion_identifiers, error_assertion_identifiers,
-and mock_identifiers. Populated for Rust, Python, Java, C#, Kotlin.
-Identifier extraction verified per language."
+```bash
+git add src/search/language_config.rs src/analysis/test_linkage.rs languages/*.toml
+git commit -m "feat: add test_evidence config, update test_linkage for scorable tests
+
+TestEvidenceConfig with framework-specific assertion/mock/error identifiers.
+test_linkage uses is_scorable_test (excludes fixtures from coverage).
+Confidence carried through linkage aggregation for downstream consumption."
 ```
 
 ---
 
-### Task 7: Rewrite test_quality.rs with evidence model
+### Task 4: Rewrite test_quality with evidence model
 
 **Files:**
 - Modify: `src/analysis/test_quality.rs` (replace regex oracle)
 - Modify: `src/analysis/mod.rs` (update re-exports)
 - Test: `src/tests/analysis/test_quality_tests.rs` (rewrite tests)
 
-**Step 1: Write failing tests for the new model**
+**Step 1: Write failing tests**
 
 ```rust
-use crate::analysis::test_quality::{TestQualityAssessment, TestQualityTier, EvidenceSource};
-
 #[test]
 fn test_fixture_is_not_applicable() {
-    let assessment = analyze_with_role(
-        "fixture_setup",  // role
-        "fn setUp() { db.reset(); }",  // body
-        0,  // assertion_identifier_count
-        EvidenceSource::None,
+    let assessment = assess_test_quality(
+        Some("fixture_setup"), None, 0, 0, 0, false,
     );
     assert_eq!(assessment.tier, TestQualityTier::NotApplicable);
     assert_eq!(assessment.confidence, 1.0);
@@ -986,329 +494,56 @@ fn test_fixture_is_not_applicable() {
 
 #[test]
 fn test_empty_body_is_stub() {
-    let assessment = analyze_with_role(
-        "test_case",
-        "",
-        0,
-        EvidenceSource::None,
+    let assessment = assess_test_quality(
+        Some("test_case"), Some(""), 0, 0, 0, false,
     );
     assert_eq!(assessment.tier, TestQualityTier::Stub);
     assert_eq!(assessment.confidence, 1.0);
 }
 
 #[test]
-fn test_identifier_based_thorough() {
-    let assessment = analyze_with_role(
-        "test_case",
-        "fn test_foo() { assert_eq!(a, b); assert_ne!(c, d); assert!(e); should_err(); }",
-        3,  // 3 assertion identifiers found
-        EvidenceSource::Identifier,
+fn test_identifier_thorough_high_confidence() {
+    let assessment = assess_test_quality(
+        Some("test_case"),
+        Some("fn test_foo() { assert_eq!(a, b); assert_ne!(c, d); assert!(e); should_err(); }"),
+        3, 1, 0, true,
     );
     assert_eq!(assessment.tier, TestQualityTier::Thorough);
     assert!(assessment.confidence >= 0.85);
 }
 
 #[test]
-fn test_regex_zero_assertions_is_unknown_not_stub() {
-    let assessment = analyze_with_role(
-        "test_case",
-        "fn test_foo() { let x = compute(); println!(\"{}\", x); }",
-        0,
-        EvidenceSource::Regex,
+fn test_regex_zero_assertions_is_unknown() {
+    let assessment = assess_test_quality(
+        Some("test_case"),
+        Some("fn test_foo() { let x = compute(); println!(\"{}\", x); }"),
+        0, 0, 0, false, // no identifier evidence, will use regex fallback
     );
+    // Regex finds zero assertions -> Unknown, not Stub
     assert_eq!(assessment.tier, TestQualityTier::Unknown);
 }
 ```
 
-**Step 2: Implement the new evidence model**
+**Step 2: Implement evidence model**
 
-Replace the core of `src/analysis/test_quality.rs`. Keep `strip_comments_and_strings` (it's well-implemented and needed for regex fallback). Replace `analyze_test_body` and `classify_tier`:
+Replace `analyze_test_body` and `classify_tier` with `assess_test_quality`. Keep `strip_comments_and_strings` for regex fallback. Full implementation per the design doc Part 4, with these corrections from review:
 
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct TestQualityAssessment {
-    pub tier: TestQualityTier,
-    pub confidence: f32,
-    pub evidence: QualityEvidence,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum TestQualityTier {
-    Thorough,
-    Adequate,
-    Thin,
-    Stub,
-    Unknown,
-    NotApplicable,
-}
-
-impl TestQualityTier {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Thorough => "thorough",
-            Self::Adequate => "adequate",
-            Self::Thin => "thin",
-            Self::Stub => "stub",
-            Self::Unknown => "unknown",
-            Self::NotApplicable => "n/a",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct QualityEvidence {
-    pub assertion_count: u32,
-    pub assertion_source: EvidenceSource,
-    pub has_error_testing: bool,
-    pub mock_count: u32,
-    pub body_lines: u32,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum EvidenceSource {
-    Identifier,
-    Regex,
-    None,
-}
-
-pub fn assess_test_quality(
-    test_role: Option<&str>,
-    body: Option<&str>,
-    identifier_assertion_count: u32,
-    identifier_error_count: u32,
-    identifier_mock_count: u32,
-    has_identifier_evidence: bool,
-) -> TestQualityAssessment {
-    // Fixtures and containers are not scored
-    if matches!(test_role, Some("fixture_setup") | Some("fixture_teardown") | Some("test_container")) {
-        return TestQualityAssessment {
-            tier: TestQualityTier::NotApplicable,
-            confidence: 1.0,
-            evidence: QualityEvidence {
-                assertion_count: 0,
-                assertion_source: EvidenceSource::None,
-                has_error_testing: false,
-                mock_count: 0,
-                body_lines: 0,
-            },
-        };
-    }
-
-    // No body or placeholder body
-    let body = match body {
-        Some(b) if !is_placeholder_body(b) => b,
-        _ => {
-            return TestQualityAssessment {
-                tier: TestQualityTier::Stub,
-                confidence: 1.0,
-                evidence: QualityEvidence {
-                    assertion_count: 0,
-                    assertion_source: EvidenceSource::None,
-                    has_error_testing: false,
-                    mock_count: 0,
-                    body_lines: 0,
-                },
-            };
-        }
-    };
-
-    let body_lines = body.lines().count() as u32;
-
-    // Prefer identifier evidence over regex
-    if has_identifier_evidence {
-        let has_error = identifier_error_count > 0;
-        let tier = classify_from_counts(identifier_assertion_count, has_error);
-        let confidence = match tier {
-            TestQualityTier::Thorough => 0.9,
-            TestQualityTier::Adequate => 0.85,
-            TestQualityTier::Thin => 0.8,
-            TestQualityTier::Stub => 0.85,
-            _ => 0.5,
-        };
-        return TestQualityAssessment {
-            tier,
-            confidence,
-            evidence: QualityEvidence {
-                assertion_count: identifier_assertion_count,
-                assertion_source: EvidenceSource::Identifier,
-                has_error_testing: has_error,
-                mock_count: identifier_mock_count,
-                body_lines,
-            },
-        };
-    }
-
-    // Regex fallback
-    let stripped = strip_comments_and_strings(body);
-    let regex_assertions = count_pattern_matches(&stripped, assertion_patterns());
-    let regex_errors = count_pattern_matches(&stripped, error_testing_patterns()) > 0;
-    let regex_mocks = count_pattern_matches(&stripped, mock_patterns());
-
-    if regex_assertions == 0 {
-        // Regex found nothing; might be a custom assertion library we don't know about
-        return TestQualityAssessment {
-            tier: TestQualityTier::Unknown,
-            confidence: 0.3,
-            evidence: QualityEvidence {
-                assertion_count: 0,
-                assertion_source: EvidenceSource::Regex,
-                has_error_testing: false,
-                mock_count: regex_mocks as u32,
-                body_lines,
-            },
-        };
-    }
-
-    let tier = classify_from_counts(regex_assertions as u32, regex_errors);
-    let confidence = match tier {
-        TestQualityTier::Thorough => 0.5,
-        TestQualityTier::Adequate => 0.45,
-        TestQualityTier::Thin => 0.4,
-        _ => 0.3,
-    };
-    TestQualityAssessment {
-        tier,
-        confidence,
-        evidence: QualityEvidence {
-            assertion_count: regex_assertions as u32,
-            assertion_source: EvidenceSource::Regex,
-            has_error_testing: regex_errors,
-            mock_count: regex_mocks as u32,
-            body_lines,
-        },
-    }
-}
-
-fn classify_from_counts(assertion_count: u32, has_error_testing: bool) -> TestQualityTier {
-    if assertion_count >= 3 && has_error_testing {
-        TestQualityTier::Thorough
-    } else if assertion_count >= 2 {
-        TestQualityTier::Adequate
-    } else if assertion_count >= 1 {
-        TestQualityTier::Thin
-    } else {
-        TestQualityTier::Stub
-    }
-}
-
-fn is_placeholder_body(body: &str) -> bool {
-    let trimmed = body.trim();
-    trimmed.is_empty()
-        || trimmed == "pass"
-        || trimmed == "..."
-        || trimmed.starts_with("todo!(")
-        || trimmed.starts_with("unimplemented!(")
-        || trimmed.starts_with("// TODO")
-        || trimmed.starts_with("# TODO")
-}
-```
+- `TestQualityTier::NotApplicable` for fixtures/teardown/containers
+- `TestQualityTier::Unknown` for regex-found-nothing (not false `Stub`)
+- Confidence scores on every tier
 
 **Step 3: Update compute_test_quality_metrics**
 
-The pipeline function `compute_test_quality_metrics` needs to:
-1. Read `test_role` from symbol metadata (not just `is_test`)
-2. Query identifier counts from the database for each test
-3. Call `assess_test_quality` with identifier evidence
-4. Store the new assessment format in metadata
+The pipeline function now:
+1. Reads `test_role` from symbol metadata
+2. Queries identifiers WHERE `kind = 'Call'` AND `containing_symbol_id = ?test_id`
+3. Matches against `TestEvidenceConfig` assertion/error/mock identifier lists
+4. Calls `assess_test_quality` with identifier evidence
+5. Stores assessment with `confidence` field in metadata
+
+The identifier query MUST filter on `kind = 'Call'`:
 
 ```rust
-pub fn compute_test_quality_metrics(
-    db: &SymbolDatabase,
-    language_configs: &LanguageConfigs,
-) -> Result<TestQualityStats> {
-    let mut stats = TestQualityStats::default();
-
-    let mut stmt = db.conn.prepare(
-        "SELECT id, code_context, metadata, language FROM symbols
-         WHERE json_extract(metadata, '$.is_test') = 1",
-    )?;
-
-    let rows: Vec<(String, Option<String>, Option<String>, String)> = stmt
-        .query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, Option<String>>(1)?,
-                row.get::<_, Option<String>>(2)?,
-                row.get::<_, String>(3)?,
-            ))
-        })?
-        .filter_map(|r| r.ok())
-        .collect();
-
-    db.conn.execute_batch("BEGIN")?;
-    let result = (|| -> Result<()> {
-        for (id, code_context, metadata_str, language) in &rows {
-            let test_role = metadata_str
-                .as_ref()
-                .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
-                .and_then(|v| v.get("test_role")?.as_str().map(String::from));
-
-            // Query identifier evidence
-            let evidence_config = language_configs
-                .get(language)
-                .map(|c| &c.test_evidence);
-
-            let (id_assertions, id_errors, id_mocks, has_id_evidence) =
-                if let Some(config) = evidence_config {
-                    query_identifier_evidence(db, id, config)?
-                } else {
-                    (0, 0, 0, false)
-                };
-
-            let assessment = assess_test_quality(
-                test_role.as_deref(),
-                code_context.as_deref(),
-                id_assertions,
-                id_errors,
-                id_mocks,
-                has_id_evidence,
-            );
-
-            // Update stats
-            stats.total_tests += 1;
-            match assessment.tier {
-                TestQualityTier::Thorough => stats.thorough += 1,
-                TestQualityTier::Adequate => stats.adequate += 1,
-                TestQualityTier::Thin => stats.thin += 1,
-                TestQualityTier::Stub => stats.stub += 1,
-                TestQualityTier::Unknown | TestQualityTier::NotApplicable => {}
-            }
-
-            // Merge assessment into metadata
-            let quality_json = serde_json::json!({
-                "quality_tier": assessment.tier.as_str(),
-                "confidence": assessment.confidence,
-                "assertion_count": assessment.evidence.assertion_count,
-                "assertion_source": format!("{:?}", assessment.evidence.assertion_source).to_lowercase(),
-                "has_error_testing": assessment.evidence.has_error_testing,
-                "mock_count": assessment.evidence.mock_count,
-                "body_lines": assessment.evidence.body_lines,
-            });
-
-            db.conn.execute(
-                "UPDATE symbols SET metadata = json_set(
-                    COALESCE(metadata, '{}'),
-                    '$.test_quality', json(?1)
-                ) WHERE id = ?2",
-                rusqlite::params![quality_json.to_string(), id],
-            )?;
-        }
-        Ok(())
-    })();
-
-    match result {
-        Ok(()) => db.conn.execute_batch("COMMIT")?,
-        Err(e) => {
-            let _ = db.conn.execute_batch("ROLLBACK");
-            return Err(e);
-        }
-    }
-
-    Ok(stats)
-}
-
 fn query_identifier_evidence(
     db: &SymbolDatabase,
     symbol_id: &str,
@@ -1318,9 +553,8 @@ fn query_identifier_evidence(
         return Ok((0, 0, 0, false));
     }
 
-    let names: Vec<String> = db
-        .conn
-        .prepare("SELECT LOWER(name) FROM identifiers WHERE containing_symbol_id = ?1")?
+    let names: Vec<String> = db.conn
+        .prepare("SELECT LOWER(name) FROM identifiers WHERE containing_symbol_id = ?1 AND kind = 'Call'")?
         .query_map([symbol_id], |row| row.get::<_, String>(0))?
         .filter_map(|r| r.ok())
         .collect();
@@ -1329,12 +563,9 @@ fn query_identifier_evidence(
         return Ok((0, 0, 0, false));
     }
 
-    let assertion_set: std::collections::HashSet<&str> =
-        config.assertion_identifiers.iter().map(|s| s.as_str()).collect();
-    let error_set: std::collections::HashSet<&str> =
-        config.error_assertion_identifiers.iter().map(|s| s.as_str()).collect();
-    let mock_set: std::collections::HashSet<&str> =
-        config.mock_identifiers.iter().map(|s| s.as_str()).collect();
+    let assertion_set: HashSet<&str> = config.assertion_identifiers.iter().map(|s| s.as_str()).collect();
+    let error_set: HashSet<&str> = config.error_assertion_identifiers.iter().map(|s| s.as_str()).collect();
+    let mock_set: HashSet<&str> = config.mock_identifiers.iter().map(|s| s.as_str()).collect();
 
     let assertions = names.iter().filter(|n| assertion_set.contains(n.as_str())).count() as u32;
     let errors = names.iter().filter(|n| error_set.contains(n.as_str())).count() as u32;
@@ -1344,73 +575,67 @@ fn query_identifier_evidence(
 }
 ```
 
-**Step 4: Update analyze_batch to pass language_configs**
+**Step 4: Update analyze_batch signature**
 
-In `src/tools/workspace/indexing/pipeline.rs:627`, `compute_test_quality_metrics` now takes `language_configs`:
+`compute_test_quality_metrics` now takes `language_configs: &LanguageConfigs` to access `TestEvidenceConfig`.
 
-```rust
-let language_configs = handler.language_configs();
-if let Err(e) = crate::analysis::compute_test_quality_metrics(&db_lock, &language_configs) {
-    warn!("Failed to compute test quality metrics: {}", e);
-}
-```
-
-Find how `handler` exposes language_configs (use `deep_dive(symbol="language_configs")`) and wire it through.
-
-**Step 5: Run tests**
+**Step 5: Run tests, commit**
 
 ```bash
 cargo nextest run --lib test_fixture_is_not 2>&1 | tail -5
-cargo nextest run --lib test_empty_body_is 2>&1 | tail -5
-cargo nextest run --lib test_identifier_based 2>&1 | tail -5
+cargo nextest run --lib test_identifier_thorough 2>&1 | tail -5
 cargo nextest run --lib test_regex_zero 2>&1 | tail -5
 ```
 
-**Step 6: Commit**
-
 ```bash
-git add src/analysis/test_quality.rs src/analysis/mod.rs src/tools/workspace/indexing/pipeline.rs src/tests/analysis/test_quality_tests.rs
+git add src/analysis/test_quality.rs src/analysis/mod.rs \
+       src/tools/workspace/indexing/pipeline.rs src/tests/analysis/test_quality_tests.rs
 git commit -m "feat(analysis): replace regex quality oracle with evidence model
 
-test_quality now uses identifier-based assertion counting against
-framework-specific config, with regex as lower-confidence fallback.
-Fixtures return NotApplicable instead of false Stub. Unknown tier
-replaces false Stub when regex finds zero assertions. All tiers
-carry confidence scores."
+Identifier-based assertion counting filtered on kind='Call' against
+framework-specific TOML config. Regex as lower-confidence fallback.
+Fixtures return NotApplicable. Unknown replaces false Stub for
+regex-found-nothing. All tiers carry confidence scores."
 ```
 
 ---
 
-## Session 4: Risk Gating & Signal Surfaces
+## Session 3: Risk Gating & Consumer Updates
 
-### Task 8: Confidence-gated change_risk
+### Task 5: Confidence-gated change_risk
 
 **Files:**
 - Modify: `src/analysis/change_risk.rs:72-81` (update test_weakness_score)
-- Modify: `src/analysis/change_risk.rs:115-238` (read confidence from metadata)
+- Modify: `src/analysis/change_risk.rs:115-238` (read confidence from test_linkage)
 - Test: `src/tests/analysis/change_risk_tests.rs`
 
-**Step 1: Write failing test**
+**Step 1: Write failing tests**
 
 ```rust
 #[test]
-fn test_weakness_score_with_high_confidence() {
+fn test_weakness_high_confidence_thorough() {
     let score = test_weakness_score(Some("thorough"), 0.9);
-    assert!((score - 0.1).abs() < 0.05); // Near the raw 0.1 for thorough
+    // raw = 0.1, confidence 0.9: 0.5 + (0.1 - 0.5) * 0.9 = 0.14
+    assert!((score - 0.14).abs() < 0.02);
 }
 
 #[test]
-fn test_weakness_score_with_low_confidence_converges_to_neutral() {
+fn test_weakness_low_confidence_converges_to_neutral() {
     let score = test_weakness_score(Some("stub"), 0.0);
-    assert!((score - 0.5).abs() < 0.01); // Should be neutral
+    assert!((score - 0.5).abs() < 0.01);
 }
 
 #[test]
-fn test_weakness_score_unknown_tier() {
+fn test_weakness_unknown_tier() {
     let score = test_weakness_score(Some("unknown"), 0.3);
-    // raw_weakness for unknown = 0.5, confidence 0.3
-    // result = 0.5 + (0.5 - 0.5) * 0.3 = 0.5
+    // raw = 0.5, any confidence: 0.5 + (0.5 - 0.5) * 0.3 = 0.5
     assert!((score - 0.5).abs() < 0.01);
+}
+
+#[test]
+fn test_weakness_no_linkage_full_penalty() {
+    let score = test_weakness_score(None, 1.0);
+    assert!((score - 1.0).abs() < 0.01);
 }
 ```
 
@@ -1428,74 +653,106 @@ pub fn test_weakness_score(best_tier: Option<&str>, confidence: f64) -> f64 {
         Some("n/a") => 0.5,
         _ => 0.5,
     };
+    let confidence = confidence.clamp(0.0, 1.0);
     let neutral = 0.5;
     neutral + (raw_weakness - neutral) * confidence
 }
 ```
 
-**Step 3: Update compute_change_risk_scores to read confidence**
+**Step 3: Read confidence from test_linkage metadata**
 
-In the query that reads `test_linkage` metadata (around line 180), also read `test_quality.confidence`:
+In `compute_change_risk_scores`, where it reads `best_tier` from `test_linkage`:
 
 ```rust
-let confidence: f64 = meta
-    .get("test_linkage")
-    .and_then(|tl| {
-        // Get linked test quality confidence
-        // For now, use 1.0 if tier is known, 0.5 for unknown
-        let tier = tl.get("best_tier")?.as_str()?;
-        match tier {
-            "thorough" | "adequate" | "thin" | "stub" => Some(0.8),
-            "unknown" => Some(0.3),
-            _ => Some(0.5),
-        }
-    })
-    .unwrap_or(1.0); // No linkage at all: full weight on "untested"
+let best_tier = meta.get("test_linkage")
+    .and_then(|tl| tl.get("best_tier"))
+    .and_then(|v| v.as_str());
+
+let confidence = meta.get("test_linkage")
+    .and_then(|tl| tl.get("best_confidence"))
+    .and_then(|v| v.as_f64())
+    .unwrap_or(0.5); // Default: moderate confidence for old data without the field
 
 let test_weak = test_weakness_score(best_tier, confidence);
 ```
 
-**Step 4: Run tests**
+**Step 4: Run tests, commit**
 
 ```bash
-cargo nextest run --lib test_weakness_score 2>&1 | tail -10
+cargo nextest run --lib test_weakness 2>&1 | tail -10
 cargo nextest run --lib test_compute_change_risk 2>&1 | tail -10
 ```
-
-**Step 5: Commit**
 
 ```bash
 git add src/analysis/change_risk.rs src/tests/analysis/change_risk_tests.rs
 git commit -m "feat(analysis): confidence-gate test weakness in change_risk
 
-test_weakness_score takes confidence parameter. Low-confidence tiers
-converge toward neutral (0.5), preventing unreliable quality
-assessments from dominating risk scores."
+test_weakness_score takes confidence from test_linkage aggregation.
+Low-confidence tiers converge toward neutral (0.5). thorough maps
+to 0.1 not 0.0 since static evidence lowers but cannot erase risk."
 ```
 
 ---
 
-### Task 9: Add scheduler signal to early_warnings
+### Task 6: Update server-side consumers
 
 **Files:**
-- Modify: `src/analysis/early_warnings.rs` (add SchedulerSignal section)
-- Test: `src/tests/analysis/` (add scheduler signal tests)
+- Modify: `src/tools/impact/mod.rs:448` (use is_test_related)
+- Modify: `src/tools/impact/ranking.rs:106` (use is_test_related)
+- Modify: `src/tools/deep_dive/data.rs:322` (use is_test_related)
+- Modify: `src/tools/deep_dive/formatting.rs:186` (display test_role)
+- Modify: `src/embeddings/metadata.rs:86` (use is_test_related)
 
-**Step 1: Write failing test**
+**What to build:** Replace raw `metadata.get("is_test")` checks with the new helpers. Display test_role in deep_dive output.
+
+The three server-side `is_test_symbol` / `symbol_is_test` functions all check `metadata["is_test"]` and fall back to `is_test_path`. Replace them with:
 
 ```rust
-#[test]
-fn test_scheduler_signal_from_annotation() {
-    // Build a symbol with a scheduler annotation
-    let symbol = test_symbol("process_daily", "java", "src/jobs/DailyJob.java",
-        vec![annotation("scheduled", "Scheduled")]);
-    // ... setup db, insert, generate report
-    assert!(!report.scheduler_signals.is_empty());
-    assert_eq!(report.scheduler_signals[0].symbol_name, "process_daily");
+use crate::analysis::test_roles::is_test_related;
+
+fn is_test_symbol(symbol: &Symbol) -> bool {
+    is_test_related(symbol) || is_test_path(&symbol.file_path)
 }
 ```
 
-**Step 2: Add SchedulerSignal to report structs**
+Update deep_dive formatting to show role:
+
+```rust
+fn format_test_quality_info(metadata: &serde_json::Value) -> Option<String> {
+    let tier = metadata.get("test_quality")
+        .and_then(|tq| tq.get("quality_tier"))
+        .and_then(|v| v.as_str())?;
+    let role = metadata.get("test_role")
+        .and_then(|v| v.as_str())
+        .unwrap_or("test");
+    let confidence = metadata.get("test_quality")
+        .and_then(|tq| tq.get("confidence"))
+        .and_then(|v| v.as_f64());
+    match confidence {
+        Some(c) => Some(format!("  [{}] [{} confidence:{:.0}%]", role, tier, c * 100.0)),
+        None => Some(format!("  [{}] [{}]", role, tier)),
+    }
+}
+```
+
+**Commit**
+
+```bash
+git add src/tools/ src/embeddings/
+git commit -m "refactor(tools): use is_test_related helper, display test_role in deep_dive"
+```
+
+---
+
+## Session 4: Signal Surfaces
+
+### Task 7: Add scheduler signal and bump cache schema
+
+**Files:**
+- Modify: `src/analysis/early_warnings.rs` (add SchedulerSignal, bump schema)
+- Test: add scheduler signal tests
+
+**Step 1: Add SchedulerSignal struct**
 
 ```rust
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1515,86 +772,41 @@ pub struct SchedulerSignal {
 Add `scheduler_signals: Vec<SchedulerSignal>` to `EarlyWarningReport`.
 Add `scheduler_signals: usize` to `ReportSummary`.
 
-**Step 3: Add scheduler to AnnotationSets and build_report**
+**Step 2: Add scheduler to AnnotationSets and build_report**
 
-In `annotation_sets()`:
+Add `scheduler: HashSet<String>` to `AnnotationSets`. Populate from `config.annotation_classes.scheduler`. In `build_report`, detect scheduler annotations alongside existing signals.
 
-```rust
-let scheduler: HashSet<String> = config
-    .annotation_classes
-    .scheduler
-    .iter()
-    .cloned()
-    .collect();
-```
+**Step 3: Bump cache schema version**
 
-In `build_report()`, add scheduler detection alongside entrypoint/auth/review:
+In `early_warnings.rs`, increment `DEFAULT_CONFIG_SCHEMA_VERSION` from `1` to `2`. This invalidates cached reports so new fields are populated.
 
-```rust
-if sets.scheduler.contains(&annotation.annotation_key) {
-    scheduler_signals.push(scheduler_signal(symbol, annotation));
-}
-```
-
-**Step 4: Commit**
+**Step 4: Run tests, commit**
 
 ---
 
-### Task 10: Add untested entry point and high-centrality untested signals
+### Task 8: Add linkage gap signals
 
 **Files:**
-- Modify: `src/analysis/early_warnings.rs`
-- Test: `src/tests/analysis/`
+- Modify: `src/analysis/early_warnings.rs` (add two new signal types)
+- Modify: `src/cli_tools/` (update signals CLI formatter)
+- Test: add linkage gap signal tests
 
-**Step 1: Add UntestedEntryPointSignal**
-
-Cross-reference entry points with test_linkage metadata. For each entry point symbol, check if `metadata.test_linkage` exists:
+**Step 1: Add signal structs with honest names**
 
 ```rust
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct UntestedEntryPointSignal {
+pub struct EntryPointLinkageGap {
     pub symbol_id: String,
     pub symbol_name: String,
     pub symbol_kind: String,
     pub language: String,
     pub file_path: String,
     pub start_line: u32,
-    pub annotation: String,
+    pub entry_annotation: String,
 }
-```
 
-In `build_report`, after collecting entry_points:
-
-```rust
-let mut untested_entry_points = Vec::new();
-for ep in &entry_points {
-    if let Some(symbol) = symbol_map.get(&ep.symbol_id) {
-        let has_test_linkage = symbol.metadata
-            .as_ref()
-            .and_then(|m| m.get("test_linkage"))
-            .is_some();
-        if !has_test_linkage {
-            untested_entry_points.push(UntestedEntryPointSignal {
-                symbol_id: ep.symbol_id.clone(),
-                symbol_name: ep.symbol_name.clone(),
-                symbol_kind: ep.symbol_kind.clone(),
-                language: ep.language.clone(),
-                file_path: ep.file_path.clone(),
-                start_line: ep.start_line,
-                annotation: ep.annotation.clone(),
-            });
-        }
-    }
-}
-```
-
-**Step 2: Add HighCentralityUntestedSignal**
-
-Query top-N centrality symbols with no test linkage:
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct HighCentralityUntestedSignal {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HighCentralityLinkageGap {
     pub symbol_id: String,
     pub symbol_name: String,
     pub symbol_kind: String,
@@ -1605,57 +817,44 @@ pub struct HighCentralityUntestedSignal {
 }
 ```
 
-Query from the database (not the in-memory symbol list, since we need reference_score):
+**Step 2: Implement in build_report**
 
-```rust
-fn collect_high_centrality_untested(
-    db: &SymbolDatabase,
-    file_pattern: Option<&str>,
-    limit: usize,
-) -> Result<Vec<HighCentralityUntestedSignal>> {
-    let mut stmt = db.conn.prepare(
-        "SELECT id, name, kind, language, file_path, start_line, reference_score
-         FROM symbols
-         WHERE reference_score > 0
-           AND (json_extract(metadata, '$.is_test') IS NULL
-                OR json_extract(metadata, '$.is_test') != 1)
-           AND json_extract(metadata, '$.test_linkage') IS NULL
-         ORDER BY reference_score DESC
-         LIMIT ?1",
-    )?;
-    // ... map rows to HighCentralityUntestedSignal
-}
+Entry point linkage gaps: cross-reference `entry_points` with `test_linkage` metadata. For each entry point, check if the symbol has `metadata.test_linkage`. If not, add to gaps.
+
+High-centrality linkage gaps: query DB for top-N centrality non-test symbols without test_linkage. Use `collect_high_centrality_linkage_gaps()` function querying:
+
+```sql
+SELECT id, name, kind, language, file_path, start_line, reference_score
+FROM symbols
+WHERE reference_score > 0
+  AND (json_extract(metadata, '$.is_test') IS NULL OR json_extract(metadata, '$.is_test') != 1)
+  AND json_extract(metadata, '$.test_linkage') IS NULL
+ORDER BY reference_score DESC
+LIMIT ?1
 ```
 
-**Step 3: Update report structs and CLI output**
+**Step 3: Update CLI output with honest framing**
 
-Add both new signal vecs to `EarlyWarningReport` and `ReportSummary`. Update the CLI `signals` command formatter to render the new sections.
+All signal sections must use "observed" / "no linkage found" language:
+- "No test linkage observed for these API endpoints"
+- "These high-centrality symbols have no observed test coverage"
 
-**Step 4: Signal framing**
-
-All output must use honest language:
-- "No test linkage observed" not "untested"
-- "No auth marker found in owner chain" not "unauthenticated"
-- "Executes on a schedule without request context" not "insecure"
-
-**Step 5: Run full test tier**
+**Step 4: Run full test tier**
 
 ```bash
 cargo xtask test dev 2>&1 | tail -20
 ```
 
-**Step 6: Commit**
+**Step 5: Commit**
 
 ```bash
-git add src/analysis/early_warnings.rs src/analysis/mod.rs src/tests/analysis/ src/cli_tools/
-git commit -m "feat(signals): add scheduler, untested entry point, and high-centrality signals
+git add src/analysis/early_warnings.rs src/analysis/mod.rs src/cli_tools/ src/tests/analysis/
+git commit -m "feat(signals): add scheduler, entry point linkage gaps, high-centrality gaps
 
-Three new signal sections in the early warning report:
-- SchedulerSignal: symbols with scheduler annotations
-- UntestedEntryPointSignal: API endpoints with no observed test linkage
-- HighCentralityUntestedSignal: high-centrality symbols with no test coverage
-
-All framing uses 'observed'/'no linkage found' language."
+Three new signal sections: SchedulerSignal for annotated scheduled tasks,
+EntryPointLinkageGap for API endpoints with no observed test linkage,
+HighCentralityLinkageGap for high-centrality symbols with no coverage.
+Cache schema version bumped to invalidate stale reports."
 ```
 
 ---
@@ -1670,30 +869,32 @@ After all sessions complete:
 4. `cargo fmt` clean
 5. Run `julie-server signals --workspace . --standalone --json` and verify:
    - Scheduler signals appear for annotated symbols
-   - Entry point test coverage gaps appear
+   - Entry point linkage gaps appear
    - No false "stub" tiers on fixture functions
 6. Run `julie-server signals --workspace . --standalone --format markdown` and verify honest framing language
+7. Verify fixtures are classified as `fixture_setup`/`fixture_teardown` (not `test_case`)
+8. Verify `deep_dive` displays role + confidence alongside tier
 
 ---
 
 ## Task Dependency Graph
 
 ```
-Task 1 (types) ──→ Task 2 (TOML) ──→ Task 3 (init)
-                                           │
-                                           ▼
-                    Task 4 (classify) ──→ Task 5 (server consumers)
-                         │
-                         ▼
-Task 6 (evidence config) ──→ Task 7 (quality model)
+Task 1 (types + config) ──→ Task 2 (classify + helpers + pipeline)
                                       │
-                                      ▼
-                              Task 8 (risk gating)
-                                      │
-                                      ▼
-                    Task 9 (scheduler) ──→ Task 10 (coverage signals)
+                     ┌────────────────┤
+                     ▼                ▼
+           Task 3 (evidence     Task 6 (consumers)
+            + linkage)
+                     │
+                     ▼
+           Task 4 (quality model)
+                     │
+                     ▼
+           Task 5 (risk gating)
+                     │
+                     ▼
+           Task 7 (scheduler) ──→ Task 8 (linkage gaps)
 ```
 
-Tasks 1-3 are serial (each depends on previous). Tasks 4-5 depend on 1-3. Tasks 6-7 can start after Task 3 (don't need Task 4-5). Task 8 needs Task 7. Tasks 9-10 need Task 8.
-
-Within each session, tasks are serial. Sessions 1-2 are serial. Session 3 depends on Session 1 but can overlap with Session 2 if desired. Session 4 depends on Session 3.
+Tasks 1-2 are serial. Task 3 and Task 6 can run in parallel after Task 2. Task 4 depends on Task 3. Tasks 5, 7, 8 are serial after Task 4.

--- a/docs/plans/2026-04-24-test-intelligence-foundation.md
+++ b/docs/plans/2026-04-24-test-intelligence-foundation.md
@@ -1,0 +1,1699 @@
+# Test Intelligence Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use razorback:subagent-driven-development when subagent delegation is available. Fall back to razorback:executing-plans for single-task, tightly-sequential, or no-delegation runs.
+
+**Goal:** Replace Julie's test/fixture conflation and regex-based quality oracle with config-driven role classification and evidence-based quality assessment, then add security and test coverage signals on the trustworthy foundation.
+
+**Architecture:** `TestRole` enum and `TestRoleConfig` stored via `OnceLock` in the extractors crate, populated from TOML language configs at server startup. `classify_test_role()` replaces `is_test_symbol()`, setting `metadata.test_role` alongside backward-compat `metadata.is_test`. Evidence-based quality model queries identifier data against framework-specific `[test_evidence]` TOML config, with regex fallback at lower confidence. Quality tiers carry confidence scores that gate the 30% test_weakness weight in change_risk.
+
+**Tech Stack:** Rust, serde, tree-sitter, TOML configs, SQLite (identifiers table), existing Julie pipeline infrastructure
+
+**Design doc:** `docs/plans/2026-04-24-test-intelligence-foundation-design.md`
+
+---
+
+## Session 1: Foundation Types & Config
+
+### Task 1: Define TestRole, TestRoleConfig, and global config store
+
+**Files:**
+- Create: `crates/julie-extractors/src/test_roles.rs`
+- Modify: `crates/julie-extractors/src/lib.rs:41` (add module + re-export)
+- Test: `crates/julie-extractors/src/tests/test_detection.rs` (add role tests at bottom)
+
+**What to build:** The core types that everything else depends on. A `TestRole` enum, a `TestRoleConfig` struct holding annotation-key sets per role, and a `OnceLock`-backed global store so extractors can access role configs without signature changes to the 30+ function extraction pipeline.
+
+**Step 1: Write failing tests**
+
+Add to `crates/julie-extractors/src/tests/test_detection.rs`:
+
+```rust
+// --- Test role classification ---
+
+use crate::test_roles::{TestRole, TestRoleConfig, init_test_role_configs, classify_test_role};
+use std::collections::{HashMap, HashSet};
+
+fn make_csharp_role_config() -> TestRoleConfig {
+    TestRoleConfig {
+        test_case: HashSet::from(["fact".into(), "test".into(), "testmethod".into()]),
+        parameterized_test: HashSet::from(["theory".into(), "testcase".into(), "datatestmethod".into()]),
+        fixture_setup: HashSet::from(["setup".into(), "onetimesetup".into(), "testinitialize".into()]),
+        fixture_teardown: HashSet::from(["teardown".into(), "onetimeteardown".into(), "testcleanup".into()]),
+        test_container: HashSet::from(["testfixture".into(), "testclass".into()]),
+    }
+}
+
+#[test]
+fn classify_csharp_fact_as_test_case() {
+    let config = make_csharp_role_config();
+    let role = classify_test_role(
+        "csharp", "MyTest", "src/Tests/MyTests.cs",
+        &SymbolKind::Method, &[s("fact")], None, Some(&config),
+    );
+    assert_eq!(role, Some(TestRole::TestCase));
+}
+
+#[test]
+fn classify_csharp_setup_as_fixture() {
+    let config = make_csharp_role_config();
+    let role = classify_test_role(
+        "csharp", "SetUp", "src/Tests/MyTests.cs",
+        &SymbolKind::Method, &[s("setup")], None, Some(&config),
+    );
+    assert_eq!(role, Some(TestRole::FixtureSetup));
+}
+
+#[test]
+fn classify_csharp_theory_as_parameterized() {
+    let config = make_csharp_role_config();
+    let role = classify_test_role(
+        "csharp", "DataTest", "src/Tests/MyTests.cs",
+        &SymbolKind::Method, &[s("theory")], None, Some(&config),
+    );
+    assert_eq!(role, Some(TestRole::ParameterizedTest));
+}
+
+#[test]
+fn classify_csharp_teardown_as_fixture_teardown() {
+    let config = make_csharp_role_config();
+    let role = classify_test_role(
+        "csharp", "Cleanup", "src/Tests/MyTests.cs",
+        &SymbolKind::Method, &[s("teardown")], None, Some(&config),
+    );
+    assert_eq!(role, Some(TestRole::FixtureTeardown));
+}
+
+#[test]
+fn classify_go_test_without_config_falls_back() {
+    let role = classify_test_role(
+        "go", "TestFoo", "pkg/handler_test.go",
+        &SymbolKind::Function, &[], None, None,
+    );
+    assert_eq!(role, Some(TestRole::TestCase));
+}
+
+#[test]
+fn classify_regular_function_returns_none() {
+    let config = make_csharp_role_config();
+    let role = classify_test_role(
+        "csharp", "ProcessData", "src/Services/DataService.cs",
+        &SymbolKind::Method, &[], None, Some(&config),
+    );
+    assert_eq!(role, None);
+}
+
+#[test]
+fn classify_class_returns_none_not_callable() {
+    let config = make_csharp_role_config();
+    let role = classify_test_role(
+        "csharp", "TestFixture", "src/Tests/MyTests.cs",
+        &SymbolKind::Class, &[s("testfixture")], None, Some(&config),
+    );
+    // test_container applies to classes, but classify_test_role gates on callable kinds
+    // for test_case/parameterized/fixture roles. test_container is the exception.
+    assert_eq!(role, Some(TestRole::TestContainer));
+}
+```
+
+**Step 2: Run tests, verify they fail**
+
+```bash
+cargo nextest run --lib classify_csharp_fact 2>&1 | tail -5
+```
+Expected: compilation error (module doesn't exist yet)
+
+**Step 3: Implement test_roles.rs**
+
+Create `crates/julie-extractors/src/test_roles.rs`:
+
+```rust
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+use crate::base::SymbolKind;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TestRole {
+    TestCase,
+    ParameterizedTest,
+    FixtureSetup,
+    FixtureTeardown,
+    TestContainer,
+}
+
+impl TestRole {
+    pub fn is_scorable(&self) -> bool {
+        matches!(self, TestRole::TestCase | TestRole::ParameterizedTest)
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TestRole::TestCase => "test_case",
+            TestRole::ParameterizedTest => "parameterized_test",
+            TestRole::FixtureSetup => "fixture_setup",
+            TestRole::FixtureTeardown => "fixture_teardown",
+            TestRole::TestContainer => "test_container",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TestRoleConfig {
+    pub test_case: HashSet<String>,
+    pub parameterized_test: HashSet<String>,
+    pub fixture_setup: HashSet<String>,
+    pub fixture_teardown: HashSet<String>,
+    pub test_container: HashSet<String>,
+}
+
+impl TestRoleConfig {
+    pub fn classify_annotation(&self, annotation_key: &str) -> Option<TestRole> {
+        if self.test_case.contains(annotation_key) {
+            Some(TestRole::TestCase)
+        } else if self.parameterized_test.contains(annotation_key) {
+            Some(TestRole::ParameterizedTest)
+        } else if self.fixture_setup.contains(annotation_key) {
+            Some(TestRole::FixtureSetup)
+        } else if self.fixture_teardown.contains(annotation_key) {
+            Some(TestRole::FixtureTeardown)
+        } else if self.test_container.contains(annotation_key) {
+            Some(TestRole::TestContainer)
+        } else {
+            None
+        }
+    }
+
+    pub fn is_test_related(&self, annotation_key: &str) -> bool {
+        self.classify_annotation(annotation_key).is_some()
+    }
+}
+
+static TEST_ROLE_CONFIGS: OnceLock<HashMap<String, TestRoleConfig>> = OnceLock::new();
+
+pub fn init_test_role_configs(configs: HashMap<String, TestRoleConfig>) {
+    TEST_ROLE_CONFIGS.set(configs).ok();
+}
+
+pub fn get_role_config(language: &str) -> Option<&'static TestRoleConfig> {
+    TEST_ROLE_CONFIGS.get()?.get(language)
+}
+
+fn is_callable(kind: &SymbolKind) -> bool {
+    matches!(
+        kind,
+        SymbolKind::Function | SymbolKind::Method | SymbolKind::Constructor
+    )
+}
+
+fn is_container_kind(kind: &SymbolKind) -> bool {
+    matches!(
+        kind,
+        SymbolKind::Class | SymbolKind::Struct | SymbolKind::Module | SymbolKind::Namespace
+    )
+}
+
+pub fn classify_test_role(
+    language: &str,
+    name: &str,
+    file_path: &str,
+    kind: &SymbolKind,
+    annotation_keys: &[String],
+    doc_comment: Option<&str>,
+    role_config: Option<&TestRoleConfig>,
+) -> Option<TestRole> {
+    // Try config-driven classification first
+    if let Some(config) = role_config {
+        // Check annotations against role config
+        for key in annotation_keys {
+            if let Some(role) = config.classify_annotation(key) {
+                // test_container applies to container kinds
+                if role == TestRole::TestContainer {
+                    if is_container_kind(kind) {
+                        return Some(role);
+                    }
+                    continue;
+                }
+                // All other roles require callable kinds
+                if is_callable(kind) {
+                    return Some(role);
+                }
+            }
+        }
+    }
+
+    // Fall back to name/path heuristics for convention-based languages
+    if is_callable(kind) {
+        if let Some(role) = detect_by_convention(language, name, file_path, annotation_keys, doc_comment) {
+            return Some(role);
+        }
+    }
+
+    None
+}
+
+fn detect_by_convention(
+    language: &str,
+    name: &str,
+    file_path: &str,
+    annotation_keys: &[String],
+    doc_comment: Option<&str>,
+) -> Option<TestRole> {
+    // Delegate to language-specific convention detection
+    // These cover languages without annotation-based test frameworks
+    let is_test = match language {
+        "go" => detect_go(name, file_path),
+        "javascript" | "typescript" => detect_js_ts(name, file_path),
+        "ruby" => detect_ruby(name, file_path),
+        "swift" => detect_swift(name, file_path),
+        "elixir" => detect_elixir(name, file_path),
+        "php" => detect_php_convention(name, file_path, doc_comment),
+        "python" => detect_python_convention(name),
+        "scala" => detect_scala_convention(name, file_path),
+        _ => detect_generic(name, file_path),
+    };
+    if is_test { Some(TestRole::TestCase) } else { None }
+}
+
+// Convention-based detectors (moved from test_detection.rs, unchanged logic)
+
+fn is_test_path(file_path: &str) -> bool {
+    for segment in file_path.split('/') {
+        match segment {
+            "test" | "tests" | "Test" | "Tests" | "spec" | "Spec" | "__tests__" | "autotests" => {
+                return true;
+            }
+            _ => {}
+        }
+        if segment.ends_with(".Tests") || segment.ends_with(".Test") {
+            return true;
+        }
+    }
+    let file_name = file_path.rsplit('/').next().unwrap_or(file_path);
+    if file_name.ends_with("_test.go")
+        || file_name.contains(".test.")
+        || file_name.contains(".spec.")
+        || file_name.starts_with("test_")
+        || file_name.starts_with("tst_")
+    {
+        return true;
+    }
+    false
+}
+
+fn detect_go(name: &str, file_path: &str) -> bool {
+    let file_name = file_path.rsplit('/').next().unwrap_or(file_path);
+    (name.starts_with("Test") || name.starts_with("Fuzz") || name.starts_with("Example"))
+        && file_name.ends_with("_test.go")
+}
+
+fn detect_js_ts(name: &str, file_path: &str) -> bool {
+    let is_test_fn = matches!(name, "describe" | "it" | "test");
+    let file_name = file_path.rsplit('/').next().unwrap_or(file_path);
+    let in_test_file =
+        file_name.contains(".test.") || file_name.contains(".spec.") || is_test_path(file_path);
+    is_test_fn && in_test_file
+}
+
+fn detect_ruby(name: &str, file_path: &str) -> bool {
+    name.starts_with("test_") && is_test_path(file_path)
+}
+
+fn detect_swift(name: &str, file_path: &str) -> bool {
+    is_test_path(file_path)
+        && (name.starts_with("test")
+            || matches!(
+                name,
+                "setUp" | "tearDown" | "setUpWithError" | "tearDownWithError"
+            ))
+}
+
+fn detect_elixir(name: &str, file_path: &str) -> bool {
+    name.starts_with("test_") || name.starts_with("test ") || is_test_path(file_path)
+}
+
+fn detect_php_convention(name: &str, file_path: &str, doc_comment: Option<&str>) -> bool {
+    if let Some(doc) = doc_comment {
+        if doc.contains("@test") {
+            return true;
+        }
+    }
+    name.starts_with("test") && is_test_path(file_path)
+}
+
+fn detect_python_convention(name: &str) -> bool {
+    if matches!(name, "setUp" | "tearDown" | "setUpClass" | "tearDownClass") {
+        return true;
+    }
+    name.starts_with("test_")
+}
+
+fn detect_scala_convention(name: &str, file_path: &str) -> bool {
+    if is_test_path(file_path) {
+        return true;
+    }
+    name.starts_with("test")
+}
+
+fn detect_generic(name: &str, file_path: &str) -> bool {
+    let has_test_name = name.starts_with("test_") || name.starts_with("Test");
+    has_test_name && is_test_path(file_path)
+}
+```
+
+**Step 4: Wire up the module**
+
+In `crates/julie-extractors/src/lib.rs`, add after line 41 (`pub mod test_detection`):
+
+```rust
+pub mod test_roles;
+```
+
+And add to the re-exports (after line 90):
+
+```rust
+pub use test_roles::{TestRole, TestRoleConfig, classify_test_role, init_test_role_configs, get_role_config};
+```
+
+**Step 5: Run tests, verify they pass**
+
+```bash
+cargo nextest run --lib classify_csharp 2>&1 | tail -10
+cargo nextest run --lib classify_go_test 2>&1 | tail -5
+cargo nextest run --lib classify_regular 2>&1 | tail -5
+```
+
+**Step 6: Commit**
+
+```bash
+git add crates/julie-extractors/src/test_roles.rs crates/julie-extractors/src/lib.rs crates/julie-extractors/src/tests/test_detection.rs
+git commit -m "feat(extractors): add TestRole enum, TestRoleConfig, and classify_test_role
+
+Introduces config-driven test role classification with five roles:
+TestCase, ParameterizedTest, FixtureSetup, FixtureTeardown, TestContainer.
+
+Uses OnceLock global for config storage to avoid threading through
+30+ extraction pipeline function signatures. Falls back to
+convention-based detection for languages without annotation configs."
+```
+
+---
+
+### Task 2: Update AnnotationClassesConfig and all language TOMLs
+
+**Files:**
+- Modify: `src/search/language_config.rs:73-88` (replace flat test/fixture with TestAnnotationClasses)
+- Modify: `src/search/language_config.rs:248-456` (update tests)
+- Modify: `languages/java.toml`
+- Modify: `languages/kotlin.toml`
+- Modify: `languages/csharp.toml`
+- Modify: `languages/python.toml`
+- Modify: `languages/rust.toml`
+- Modify: `languages/typescript.toml`
+- Modify: `languages/javascript.toml`
+- Modify: `languages/php.toml` (if exists, otherwise create section)
+- Modify: `languages/scala.toml` (if exists, otherwise create section)
+- Modify: `languages/dart.toml` (if exists, otherwise create section)
+- Modify: `languages/vbnet.toml` (if exists, otherwise create section)
+- Modify: `languages/razor.toml` (if exists, otherwise create section)
+
+**Step 1: Write failing test**
+
+Update `src/search/language_config.rs` test `test_embedded_language_configs_include_expected_annotation_classes` to expect the new structure:
+
+```rust
+#[test]
+fn test_annotation_classes_use_role_taxonomy() {
+    let configs = LanguageConfigs::load_embedded();
+    let csharp = configs.get("csharp").expect("csharp config");
+
+    // xUnit
+    assert!(csharp.annotation_classes.test.test_case.contains(&"fact".to_string()));
+    // NUnit
+    assert!(csharp.annotation_classes.test.test_case.contains(&"test".to_string()));
+    // MSTest
+    assert!(csharp.annotation_classes.test.test_case.contains(&"testmethod".to_string()));
+
+    // Fixtures are NOT in test_case
+    assert!(!csharp.annotation_classes.test.test_case.contains(&"setup".to_string()));
+
+    // Fixtures are in fixture_setup
+    assert!(csharp.annotation_classes.test.fixture_setup.contains(&"setup".to_string()));
+    assert!(csharp.annotation_classes.test.fixture_setup.contains(&"onetimesetup".to_string()));
+
+    // Teardown
+    assert!(csharp.annotation_classes.test.fixture_teardown.contains(&"teardown".to_string()));
+
+    // Parameterized
+    assert!(csharp.annotation_classes.test.parameterized_test.contains(&"theory".to_string()));
+
+    // Containers
+    assert!(csharp.annotation_classes.test.test_container.contains(&"testfixture".to_string()));
+}
+
+#[test]
+fn test_java_role_taxonomy_covers_junit4_and_5() {
+    let configs = LanguageConfigs::load_embedded();
+    let java = configs.get("java").expect("java config");
+
+    // JUnit 5
+    assert!(java.annotation_classes.test.test_case.contains(&"test".to_string()));
+    assert!(java.annotation_classes.test.test_case.contains(&"repeatedtest".to_string()));
+    assert!(java.annotation_classes.test.parameterized_test.contains(&"parameterizedtest".to_string()));
+
+    // JUnit 4 fixtures
+    assert!(java.annotation_classes.test.fixture_setup.contains(&"before".to_string()));
+    assert!(java.annotation_classes.test.fixture_setup.contains(&"beforeclass".to_string()));
+
+    // JUnit 5 fixtures
+    assert!(java.annotation_classes.test.fixture_setup.contains(&"beforeeach".to_string()));
+    assert!(java.annotation_classes.test.fixture_setup.contains(&"beforeall".to_string()));
+
+    // Teardown (both versions)
+    assert!(java.annotation_classes.test.fixture_teardown.contains(&"aftereach".to_string()));
+    assert!(java.annotation_classes.test.fixture_teardown.contains(&"after".to_string()));
+}
+
+#[test]
+fn test_python_fixture_classified_correctly() {
+    let configs = LanguageConfigs::load_embedded();
+    let python = configs.get("python").expect("python config");
+
+    // pytest.fixture is fixture_setup, not test_case
+    assert!(python.annotation_classes.test.fixture_setup.contains(&"pytest.fixture".to_string()));
+    assert!(!python.annotation_classes.test.test_case.contains(&"pytest.fixture".to_string()));
+}
+
+#[test]
+fn test_languages_without_test_annotations_have_empty_sections() {
+    let configs = LanguageConfigs::load_embedded();
+    let go = configs.get("go").expect("go config");
+
+    assert!(go.annotation_classes.test.test_case.is_empty());
+    assert!(go.annotation_classes.test.fixture_setup.is_empty());
+}
+```
+
+**Step 2: Run test, verify it fails**
+
+```bash
+cargo nextest run --lib test_annotation_classes_use_role 2>&1 | tail -5
+```
+
+**Step 3: Update AnnotationClassesConfig in language_config.rs**
+
+Replace `AnnotationClassesConfig` at `src/search/language_config.rs:73-88`:
+
+```rust
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct TestAnnotationClasses {
+    #[serde(default)]
+    pub test_case: Vec<String>,
+    #[serde(default)]
+    pub parameterized_test: Vec<String>,
+    #[serde(default)]
+    pub fixture_setup: Vec<String>,
+    #[serde(default)]
+    pub fixture_teardown: Vec<String>,
+    #[serde(default)]
+    pub test_container: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct AnnotationClassesConfig {
+    #[serde(default)]
+    pub entrypoint: Vec<String>,
+    #[serde(default)]
+    pub auth: Vec<String>,
+    #[serde(default)]
+    pub auth_bypass: Vec<String>,
+    #[serde(default)]
+    pub middleware: Vec<String>,
+    #[serde(default)]
+    pub scheduler: Vec<String>,
+    #[serde(default)]
+    pub test: TestAnnotationClasses,
+}
+```
+
+**Step 4: Update all language TOML files**
+
+Replace `[annotation_classes]` sections. Each language's complete `[annotation_classes]` and `[annotation_classes.test]` sections are specified in the design doc at `docs/plans/2026-04-24-test-intelligence-foundation-design.md` Part 2. Copy them verbatim.
+
+For languages that currently have flat `test = [...]` and `fixture = [...]` fields, these must be replaced with the nested `[annotation_classes.test]` table.
+
+Example for `languages/csharp.toml` - replace existing annotation_classes:
+
+```toml
+[annotation_classes]
+entrypoint = [
+    "apicontroller",
+    "route",
+    "httpget",
+    "httppost",
+    "httpput",
+    "httpdelete",
+    "httppatch",
+]
+auth = ["authorize"]
+auth_bypass = ["allowanonymous"]
+
+[annotation_classes.test]
+test_case = ["fact", "test", "testmethod"]
+parameterized_test = ["theory", "testcase", "testcasesource", "datatestmethod"]
+fixture_setup = ["setup", "onetimesetup", "testinitialize", "classinitialize", "assemblyinitialize"]
+fixture_teardown = ["teardown", "onetimeteardown", "testcleanup", "classcleanup", "assemblycleanup"]
+test_container = ["testfixture", "testclass", "collection", "collectiondefinition"]
+```
+
+For languages WITHOUT test annotations (go, c, cpp, lua, zig, etc.), no `[annotation_classes.test]` section is needed; the `#[serde(default)]` produces empty vecs.
+
+**Step 5: Update existing tests in language_config.rs**
+
+The existing test `test_language_config_defaults_empty_annotation_sections` checks `config.annotation_classes.test.is_empty()` which won't compile since `test` is now `TestAnnotationClasses`, not `Vec<String>`. Update:
+
+```rust
+assert!(config.annotation_classes.test.test_case.is_empty());
+assert!(config.annotation_classes.test.fixture_setup.is_empty());
+```
+
+The test `test_language_config_loads_populated_annotation_sections` and `test_embedded_language_configs_include_expected_annotation_classes` need similar updates. Replace assertions that check the old flat `test`/`fixture` fields with assertions against the new role fields.
+
+**Step 6: Fix early_warnings.rs annotation_sets function**
+
+The `annotation_sets` function in `src/analysis/early_warnings.rs:318-340` reads `config.annotation_classes.test` and `config.annotation_classes.fixture`. It only uses these fields indirectly through `AnnotationSets.auth` (not test/fixture). Verify it doesn't reference the old flat fields. Currently it does NOT read test/fixture, so no change needed here.
+
+**Step 7: Run tests, verify they pass**
+
+```bash
+cargo nextest run --lib test_annotation_classes 2>&1 | tail -10
+cargo nextest run --lib test_java_role 2>&1 | tail -5
+cargo nextest run --lib test_python_fixture 2>&1 | tail -5
+cargo nextest run --lib test_language_config 2>&1 | tail -10
+```
+
+**Step 8: Commit**
+
+```bash
+git add src/search/language_config.rs languages/*.toml
+git commit -m "feat(config): replace flat test/fixture with role taxonomy
+
+AnnotationClassesConfig.test is now TestAnnotationClasses with five
+role fields: test_case, parameterized_test, fixture_setup,
+fixture_teardown, test_container.
+
+All 10 applicable language TOMLs updated with comprehensive
+framework-specific role classifications covering xUnit/NUnit/MSTest
+(C#), JUnit 4/5/TestNG (Java/Kotlin), pytest (Python), PHPUnit,
+and framework-specific annotations for Rust, Scala, Dart, VB.NET."
+```
+
+---
+
+### Task 3: Build TestRoleConfig from LanguageConfigs and init at startup
+
+**Files:**
+- Modify: `src/search/language_config.rs` (add `build_test_role_configs` method)
+- Modify: `src/handler.rs` or `src/tools/workspace/indexing/pipeline.rs` (call init at startup)
+- Test: `src/search/language_config.rs` (test the builder)
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_build_test_role_configs_from_language_configs() {
+    let configs = LanguageConfigs::load_embedded();
+    let role_configs = configs.build_test_role_configs();
+
+    let csharp = role_configs.get("csharp").expect("csharp role config");
+    assert!(csharp.test_case.contains("fact"));
+    assert!(csharp.fixture_setup.contains("setup"));
+    assert!(!csharp.test_case.contains("setup"));
+
+    let java = role_configs.get("java").expect("java role config");
+    assert!(java.test_case.contains("test"));
+    assert!(java.fixture_setup.contains("beforeeach"));
+    assert!(java.fixture_teardown.contains("aftereach"));
+
+    // Go has no test annotations, should have empty config
+    let go = role_configs.get("go").expect("go role config");
+    assert!(go.test_case.is_empty());
+}
+```
+
+**Step 2: Implement build_test_role_configs**
+
+Add to `LanguageConfigs` impl in `src/search/language_config.rs`:
+
+```rust
+pub fn build_test_role_configs(&self) -> HashMap<String, julie_extractors::TestRoleConfig> {
+    self.configs
+        .iter()
+        .map(|(lang, config)| {
+            let tc = &config.annotation_classes.test;
+            let role_config = julie_extractors::TestRoleConfig {
+                test_case: tc.test_case.iter().cloned().collect(),
+                parameterized_test: tc.parameterized_test.iter().cloned().collect(),
+                fixture_setup: tc.fixture_setup.iter().cloned().collect(),
+                fixture_teardown: tc.fixture_teardown.iter().cloned().collect(),
+                test_container: tc.test_container.iter().cloned().collect(),
+            };
+            (lang.clone(), role_config)
+        })
+        .collect()
+}
+```
+
+**Step 3: Init at server startup**
+
+Find where `LanguageConfigs::load_embedded()` is called in the server (likely `handler.rs` or during `JulieServerHandler` construction). After loading, add:
+
+```rust
+let role_configs = language_configs.build_test_role_configs();
+julie_extractors::init_test_role_configs(role_configs);
+```
+
+Use `deep_dive(symbol="load_embedded")` to find the exact call site and add the init there.
+
+**Step 4: Run tests, verify pass**
+
+```bash
+cargo nextest run --lib test_build_test_role 2>&1 | tail -10
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/search/language_config.rs src/handler.rs
+git commit -m "feat(config): build TestRoleConfig from TOML and init at startup
+
+LanguageConfigs::build_test_role_configs() converts TOML role
+taxonomy into the extractors crate's TestRoleConfig format.
+Initialized via OnceLock at server startup."
+```
+
+---
+
+## Session 2: Config-Driven Classification
+
+### Task 4: Replace is_test_symbol with classify_test_role in all extractors
+
+**Files:**
+- Modify: 21 extractor files (see list below)
+- Modify: `crates/julie-extractors/src/test_detection.rs` (deprecate, re-export compat shim)
+- Test: existing tests in `crates/julie-extractors/src/tests/test_detection.rs`
+
+**Extractor files to update** (each has `use crate::test_detection::is_test_symbol` and 1-3 call sites):
+
+1. `crates/julie-extractors/src/bash/functions.rs:6,27`
+2. `crates/julie-extractors/src/java/methods.rs:4,84,155`
+3. `crates/julie-extractors/src/php/functions.rs:5,99`
+4. `crates/julie-extractors/src/swift/callables.rs:2,81`
+5. `crates/julie-extractors/src/lua/functions.rs:10,98`
+6. `crates/julie-extractors/src/gdscript/functions.rs:4,109`
+7. `crates/julie-extractors/src/vue/script.rs:11,95`
+8. `crates/julie-extractors/src/javascript/functions.rs:7,70,149`
+9. `crates/julie-extractors/src/python/functions.rs:6,77`
+10. `crates/julie-extractors/src/rust/functions.rs:12,118`
+11. `crates/julie-extractors/src/ruby/symbols.rs:6,161`
+12. `crates/julie-extractors/src/scala/declarations.rs:7,90`
+13. `crates/julie-extractors/src/go/functions.rs:2,61,164`
+14. `crates/julie-extractors/src/csharp/members.rs:5,73,135,187`
+15. `crates/julie-extractors/src/kotlin/declarations.rs:8,109,189`
+16. `crates/julie-extractors/src/dart/functions.rs:11,99,200,298`
+17. `crates/julie-extractors/src/qml/mod.rs:216`
+18. `crates/julie-extractors/src/elixir/calls.rs:120`
+19. `crates/julie-extractors/src/razor/csharp.rs:258`
+20. `crates/julie-extractors/src/razor/stubs.rs:145`
+21. `crates/julie-extractors/src/zig/functions.rs:40`
+
+**The pattern for each file is identical.** Here's the transformation using `rust/functions.rs` as the example:
+
+Before:
+```rust
+use crate::test_detection::is_test_symbol;
+// ...
+if is_test_symbol(
+    "rust",
+    &name,
+    &base.file_path,
+    &kind,
+    &annotation_keys,
+    None,
+) {
+    metadata.insert("is_test".to_string(), Value::Bool(true));
+}
+```
+
+After:
+```rust
+use crate::test_roles::{classify_test_role, get_role_config};
+// ...
+if let Some(role) = classify_test_role(
+    "rust",
+    &name,
+    &base.file_path,
+    &kind,
+    &annotation_keys,
+    None,
+    get_role_config("rust"),
+) {
+    metadata.insert("is_test".to_string(), Value::Bool(true));
+    metadata.insert("test_role".to_string(), Value::String(role.as_str().to_string()));
+}
+```
+
+Apply this transformation to all 21 files. The language string passed to `get_role_config` must match the language string passed as the first argument (already present in each call site).
+
+**For files that pass `doc_comment`** (php/functions.rs), keep passing it:
+
+```rust
+if let Some(role) = classify_test_role(
+    "php",
+    &name,
+    &base.file_path,
+    &kind,
+    &annotation_keys,
+    doc_comment.as_deref(),
+    get_role_config("php"),
+) {
+```
+
+**Step: Add backward-compat shim to test_detection.rs**
+
+Keep `test_detection.rs` but replace the body with a delegation:
+
+```rust
+use crate::base::SymbolKind;
+use crate::test_roles::{classify_test_role, get_role_config};
+
+pub fn is_test_symbol(
+    language: &str,
+    name: &str,
+    file_path: &str,
+    kind: &SymbolKind,
+    annotation_keys: &[String],
+    doc_comment: Option<&str>,
+) -> bool {
+    classify_test_role(
+        language,
+        name,
+        file_path,
+        kind,
+        annotation_keys,
+        doc_comment,
+        get_role_config(language),
+    )
+    .is_some()
+}
+```
+
+This preserves backward compatibility for any code that still calls `is_test_symbol` (server-side `is_test_symbol_for_embedding`, etc.) while delegating to the new classify_test_role.
+
+**Step: Run full test suite for extractors**
+
+```bash
+cargo nextest run --lib tests::test_detection 2>&1 | tail -20
+```
+
+All existing tests should pass since `classify_test_role` preserves the same detection behavior.
+
+**Step: Commit**
+
+```bash
+git add crates/julie-extractors/
+git commit -m "refactor(extractors): replace is_test_symbol with classify_test_role
+
+All 21 extractor files now call classify_test_role and store both
+metadata.is_test (backward compat) and metadata.test_role (new).
+is_test_symbol retained as thin shim delegating to classify_test_role.
+Config-driven annotation classification for languages with TOML
+configs, convention-based fallback for others."
+```
+
+---
+
+### Task 5: Update server-side is_test consumers and verify pipeline
+
+**Files:**
+- Modify: `src/tools/impact/mod.rs:448` (add test_role awareness)
+- Modify: `src/tools/impact/ranking.rs:106` (add test_role awareness)
+- Modify: `src/tools/deep_dive/data.rs:322` (add test_role awareness)
+- Modify: `src/tools/deep_dive/formatting.rs:186` (display test_role)
+- Test: existing tests + new integration test
+
+**What to build:** Server-side consumers currently read `metadata["is_test"]`. They continue to work unchanged (backward compat). But add `test_role` awareness where it matters:
+
+- `deep_dive` formatting: show the role (e.g., "[test_case]" or "[fixture_setup]") instead of generic "[test]"
+- `impact/ranking.rs`: separate test_case from fixture in impact sorting
+
+**Step 1: Update deep_dive formatting**
+
+In `src/tools/deep_dive/formatting.rs`, find `format_test_quality_info` (line 186). Update to include role:
+
+```rust
+fn format_test_quality_info(metadata: &serde_json::Value) -> Option<String> {
+    let tier = metadata
+        .get("test_quality")
+        .and_then(|tq| tq.get("quality_tier"))
+        .and_then(|v| v.as_str())?;
+    let role = metadata
+        .get("test_role")
+        .and_then(|v| v.as_str())
+        .unwrap_or("test");
+    Some(format!("  [{}] [{}]", role, tier))
+}
+```
+
+**Step 2: Verify pipeline end-to-end**
+
+Write an integration test or use the fixture database to verify:
+1. Index a file containing test functions and fixtures
+2. Verify `metadata.test_role` is set correctly on extracted symbols
+3. Verify `metadata.is_test` is still set for backward compat
+
+**Step 3: Run `cargo xtask test changed`**
+
+```bash
+cargo xtask test changed 2>&1 | tail -20
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/tools/
+git commit -m "feat(tools): add test_role awareness to deep_dive and impact
+
+deep_dive displays test role alongside quality tier.
+Server-side is_test consumers continue working via backward-compat
+metadata.is_test field."
+```
+
+---
+
+## Session 3: Evidence-Based Quality Model
+
+### Task 6: Add TestEvidenceConfig to language configs and TOML files
+
+**Files:**
+- Modify: `src/search/language_config.rs` (add TestEvidenceConfig struct)
+- Modify: `languages/rust.toml`, `languages/python.toml`, `languages/java.toml`, `languages/csharp.toml`, `languages/kotlin.toml` (add `[test_evidence]` sections)
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_evidence_config_loads_from_toml() {
+    let configs = LanguageConfigs::load_embedded();
+    let rust = configs.get("rust").expect("rust config");
+    assert!(!rust.test_evidence.assertion_identifiers.is_empty());
+    assert!(rust.test_evidence.assertion_identifiers.contains(&"assert_eq".to_string()));
+}
+```
+
+**Step 2: Add TestEvidenceConfig**
+
+In `src/search/language_config.rs`, after `EarlyWarningConfig`:
+
+```rust
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct TestEvidenceConfig {
+    #[serde(default)]
+    pub assertion_identifiers: Vec<String>,
+    #[serde(default)]
+    pub error_assertion_identifiers: Vec<String>,
+    #[serde(default)]
+    pub mock_identifiers: Vec<String>,
+}
+```
+
+Add to `LanguageConfig`:
+
+```rust
+#[serde(default)]
+pub test_evidence: TestEvidenceConfig,
+```
+
+**Step 3: Populate TOML files**
+
+Add `[test_evidence]` sections per the design doc Part 7. Start with the 5 most-used languages. Before populating each language, verify identifier extraction:
+
+```bash
+# Verify Rust assertion identifiers are extracted
+./target/debug/julie-server search "assert_eq" --target definitions --workspace . --standalone --json 2>/dev/null | head -5
+```
+
+The verification step is critical: if `assert_eq` doesn't appear as an identifier for Rust (it's a macro), document this gap and use regex fallback for Rust.
+
+**Step 4: Commit**
+
+```bash
+git add src/search/language_config.rs languages/*.toml
+git commit -m "feat(config): add test_evidence TOML sections for assertion identifiers
+
+TestEvidenceConfig with assertion_identifiers, error_assertion_identifiers,
+and mock_identifiers. Populated for Rust, Python, Java, C#, Kotlin.
+Identifier extraction verified per language."
+```
+
+---
+
+### Task 7: Rewrite test_quality.rs with evidence model
+
+**Files:**
+- Modify: `src/analysis/test_quality.rs` (replace regex oracle)
+- Modify: `src/analysis/mod.rs` (update re-exports)
+- Test: `src/tests/analysis/test_quality_tests.rs` (rewrite tests)
+
+**Step 1: Write failing tests for the new model**
+
+```rust
+use crate::analysis::test_quality::{TestQualityAssessment, TestQualityTier, EvidenceSource};
+
+#[test]
+fn test_fixture_is_not_applicable() {
+    let assessment = analyze_with_role(
+        "fixture_setup",  // role
+        "fn setUp() { db.reset(); }",  // body
+        0,  // assertion_identifier_count
+        EvidenceSource::None,
+    );
+    assert_eq!(assessment.tier, TestQualityTier::NotApplicable);
+    assert_eq!(assessment.confidence, 1.0);
+}
+
+#[test]
+fn test_empty_body_is_stub() {
+    let assessment = analyze_with_role(
+        "test_case",
+        "",
+        0,
+        EvidenceSource::None,
+    );
+    assert_eq!(assessment.tier, TestQualityTier::Stub);
+    assert_eq!(assessment.confidence, 1.0);
+}
+
+#[test]
+fn test_identifier_based_thorough() {
+    let assessment = analyze_with_role(
+        "test_case",
+        "fn test_foo() { assert_eq!(a, b); assert_ne!(c, d); assert!(e); should_err(); }",
+        3,  // 3 assertion identifiers found
+        EvidenceSource::Identifier,
+    );
+    assert_eq!(assessment.tier, TestQualityTier::Thorough);
+    assert!(assessment.confidence >= 0.85);
+}
+
+#[test]
+fn test_regex_zero_assertions_is_unknown_not_stub() {
+    let assessment = analyze_with_role(
+        "test_case",
+        "fn test_foo() { let x = compute(); println!(\"{}\", x); }",
+        0,
+        EvidenceSource::Regex,
+    );
+    assert_eq!(assessment.tier, TestQualityTier::Unknown);
+}
+```
+
+**Step 2: Implement the new evidence model**
+
+Replace the core of `src/analysis/test_quality.rs`. Keep `strip_comments_and_strings` (it's well-implemented and needed for regex fallback). Replace `analyze_test_body` and `classify_tier`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TestQualityAssessment {
+    pub tier: TestQualityTier,
+    pub confidence: f32,
+    pub evidence: QualityEvidence,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum TestQualityTier {
+    Thorough,
+    Adequate,
+    Thin,
+    Stub,
+    Unknown,
+    NotApplicable,
+}
+
+impl TestQualityTier {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Thorough => "thorough",
+            Self::Adequate => "adequate",
+            Self::Thin => "thin",
+            Self::Stub => "stub",
+            Self::Unknown => "unknown",
+            Self::NotApplicable => "n/a",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QualityEvidence {
+    pub assertion_count: u32,
+    pub assertion_source: EvidenceSource,
+    pub has_error_testing: bool,
+    pub mock_count: u32,
+    pub body_lines: u32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceSource {
+    Identifier,
+    Regex,
+    None,
+}
+
+pub fn assess_test_quality(
+    test_role: Option<&str>,
+    body: Option<&str>,
+    identifier_assertion_count: u32,
+    identifier_error_count: u32,
+    identifier_mock_count: u32,
+    has_identifier_evidence: bool,
+) -> TestQualityAssessment {
+    // Fixtures and containers are not scored
+    if matches!(test_role, Some("fixture_setup") | Some("fixture_teardown") | Some("test_container")) {
+        return TestQualityAssessment {
+            tier: TestQualityTier::NotApplicable,
+            confidence: 1.0,
+            evidence: QualityEvidence {
+                assertion_count: 0,
+                assertion_source: EvidenceSource::None,
+                has_error_testing: false,
+                mock_count: 0,
+                body_lines: 0,
+            },
+        };
+    }
+
+    // No body or placeholder body
+    let body = match body {
+        Some(b) if !is_placeholder_body(b) => b,
+        _ => {
+            return TestQualityAssessment {
+                tier: TestQualityTier::Stub,
+                confidence: 1.0,
+                evidence: QualityEvidence {
+                    assertion_count: 0,
+                    assertion_source: EvidenceSource::None,
+                    has_error_testing: false,
+                    mock_count: 0,
+                    body_lines: 0,
+                },
+            };
+        }
+    };
+
+    let body_lines = body.lines().count() as u32;
+
+    // Prefer identifier evidence over regex
+    if has_identifier_evidence {
+        let has_error = identifier_error_count > 0;
+        let tier = classify_from_counts(identifier_assertion_count, has_error);
+        let confidence = match tier {
+            TestQualityTier::Thorough => 0.9,
+            TestQualityTier::Adequate => 0.85,
+            TestQualityTier::Thin => 0.8,
+            TestQualityTier::Stub => 0.85,
+            _ => 0.5,
+        };
+        return TestQualityAssessment {
+            tier,
+            confidence,
+            evidence: QualityEvidence {
+                assertion_count: identifier_assertion_count,
+                assertion_source: EvidenceSource::Identifier,
+                has_error_testing: has_error,
+                mock_count: identifier_mock_count,
+                body_lines,
+            },
+        };
+    }
+
+    // Regex fallback
+    let stripped = strip_comments_and_strings(body);
+    let regex_assertions = count_pattern_matches(&stripped, assertion_patterns());
+    let regex_errors = count_pattern_matches(&stripped, error_testing_patterns()) > 0;
+    let regex_mocks = count_pattern_matches(&stripped, mock_patterns());
+
+    if regex_assertions == 0 {
+        // Regex found nothing; might be a custom assertion library we don't know about
+        return TestQualityAssessment {
+            tier: TestQualityTier::Unknown,
+            confidence: 0.3,
+            evidence: QualityEvidence {
+                assertion_count: 0,
+                assertion_source: EvidenceSource::Regex,
+                has_error_testing: false,
+                mock_count: regex_mocks as u32,
+                body_lines,
+            },
+        };
+    }
+
+    let tier = classify_from_counts(regex_assertions as u32, regex_errors);
+    let confidence = match tier {
+        TestQualityTier::Thorough => 0.5,
+        TestQualityTier::Adequate => 0.45,
+        TestQualityTier::Thin => 0.4,
+        _ => 0.3,
+    };
+    TestQualityAssessment {
+        tier,
+        confidence,
+        evidence: QualityEvidence {
+            assertion_count: regex_assertions as u32,
+            assertion_source: EvidenceSource::Regex,
+            has_error_testing: regex_errors,
+            mock_count: regex_mocks as u32,
+            body_lines,
+        },
+    }
+}
+
+fn classify_from_counts(assertion_count: u32, has_error_testing: bool) -> TestQualityTier {
+    if assertion_count >= 3 && has_error_testing {
+        TestQualityTier::Thorough
+    } else if assertion_count >= 2 {
+        TestQualityTier::Adequate
+    } else if assertion_count >= 1 {
+        TestQualityTier::Thin
+    } else {
+        TestQualityTier::Stub
+    }
+}
+
+fn is_placeholder_body(body: &str) -> bool {
+    let trimmed = body.trim();
+    trimmed.is_empty()
+        || trimmed == "pass"
+        || trimmed == "..."
+        || trimmed.starts_with("todo!(")
+        || trimmed.starts_with("unimplemented!(")
+        || trimmed.starts_with("// TODO")
+        || trimmed.starts_with("# TODO")
+}
+```
+
+**Step 3: Update compute_test_quality_metrics**
+
+The pipeline function `compute_test_quality_metrics` needs to:
+1. Read `test_role` from symbol metadata (not just `is_test`)
+2. Query identifier counts from the database for each test
+3. Call `assess_test_quality` with identifier evidence
+4. Store the new assessment format in metadata
+
+```rust
+pub fn compute_test_quality_metrics(
+    db: &SymbolDatabase,
+    language_configs: &LanguageConfigs,
+) -> Result<TestQualityStats> {
+    let mut stats = TestQualityStats::default();
+
+    let mut stmt = db.conn.prepare(
+        "SELECT id, code_context, metadata, language FROM symbols
+         WHERE json_extract(metadata, '$.is_test') = 1",
+    )?;
+
+    let rows: Vec<(String, Option<String>, Option<String>, String)> = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    db.conn.execute_batch("BEGIN")?;
+    let result = (|| -> Result<()> {
+        for (id, code_context, metadata_str, language) in &rows {
+            let test_role = metadata_str
+                .as_ref()
+                .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+                .and_then(|v| v.get("test_role")?.as_str().map(String::from));
+
+            // Query identifier evidence
+            let evidence_config = language_configs
+                .get(language)
+                .map(|c| &c.test_evidence);
+
+            let (id_assertions, id_errors, id_mocks, has_id_evidence) =
+                if let Some(config) = evidence_config {
+                    query_identifier_evidence(db, id, config)?
+                } else {
+                    (0, 0, 0, false)
+                };
+
+            let assessment = assess_test_quality(
+                test_role.as_deref(),
+                code_context.as_deref(),
+                id_assertions,
+                id_errors,
+                id_mocks,
+                has_id_evidence,
+            );
+
+            // Update stats
+            stats.total_tests += 1;
+            match assessment.tier {
+                TestQualityTier::Thorough => stats.thorough += 1,
+                TestQualityTier::Adequate => stats.adequate += 1,
+                TestQualityTier::Thin => stats.thin += 1,
+                TestQualityTier::Stub => stats.stub += 1,
+                TestQualityTier::Unknown | TestQualityTier::NotApplicable => {}
+            }
+
+            // Merge assessment into metadata
+            let quality_json = serde_json::json!({
+                "quality_tier": assessment.tier.as_str(),
+                "confidence": assessment.confidence,
+                "assertion_count": assessment.evidence.assertion_count,
+                "assertion_source": format!("{:?}", assessment.evidence.assertion_source).to_lowercase(),
+                "has_error_testing": assessment.evidence.has_error_testing,
+                "mock_count": assessment.evidence.mock_count,
+                "body_lines": assessment.evidence.body_lines,
+            });
+
+            db.conn.execute(
+                "UPDATE symbols SET metadata = json_set(
+                    COALESCE(metadata, '{}'),
+                    '$.test_quality', json(?1)
+                ) WHERE id = ?2",
+                rusqlite::params![quality_json.to_string(), id],
+            )?;
+        }
+        Ok(())
+    })();
+
+    match result {
+        Ok(()) => db.conn.execute_batch("COMMIT")?,
+        Err(e) => {
+            let _ = db.conn.execute_batch("ROLLBACK");
+            return Err(e);
+        }
+    }
+
+    Ok(stats)
+}
+
+fn query_identifier_evidence(
+    db: &SymbolDatabase,
+    symbol_id: &str,
+    config: &TestEvidenceConfig,
+) -> Result<(u32, u32, u32, bool)> {
+    if config.assertion_identifiers.is_empty() {
+        return Ok((0, 0, 0, false));
+    }
+
+    let names: Vec<String> = db
+        .conn
+        .prepare("SELECT LOWER(name) FROM identifiers WHERE containing_symbol_id = ?1")?
+        .query_map([symbol_id], |row| row.get::<_, String>(0))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    if names.is_empty() {
+        return Ok((0, 0, 0, false));
+    }
+
+    let assertion_set: std::collections::HashSet<&str> =
+        config.assertion_identifiers.iter().map(|s| s.as_str()).collect();
+    let error_set: std::collections::HashSet<&str> =
+        config.error_assertion_identifiers.iter().map(|s| s.as_str()).collect();
+    let mock_set: std::collections::HashSet<&str> =
+        config.mock_identifiers.iter().map(|s| s.as_str()).collect();
+
+    let assertions = names.iter().filter(|n| assertion_set.contains(n.as_str())).count() as u32;
+    let errors = names.iter().filter(|n| error_set.contains(n.as_str())).count() as u32;
+    let mocks = names.iter().filter(|n| mock_set.contains(n.as_str())).count() as u32;
+
+    Ok((assertions, errors, mocks, true))
+}
+```
+
+**Step 4: Update analyze_batch to pass language_configs**
+
+In `src/tools/workspace/indexing/pipeline.rs:627`, `compute_test_quality_metrics` now takes `language_configs`:
+
+```rust
+let language_configs = handler.language_configs();
+if let Err(e) = crate::analysis::compute_test_quality_metrics(&db_lock, &language_configs) {
+    warn!("Failed to compute test quality metrics: {}", e);
+}
+```
+
+Find how `handler` exposes language_configs (use `deep_dive(symbol="language_configs")`) and wire it through.
+
+**Step 5: Run tests**
+
+```bash
+cargo nextest run --lib test_fixture_is_not 2>&1 | tail -5
+cargo nextest run --lib test_empty_body_is 2>&1 | tail -5
+cargo nextest run --lib test_identifier_based 2>&1 | tail -5
+cargo nextest run --lib test_regex_zero 2>&1 | tail -5
+```
+
+**Step 6: Commit**
+
+```bash
+git add src/analysis/test_quality.rs src/analysis/mod.rs src/tools/workspace/indexing/pipeline.rs src/tests/analysis/test_quality_tests.rs
+git commit -m "feat(analysis): replace regex quality oracle with evidence model
+
+test_quality now uses identifier-based assertion counting against
+framework-specific config, with regex as lower-confidence fallback.
+Fixtures return NotApplicable instead of false Stub. Unknown tier
+replaces false Stub when regex finds zero assertions. All tiers
+carry confidence scores."
+```
+
+---
+
+## Session 4: Risk Gating & Signal Surfaces
+
+### Task 8: Confidence-gated change_risk
+
+**Files:**
+- Modify: `src/analysis/change_risk.rs:72-81` (update test_weakness_score)
+- Modify: `src/analysis/change_risk.rs:115-238` (read confidence from metadata)
+- Test: `src/tests/analysis/change_risk_tests.rs`
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_weakness_score_with_high_confidence() {
+    let score = test_weakness_score(Some("thorough"), 0.9);
+    assert!((score - 0.1).abs() < 0.05); // Near the raw 0.1 for thorough
+}
+
+#[test]
+fn test_weakness_score_with_low_confidence_converges_to_neutral() {
+    let score = test_weakness_score(Some("stub"), 0.0);
+    assert!((score - 0.5).abs() < 0.01); // Should be neutral
+}
+
+#[test]
+fn test_weakness_score_unknown_tier() {
+    let score = test_weakness_score(Some("unknown"), 0.3);
+    // raw_weakness for unknown = 0.5, confidence 0.3
+    // result = 0.5 + (0.5 - 0.5) * 0.3 = 0.5
+    assert!((score - 0.5).abs() < 0.01);
+}
+```
+
+**Step 2: Update test_weakness_score**
+
+```rust
+pub fn test_weakness_score(best_tier: Option<&str>, confidence: f64) -> f64 {
+    let raw_weakness = match best_tier {
+        None => 1.0,
+        Some("stub") => 0.9,
+        Some("thin") => 0.6,
+        Some("adequate") => 0.3,
+        Some("thorough") => 0.1,
+        Some("unknown") => 0.5,
+        Some("n/a") => 0.5,
+        _ => 0.5,
+    };
+    let neutral = 0.5;
+    neutral + (raw_weakness - neutral) * confidence
+}
+```
+
+**Step 3: Update compute_change_risk_scores to read confidence**
+
+In the query that reads `test_linkage` metadata (around line 180), also read `test_quality.confidence`:
+
+```rust
+let confidence: f64 = meta
+    .get("test_linkage")
+    .and_then(|tl| {
+        // Get linked test quality confidence
+        // For now, use 1.0 if tier is known, 0.5 for unknown
+        let tier = tl.get("best_tier")?.as_str()?;
+        match tier {
+            "thorough" | "adequate" | "thin" | "stub" => Some(0.8),
+            "unknown" => Some(0.3),
+            _ => Some(0.5),
+        }
+    })
+    .unwrap_or(1.0); // No linkage at all: full weight on "untested"
+
+let test_weak = test_weakness_score(best_tier, confidence);
+```
+
+**Step 4: Run tests**
+
+```bash
+cargo nextest run --lib test_weakness_score 2>&1 | tail -10
+cargo nextest run --lib test_compute_change_risk 2>&1 | tail -10
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/analysis/change_risk.rs src/tests/analysis/change_risk_tests.rs
+git commit -m "feat(analysis): confidence-gate test weakness in change_risk
+
+test_weakness_score takes confidence parameter. Low-confidence tiers
+converge toward neutral (0.5), preventing unreliable quality
+assessments from dominating risk scores."
+```
+
+---
+
+### Task 9: Add scheduler signal to early_warnings
+
+**Files:**
+- Modify: `src/analysis/early_warnings.rs` (add SchedulerSignal section)
+- Test: `src/tests/analysis/` (add scheduler signal tests)
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_scheduler_signal_from_annotation() {
+    // Build a symbol with a scheduler annotation
+    let symbol = test_symbol("process_daily", "java", "src/jobs/DailyJob.java",
+        vec![annotation("scheduled", "Scheduled")]);
+    // ... setup db, insert, generate report
+    assert!(!report.scheduler_signals.is_empty());
+    assert_eq!(report.scheduler_signals[0].symbol_name, "process_daily");
+}
+```
+
+**Step 2: Add SchedulerSignal to report structs**
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SchedulerSignal {
+    pub symbol_id: String,
+    pub symbol_name: String,
+    pub symbol_kind: String,
+    pub language: String,
+    pub file_path: String,
+    pub start_line: u32,
+    pub annotation: String,
+    pub annotation_key: String,
+    pub raw_text: Option<String>,
+}
+```
+
+Add `scheduler_signals: Vec<SchedulerSignal>` to `EarlyWarningReport`.
+Add `scheduler_signals: usize` to `ReportSummary`.
+
+**Step 3: Add scheduler to AnnotationSets and build_report**
+
+In `annotation_sets()`:
+
+```rust
+let scheduler: HashSet<String> = config
+    .annotation_classes
+    .scheduler
+    .iter()
+    .cloned()
+    .collect();
+```
+
+In `build_report()`, add scheduler detection alongside entrypoint/auth/review:
+
+```rust
+if sets.scheduler.contains(&annotation.annotation_key) {
+    scheduler_signals.push(scheduler_signal(symbol, annotation));
+}
+```
+
+**Step 4: Commit**
+
+---
+
+### Task 10: Add untested entry point and high-centrality untested signals
+
+**Files:**
+- Modify: `src/analysis/early_warnings.rs`
+- Test: `src/tests/analysis/`
+
+**Step 1: Add UntestedEntryPointSignal**
+
+Cross-reference entry points with test_linkage metadata. For each entry point symbol, check if `metadata.test_linkage` exists:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UntestedEntryPointSignal {
+    pub symbol_id: String,
+    pub symbol_name: String,
+    pub symbol_kind: String,
+    pub language: String,
+    pub file_path: String,
+    pub start_line: u32,
+    pub annotation: String,
+}
+```
+
+In `build_report`, after collecting entry_points:
+
+```rust
+let mut untested_entry_points = Vec::new();
+for ep in &entry_points {
+    if let Some(symbol) = symbol_map.get(&ep.symbol_id) {
+        let has_test_linkage = symbol.metadata
+            .as_ref()
+            .and_then(|m| m.get("test_linkage"))
+            .is_some();
+        if !has_test_linkage {
+            untested_entry_points.push(UntestedEntryPointSignal {
+                symbol_id: ep.symbol_id.clone(),
+                symbol_name: ep.symbol_name.clone(),
+                symbol_kind: ep.symbol_kind.clone(),
+                language: ep.language.clone(),
+                file_path: ep.file_path.clone(),
+                start_line: ep.start_line,
+                annotation: ep.annotation.clone(),
+            });
+        }
+    }
+}
+```
+
+**Step 2: Add HighCentralityUntestedSignal**
+
+Query top-N centrality symbols with no test linkage:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HighCentralityUntestedSignal {
+    pub symbol_id: String,
+    pub symbol_name: String,
+    pub symbol_kind: String,
+    pub language: String,
+    pub file_path: String,
+    pub start_line: u32,
+    pub reference_score: f64,
+}
+```
+
+Query from the database (not the in-memory symbol list, since we need reference_score):
+
+```rust
+fn collect_high_centrality_untested(
+    db: &SymbolDatabase,
+    file_pattern: Option<&str>,
+    limit: usize,
+) -> Result<Vec<HighCentralityUntestedSignal>> {
+    let mut stmt = db.conn.prepare(
+        "SELECT id, name, kind, language, file_path, start_line, reference_score
+         FROM symbols
+         WHERE reference_score > 0
+           AND (json_extract(metadata, '$.is_test') IS NULL
+                OR json_extract(metadata, '$.is_test') != 1)
+           AND json_extract(metadata, '$.test_linkage') IS NULL
+         ORDER BY reference_score DESC
+         LIMIT ?1",
+    )?;
+    // ... map rows to HighCentralityUntestedSignal
+}
+```
+
+**Step 3: Update report structs and CLI output**
+
+Add both new signal vecs to `EarlyWarningReport` and `ReportSummary`. Update the CLI `signals` command formatter to render the new sections.
+
+**Step 4: Signal framing**
+
+All output must use honest language:
+- "No test linkage observed" not "untested"
+- "No auth marker found in owner chain" not "unauthenticated"
+- "Executes on a schedule without request context" not "insecure"
+
+**Step 5: Run full test tier**
+
+```bash
+cargo xtask test dev 2>&1 | tail -20
+```
+
+**Step 6: Commit**
+
+```bash
+git add src/analysis/early_warnings.rs src/analysis/mod.rs src/tests/analysis/ src/cli_tools/
+git commit -m "feat(signals): add scheduler, untested entry point, and high-centrality signals
+
+Three new signal sections in the early warning report:
+- SchedulerSignal: symbols with scheduler annotations
+- UntestedEntryPointSignal: API endpoints with no observed test linkage
+- HighCentralityUntestedSignal: high-centrality symbols with no test coverage
+
+All framing uses 'observed'/'no linkage found' language."
+```
+
+---
+
+## Verification
+
+After all sessions complete:
+
+1. `cargo xtask test dev` passes
+2. `cargo xtask test dogfood` passes (search quality unaffected)
+3. `cargo clippy` clean
+4. `cargo fmt` clean
+5. Run `julie-server signals --workspace . --standalone --json` and verify:
+   - Scheduler signals appear for annotated symbols
+   - Entry point test coverage gaps appear
+   - No false "stub" tiers on fixture functions
+6. Run `julie-server signals --workspace . --standalone --format markdown` and verify honest framing language
+
+---
+
+## Task Dependency Graph
+
+```
+Task 1 (types) ──→ Task 2 (TOML) ──→ Task 3 (init)
+                                           │
+                                           ▼
+                    Task 4 (classify) ──→ Task 5 (server consumers)
+                         │
+                         ▼
+Task 6 (evidence config) ──→ Task 7 (quality model)
+                                      │
+                                      ▼
+                              Task 8 (risk gating)
+                                      │
+                                      ▼
+                    Task 9 (scheduler) ──→ Task 10 (coverage signals)
+```
+
+Tasks 1-3 are serial (each depends on previous). Tasks 4-5 depend on 1-3. Tasks 6-7 can start after Task 3 (don't need Task 4-5). Task 8 needs Task 7. Tasks 9-10 need Task 8.
+
+Within each session, tasks are serial. Sessions 1-2 are serial. Session 3 depends on Session 1 but can overlap with Session 2 if desired. Session 4 depends on Session 3.

--- a/languages/csharp.toml
+++ b/languages/csharp.toml
@@ -64,6 +64,11 @@ fixture_setup = ["setup", "onetimesetup", "testinitialize", "classinitialize", "
 fixture_teardown = ["teardown", "onetimeteardown", "testcleanup", "classcleanup", "assemblycleanup"]
 test_container = ["testfixture", "testclass", "collection", "collectiondefinition"]
 
+[test_evidence]
+assertion_identifiers = ["equal", "true", "false", "null", "notnull", "throws", "throwsasync", "contains", "empty", "istype", "collection", "single", "istrue", "isfalse", "areequal"]
+error_assertion_identifiers = ["throws", "throwsasync", "catch"]
+mock_identifiers = ["mock", "setup", "returns", "verifiable"]
+
 [early_warnings]
 review_markers = ["allowanonymous"]
 schema_version = 1

--- a/languages/csharp.toml
+++ b/languages/csharp.toml
@@ -56,8 +56,13 @@ entrypoint = [
 ]
 auth = ["authorize"]
 auth_bypass = ["allowanonymous"]
-test = ["fact", "theory", "testmethod"]
-fixture = ["setup", "testinitialize", "onetimesetup", "collection"]
+
+[annotation_classes.test]
+test_case = ["fact", "test", "testmethod"]
+parameterized_test = ["theory", "testcase", "testcasesource", "datatestmethod"]
+fixture_setup = ["setup", "onetimesetup", "testinitialize", "classinitialize", "assemblyinitialize"]
+fixture_teardown = ["teardown", "onetimeteardown", "testcleanup", "classcleanup", "assemblycleanup"]
+test_container = ["testfixture", "testclass", "collection", "collectiondefinition"]
 
 [early_warnings]
 review_markers = ["allowanonymous"]

--- a/languages/java.toml
+++ b/languages/java.toml
@@ -72,6 +72,11 @@ fixture_setup = ["beforeeach", "beforeall", "before", "beforeclass", "beforemeth
 fixture_teardown = ["aftereach", "afterall", "after", "afterclass", "aftermethod", "aftersuite"]
 test_container = ["nested"]
 
+[test_evidence]
+assertion_identifiers = ["assertequals", "asserttrue", "assertfalse", "assertnull", "assertnotnull", "assertthrows", "assertthat"]
+error_assertion_identifiers = ["assertthrows"]
+mock_identifiers = ["mock", "spy", "when", "verify"]
+
 [early_warnings]
 review_markers = ["permitall"]
 schema_version = 1

--- a/languages/java.toml
+++ b/languages/java.toml
@@ -64,8 +64,13 @@ auth = [
 ]
 auth_bypass = ["permitall"]
 scheduler = ["scheduled"]
-test = ["test", "parameterizedtest"]
-fixture = ["beforeeach", "beforeall"]
+
+[annotation_classes.test]
+test_case = ["test", "repeatedtest", "testfactory", "testtemplate"]
+parameterized_test = ["parameterizedtest"]
+fixture_setup = ["beforeeach", "beforeall", "before", "beforeclass", "beforemethod", "beforesuite"]
+fixture_teardown = ["aftereach", "afterall", "after", "afterclass", "aftermethod", "aftersuite"]
+test_container = ["nested"]
 
 [early_warnings]
 review_markers = ["permitall"]

--- a/languages/kotlin.toml
+++ b/languages/kotlin.toml
@@ -69,6 +69,11 @@ fixture_setup = ["beforeeach", "beforeall", "before", "beforeclass", "beforemeth
 fixture_teardown = ["aftereach", "afterall", "after", "afterclass", "aftermethod", "aftersuite", "aftertest"]
 test_container = ["nested"]
 
+[test_evidence]
+assertion_identifiers = ["assertequals", "asserttrue", "assertfalse", "assertnull", "assertnotnull", "assertthrows", "assertthat"]
+error_assertion_identifiers = ["assertthrows"]
+mock_identifiers = ["mock", "every", "verify", "coevery"]
+
 [early_warnings]
 review_markers = ["permitall"]
 schema_version = 1

--- a/languages/kotlin.toml
+++ b/languages/kotlin.toml
@@ -61,8 +61,13 @@ auth = [
 ]
 auth_bypass = ["permitall"]
 scheduler = ["scheduled"]
-test = ["test", "parameterizedtest"]
-fixture = ["beforeeach", "beforeall"]
+
+[annotation_classes.test]
+test_case = ["test", "repeatedtest", "testfactory", "testtemplate"]
+parameterized_test = ["parameterizedtest"]
+fixture_setup = ["beforeeach", "beforeall", "before", "beforeclass", "beforemethod", "beforesuite", "beforetest"]
+fixture_teardown = ["aftereach", "afterall", "after", "afterclass", "aftermethod", "aftersuite", "aftertest"]
+test_container = ["nested"]
 
 [early_warnings]
 review_markers = ["permitall"]

--- a/languages/python.toml
+++ b/languages/python.toml
@@ -70,6 +70,11 @@ fixture_setup = ["pytest.fixture"]
 fixture_teardown = []
 test_container = []
 
+[test_evidence]
+assertion_identifiers = ["assert", "assertequal", "asserttrue", "assertfalse", "assertin", "assertisnone", "assertraises"]
+error_assertion_identifiers = ["assertraises", "pytest.raises"]
+mock_identifiers = ["mock", "magicmock", "patch", "mock_open"]
+
 [early_warnings]
 review_markers = ["allow_anonymous"]
 schema_version = 1

--- a/languages/python.toml
+++ b/languages/python.toml
@@ -62,8 +62,13 @@ auth = [
 ]
 auth_bypass = ["allow_anonymous"]
 scheduler = ["celery.task", "shared_task", "periodic_task"]
-test = ["pytest.mark.parametrize", "pytest.mark.asyncio", "pytest.mark.django_db"]
-fixture = ["pytest.fixture"]
+
+[annotation_classes.test]
+test_case = []
+parameterized_test = ["pytest.mark.parametrize"]
+fixture_setup = ["pytest.fixture"]
+fixture_teardown = []
+test_container = []
 
 [early_warnings]
 review_markers = ["allow_anonymous"]

--- a/languages/rust.toml
+++ b/languages/rust.toml
@@ -47,7 +47,9 @@ important_patterns = [
 extra_kinds = []
 
 [annotation_classes]
-test = ["test", "tokio::test"]
+
+[annotation_classes.test]
+test_case = ["test", "tokio::test", "rstest"]
 
 [early_warnings]
 schema_version = 1

--- a/languages/rust.toml
+++ b/languages/rust.toml
@@ -51,5 +51,10 @@ extra_kinds = []
 [annotation_classes.test]
 test_case = ["test", "tokio::test", "rstest"]
 
+[test_evidence]
+assertion_identifiers = ["assert_eq", "assert_ne", "assert", "assert_matches", "debug_assert"]
+error_assertion_identifiers = ["should_err", "should_panic"]
+mock_identifiers = []
+
 [early_warnings]
 schema_version = 1

--- a/src/analysis/change_risk.rs
+++ b/src/analysis/change_risk.rs
@@ -183,10 +183,13 @@ pub fn compute_change_risk_scores(db: &SymbolDatabase) -> Result<ChangeRiskStats
                 .and_then(|v| v.get("best_tier"))
                 .and_then(|v| v.as_str())
                 .map(String::from);
-            let confidence = tl_entry
-                .and_then(|v| v.get("best_confidence"))
-                .and_then(|v| v.as_f64())
-                .unwrap_or(0.5); // Default for old data without confidence
+            let confidence = match tl_entry {
+                Some(linkage) => linkage
+                    .get("best_confidence")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.5), // Default for old data without confidence
+                None => 1.0,
+            };
             let tw = test_weakness_score(best_tier.as_deref(), confidence);
 
             let score = compute_risk_score(centrality, vis_score, tw, kw);

--- a/src/analysis/change_risk.rs
+++ b/src/analysis/change_risk.rs
@@ -67,17 +67,24 @@ pub fn kind_weight(kind: &SymbolKind) -> Option<f64> {
     }
 }
 
-/// Map linked-test best_tier to a "test weakness" score.
-/// Higher = weaker linkage = more risk.
-pub fn test_weakness_score(best_tier: Option<&str>) -> f64 {
-    match best_tier {
-        None => 1.0, // Untested
-        Some("stub") => 0.8,
+/// Map linked-test best_tier to a "test weakness" score, gated by confidence.
+/// Higher = weaker linkage = more risk.  Low confidence pulls the score
+/// toward the neutral midpoint (0.5) so uncertain tiers neither inflate
+/// nor deflate risk.
+pub fn test_weakness_score(best_tier: Option<&str>, confidence: f64) -> f64 {
+    let raw_weakness = match best_tier {
+        None => 1.0,
+        Some("stub") => 0.9,
         Some("thin") => 0.6,
         Some("adequate") => 0.3,
         Some("thorough") => 0.1,
-        _ => 1.0, // Unknown tier → treat as untested
-    }
+        Some("unknown") => 0.5,
+        Some("n/a") => 0.5,
+        _ => 0.5, // Unrecognized tier -> neutral
+    };
+    let confidence = confidence.clamp(0.0, 1.0);
+    let neutral = 0.5;
+    neutral + (raw_weakness - neutral) * confidence
 }
 
 /// Normalize reference_score to 0.0–1.0 using log sigmoid.
@@ -171,13 +178,16 @@ pub fn compute_change_risk_scores(db: &SymbolDatabase) -> Result<ChangeRiskStats
             let metadata = metadata_json
                 .as_ref()
                 .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok());
-            let best_tier = metadata
-                .as_ref()
-                .and_then(test_linkage_entry)
+            let tl_entry = metadata.as_ref().and_then(test_linkage_entry);
+            let best_tier = tl_entry
                 .and_then(|v| v.get("best_tier"))
                 .and_then(|v| v.as_str())
                 .map(String::from);
-            let tw = test_weakness_score(best_tier.as_deref());
+            let confidence = tl_entry
+                .and_then(|v| v.get("best_confidence"))
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.5); // Default for old data without confidence
+            let tw = test_weakness_score(best_tier.as_deref(), confidence);
 
             let score = compute_risk_score(centrality, vis_score, tw, kw);
             let label = risk_label(score);

--- a/src/analysis/early_warnings.rs
+++ b/src/analysis/early_warnings.rs
@@ -219,14 +219,13 @@ fn build_report(
         }
     }
 
-    // Entry point linkage gaps: entry points with no observed test_linkage metadata
+    // Entry point linkage gaps: entry points with no observed linkage metadata.
     let mut entry_point_linkage_gaps = Vec::new();
     for ep in &entry_points {
         let has_test_linkage = symbol_map
             .get(&ep.symbol_id)
             .and_then(|s| s.metadata.as_ref())
-            .and_then(|m| m.get("test_linkage"))
-            .is_some();
+            .is_some_and(|m| m.contains_key("test_linkage") || m.contains_key("test_coverage"));
         if !has_test_linkage {
             entry_point_linkage_gaps.push(EntryPointLinkageGap {
                 symbol_id: ep.symbol_id.clone(),
@@ -240,7 +239,7 @@ fn build_report(
         }
     }
 
-    let high_centrality_linkage_gaps =
+    let (high_centrality_linkage_gap_count, high_centrality_linkage_gaps) =
         collect_high_centrality_linkage_gaps(db, file_pattern.as_deref(), 20)?;
 
     let summary = ReportSummary {
@@ -249,7 +248,7 @@ fn build_report(
         review_markers: review_markers.len(),
         scheduler_signals: scheduler_signals.len(),
         entry_point_linkage_gaps: entry_point_linkage_gaps.len(),
-        high_centrality_linkage_gaps: high_centrality_linkage_gaps.len(),
+        high_centrality_linkage_gaps: high_centrality_linkage_gap_count,
     };
 
     Ok(EarlyWarningReport {
@@ -544,14 +543,8 @@ fn collect_high_centrality_linkage_gaps(
     db: &SymbolDatabase,
     file_pattern: Option<&str>,
     limit: usize,
-) -> Result<Vec<HighCentralityLinkageGap>> {
-    // Query symbols with reference_score > 0, not tests, and no test_linkage metadata.
-    // Over-fetch by 4x to allow for file_pattern filtering after the query.
-    let fetch_limit = if file_pattern.is_some() {
-        limit * 4
-    } else {
-        limit
-    };
+) -> Result<(usize, Vec<HighCentralityLinkageGap>)> {
+    // Query symbols with reference_score > 0, not tests, and no linkage metadata.
     let mut stmt = db.conn.prepare(
         "SELECT id, name, kind, language, file_path, start_line, reference_score
          FROM symbols
@@ -559,10 +552,10 @@ fn collect_high_centrality_linkage_gaps(
            AND (json_extract(metadata, '$.is_test') IS NULL
                 OR json_extract(metadata, '$.is_test') != 1)
            AND json_extract(metadata, '$.test_linkage') IS NULL
-         ORDER BY reference_score DESC
-         LIMIT ?1",
+           AND json_extract(metadata, '$.test_coverage') IS NULL
+         ORDER BY reference_score DESC",
     )?;
-    let rows = stmt.query_map(params![fetch_limit as i64], |row| {
+    let rows = stmt.query_map([], |row| {
         Ok(HighCentralityLinkageGap {
             symbol_id: row.get(0)?,
             symbol_name: row.get(1)?,
@@ -575,16 +568,17 @@ fn collect_high_centrality_linkage_gaps(
     })?;
 
     let mut gaps = Vec::new();
+    let mut total_matching_gaps = 0;
     for row_result in rows {
         let gap = row_result?;
         if matches_file_pattern(&gap.file_path, file_pattern) {
-            gaps.push(gap);
-            if gaps.len() >= limit {
-                break;
+            total_matching_gaps += 1;
+            if gaps.len() < limit {
+                gaps.push(gap);
             }
         }
     }
-    Ok(gaps)
+    Ok((total_matching_gaps, gaps))
 }
 
 fn unix_timestamp_millis() -> i64 {

--- a/src/analysis/early_warnings.rs
+++ b/src/analysis/early_warnings.rs
@@ -160,14 +160,9 @@ fn build_report(
             if sets.entrypoint.contains(&annotation.annotation_key) {
                 entry_points.push(entry_point_signal(symbol, annotation));
                 if auth_candidate_symbol_ids.insert(symbol.id.clone()) {
-                    let has_auth = has_auth_marker_in_owner_chain(
-                        symbol,
-                        &symbol_map,
-                        &sets.auth,
-                    );
+                    let has_auth = has_auth_marker_in_owner_chain(symbol, &symbol_map, &sets.auth);
                     if !has_auth {
-                        auth_coverage_candidates
-                            .push(auth_coverage_candidate(symbol, annotation));
+                        auth_coverage_candidates.push(auth_coverage_candidate(symbol, annotation));
                     }
                 }
             }

--- a/src/analysis/early_warnings.rs
+++ b/src/analysis/early_warnings.rs
@@ -9,7 +9,7 @@ use crate::search::language_config::{LanguageConfig, LanguageConfigs};
 use crate::tools::search::matches_glob_pattern;
 
 const TANTIVY_PROJECTION: &str = "tantivy";
-const DEFAULT_CONFIG_SCHEMA_VERSION: u32 = 1;
+const DEFAULT_CONFIG_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EarlyWarningReportOptions {
@@ -19,7 +19,7 @@ pub struct EarlyWarningReportOptions {
     pub limit_per_section: Option<usize>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct EarlyWarningReport {
     pub workspace_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -33,6 +33,9 @@ pub struct EarlyWarningReport {
     pub entry_points: Vec<EntryPointSignal>,
     pub auth_coverage_candidates: Vec<AuthCoverageCandidate>,
     pub review_markers: Vec<ReviewMarkerSignal>,
+    pub scheduler_signals: Vec<SchedulerSignal>,
+    pub entry_point_linkage_gaps: Vec<EntryPointLinkageGap>,
+    pub high_centrality_linkage_gaps: Vec<HighCentralityLinkageGap>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -40,6 +43,9 @@ pub struct ReportSummary {
     pub entry_points: usize,
     pub auth_coverage_candidates: usize,
     pub review_markers: usize,
+    pub scheduler_signals: usize,
+    pub entry_point_linkage_gaps: usize,
+    pub high_centrality_linkage_gaps: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -84,6 +90,42 @@ pub struct ReviewMarkerSignal {
     pub raw_text: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SchedulerSignal {
+    pub symbol_id: String,
+    pub symbol_name: String,
+    pub symbol_kind: String,
+    pub language: String,
+    pub file_path: String,
+    pub start_line: u32,
+    pub annotation: String,
+    pub annotation_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_text: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EntryPointLinkageGap {
+    pub symbol_id: String,
+    pub symbol_name: String,
+    pub symbol_kind: String,
+    pub language: String,
+    pub file_path: String,
+    pub start_line: u32,
+    pub entry_annotation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HighCentralityLinkageGap {
+    pub symbol_id: String,
+    pub symbol_name: String,
+    pub symbol_kind: String,
+    pub language: String,
+    pub file_path: String,
+    pub start_line: u32,
+    pub reference_score: f64,
+}
+
 #[derive(Debug, Clone)]
 struct ReportCacheKey {
     workspace_id: String,
@@ -98,6 +140,7 @@ struct AnnotationSets {
     entrypoint: HashSet<String>,
     auth: HashSet<String>,
     review: HashSet<String>,
+    scheduler: HashSet<String>,
 }
 
 pub fn generate_early_warning_report(
@@ -140,6 +183,7 @@ fn build_report(
     let mut entry_points = Vec::new();
     let mut auth_coverage_candidates = Vec::new();
     let mut review_markers = Vec::new();
+    let mut scheduler_signals = Vec::new();
     let mut auth_candidate_symbol_ids = HashSet::new();
 
     for symbol in symbols
@@ -169,13 +213,43 @@ fn build_report(
             if sets.review.contains(&annotation.annotation_key) {
                 review_markers.push(review_marker_signal(symbol, annotation));
             }
+            if sets.scheduler.contains(&annotation.annotation_key) {
+                scheduler_signals.push(scheduler_signal(symbol, annotation));
+            }
         }
     }
+
+    // Entry point linkage gaps: entry points with no observed test_linkage metadata
+    let mut entry_point_linkage_gaps = Vec::new();
+    for ep in &entry_points {
+        let has_test_linkage = symbol_map
+            .get(&ep.symbol_id)
+            .and_then(|s| s.metadata.as_ref())
+            .and_then(|m| m.get("test_linkage"))
+            .is_some();
+        if !has_test_linkage {
+            entry_point_linkage_gaps.push(EntryPointLinkageGap {
+                symbol_id: ep.symbol_id.clone(),
+                symbol_name: ep.symbol_name.clone(),
+                symbol_kind: ep.symbol_kind.clone(),
+                language: ep.language.clone(),
+                file_path: ep.file_path.clone(),
+                start_line: ep.start_line,
+                entry_annotation: ep.annotation.clone(),
+            });
+        }
+    }
+
+    let high_centrality_linkage_gaps =
+        collect_high_centrality_linkage_gaps(db, file_pattern.as_deref(), 20)?;
 
     let summary = ReportSummary {
         entry_points: entry_points.len(),
         auth_coverage_candidates: auth_coverage_candidates.len(),
         review_markers: review_markers.len(),
+        scheduler_signals: scheduler_signals.len(),
+        entry_point_linkage_gaps: entry_point_linkage_gaps.len(),
+        high_centrality_linkage_gaps: high_centrality_linkage_gaps.len(),
     };
 
     Ok(EarlyWarningReport {
@@ -190,6 +264,9 @@ fn build_report(
         entry_points,
         auth_coverage_candidates,
         review_markers,
+        scheduler_signals,
+        entry_point_linkage_gaps,
+        high_centrality_linkage_gaps,
     })
 }
 
@@ -327,10 +404,18 @@ fn annotation_sets(config: &LanguageConfig) -> AnnotationSets {
         .collect();
     review.extend(config.early_warnings.review_markers.iter().cloned());
 
+    let scheduler = config
+        .annotation_classes
+        .scheduler
+        .iter()
+        .cloned()
+        .collect();
+
     AnnotationSets {
         entrypoint,
         auth,
         review,
+        scheduler,
     }
 }
 
@@ -395,6 +480,20 @@ fn auth_coverage_candidate(
     }
 }
 
+fn scheduler_signal(symbol: &Symbol, annotation: &AnnotationMarker) -> SchedulerSignal {
+    SchedulerSignal {
+        symbol_id: symbol.id.clone(),
+        symbol_name: symbol.name.clone(),
+        symbol_kind: symbol.kind.to_string(),
+        language: symbol.language.clone(),
+        file_path: symbol.file_path.clone(),
+        start_line: symbol.start_line,
+        annotation: annotation.annotation.clone(),
+        annotation_key: annotation.annotation_key.clone(),
+        raw_text: annotation.raw_text.clone(),
+    }
+}
+
 fn review_marker_signal(symbol: &Symbol, annotation: &AnnotationMarker) -> ReviewMarkerSignal {
     ReviewMarkerSignal {
         symbol_id: symbol.id.clone(),
@@ -436,6 +535,56 @@ fn apply_limit_per_section(report: &mut EarlyWarningReport, limit: Option<usize>
     truncate_if_needed(&mut report.entry_points, limit);
     truncate_if_needed(&mut report.auth_coverage_candidates, limit);
     truncate_if_needed(&mut report.review_markers, limit);
+    truncate_if_needed(&mut report.scheduler_signals, limit);
+    truncate_if_needed(&mut report.entry_point_linkage_gaps, limit);
+    truncate_if_needed(&mut report.high_centrality_linkage_gaps, limit);
+}
+
+fn collect_high_centrality_linkage_gaps(
+    db: &SymbolDatabase,
+    file_pattern: Option<&str>,
+    limit: usize,
+) -> Result<Vec<HighCentralityLinkageGap>> {
+    // Query symbols with reference_score > 0, not tests, and no test_linkage metadata.
+    // Over-fetch by 4x to allow for file_pattern filtering after the query.
+    let fetch_limit = if file_pattern.is_some() {
+        limit * 4
+    } else {
+        limit
+    };
+    let mut stmt = db.conn.prepare(
+        "SELECT id, name, kind, language, file_path, start_line, reference_score
+         FROM symbols
+         WHERE reference_score > 0
+           AND (json_extract(metadata, '$.is_test') IS NULL
+                OR json_extract(metadata, '$.is_test') != 1)
+           AND json_extract(metadata, '$.test_linkage') IS NULL
+         ORDER BY reference_score DESC
+         LIMIT ?1",
+    )?;
+    let rows = stmt.query_map(params![fetch_limit as i64], |row| {
+        Ok(HighCentralityLinkageGap {
+            symbol_id: row.get(0)?,
+            symbol_name: row.get(1)?,
+            symbol_kind: row.get(2)?,
+            language: row.get(3)?,
+            file_path: row.get(4)?,
+            start_line: row.get(5)?,
+            reference_score: row.get(6)?,
+        })
+    })?;
+
+    let mut gaps = Vec::new();
+    for row_result in rows {
+        let gap = row_result?;
+        if matches_file_pattern(&gap.file_path, file_pattern) {
+            gaps.push(gap);
+            if gaps.len() >= limit {
+                break;
+            }
+        }
+    }
+    Ok(gaps)
 }
 
 fn unix_timestamp_millis() -> i64 {

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -11,8 +11,9 @@ pub mod test_quality;
 pub mod test_roles;
 
 pub use early_warnings::{
-    AuthCoverageCandidate, EarlyWarningReport, EarlyWarningReportOptions, EntryPointSignal,
-    ReportSummary, ReviewMarkerSignal, generate_early_warning_report,
+    AuthCoverageCandidate, EarlyWarningReport, EarlyWarningReportOptions, EntryPointLinkageGap,
+    EntryPointSignal, HighCentralityLinkageGap, ReportSummary, ReviewMarkerSignal, SchedulerSignal,
+    generate_early_warning_report,
 };
 pub use test_linkage::compute_test_linkage;
 pub use test_quality::compute_test_quality_metrics;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -4,6 +4,7 @@
 //! These analyses enrich symbol metadata with derived quality signals
 //! that tools can surface to users.
 
+pub mod change_risk;
 pub mod early_warnings;
 pub mod test_linkage;
 pub mod test_quality;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -7,6 +7,7 @@
 pub mod early_warnings;
 pub mod test_linkage;
 pub mod test_quality;
+pub mod test_roles;
 
 pub use early_warnings::{
     AuthCoverageCandidate, EarlyWarningReport, EarlyWarningReportOptions, EntryPointSignal,
@@ -14,3 +15,6 @@ pub use early_warnings::{
 };
 pub use test_linkage::compute_test_linkage;
 pub use test_quality::compute_test_quality_metrics;
+pub use test_roles::{
+    TestRoleConfig, classify_symbols_by_role, classify_test_role, is_scorable_test, is_test_related,
+};

--- a/src/analysis/test_linkage.rs
+++ b/src/analysis/test_linkage.rs
@@ -17,6 +17,7 @@ struct LinkedTest {
     name: String,
     file_path: String,
     tier: String,
+    confidence: f64,
     evidence_sources: HashSet<String>,
 }
 
@@ -26,9 +27,15 @@ pub struct TestLinkageInfo {
     pub test_count: usize,
     pub best_tier: String,
     pub worst_tier: String,
+    #[serde(default = "default_confidence")]
+    pub best_confidence: f64,
     pub linked_tests: Vec<String>,
     pub linked_test_paths: Vec<String>,
     pub evidence_sources: Vec<String>,
+}
+
+fn default_confidence() -> f64 {
+    0.5
 }
 
 /// Summary stats from running test linkage analysis.
@@ -56,6 +63,7 @@ fn add_linkage(
     test_name: String,
     test_file_path: String,
     tier: String,
+    confidence: f64,
     source: &str,
 ) {
     let entry = linkages
@@ -66,12 +74,14 @@ fn add_linkage(
             name: test_name.clone(),
             file_path: test_file_path.clone(),
             tier: tier.clone(),
+            confidence,
             evidence_sources: HashSet::new(),
         });
 
     entry.name = test_name;
     entry.file_path = test_file_path;
     entry.tier = tier;
+    entry.confidence = confidence;
     entry.evidence_sources.insert(source.to_string());
 }
 
@@ -93,17 +103,27 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
     let mut linkages: HashMap<String, HashMap<String, LinkedTest>> = HashMap::new();
     // Maps prod_id → test_id → linked test details
 
-    let mut stmt = db.conn.prepare(
+    // Scorable test filter: prefer test_role-classified symbols (test_case,
+    // parameterized_test), fall back to is_test for symbols without role
+    // classification (convention-based languages where the pipeline step
+    // did not classify).
+    let scorable_test_filter =
+        "(json_extract(s_test.metadata, '$.test_role') IN ('test_case', 'parameterized_test')
+           OR (json_extract(s_test.metadata, '$.is_test') = 1
+               AND json_extract(s_test.metadata, '$.test_role') IS NULL))";
+
+    let mut stmt = db.conn.prepare(&format!(
         "SELECT r.to_symbol_id, s_test.id, s_test.name, s_test.file_path,
-                COALESCE(json_extract(s_test.metadata, '$.test_quality.quality_tier'), 'unknown')
+                COALESCE(json_extract(s_test.metadata, '$.test_quality.quality_tier'), 'unknown'),
+                COALESCE(json_extract(s_test.metadata, '$.test_quality.confidence'), 0.5)
          FROM relationships r
          JOIN symbols s_test ON r.from_symbol_id = s_test.id
          JOIN symbols s_prod ON r.to_symbol_id = s_prod.id
-         WHERE json_extract(s_test.metadata, '$.is_test') = 1
+         WHERE {scorable_test_filter}
            AND (json_extract(s_prod.metadata, '$.is_test') IS NULL
                 OR json_extract(s_prod.metadata, '$.is_test') != 1)
            AND r.kind IN ('calls', 'uses', 'references', 'instantiates', 'imports')",
-    )?;
+    ))?;
 
     let rows = stmt.query_map([], |row| {
         Ok((
@@ -112,11 +132,12 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
             row.get::<_, String>(2)?,
             row.get::<_, String>(3)?,
             row.get::<_, String>(4)?,
+            row.get::<_, f64>(5)?,
         ))
     })?;
 
     for row in rows {
-        let (prod_id, test_id, test_name, test_file_path, tier) = row?;
+        let (prod_id, test_id, test_name, test_file_path, tier, confidence) = row?;
         add_linkage(
             &mut linkages,
             prod_id,
@@ -124,6 +145,7 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
             test_name,
             test_file_path,
             tier,
+            confidence,
             "relationship",
         );
     }
@@ -134,17 +156,18 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
     );
 
     // Step 2: Identifier-based linkage — precise (target_symbol_id set)
-    let mut stmt2 = db.conn.prepare(
+    let mut stmt2 = db.conn.prepare(&format!(
         "SELECT i.target_symbol_id, s_test.id, s_test.name, s_test.file_path,
-                COALESCE(json_extract(s_test.metadata, '$.test_quality.quality_tier'), 'unknown')
+                COALESCE(json_extract(s_test.metadata, '$.test_quality.quality_tier'), 'unknown'),
+                COALESCE(json_extract(s_test.metadata, '$.test_quality.confidence'), 0.5)
          FROM identifiers i
          JOIN symbols s_test ON i.containing_symbol_id = s_test.id
          JOIN symbols s_prod ON i.target_symbol_id = s_prod.id
-         WHERE json_extract(s_test.metadata, '$.is_test') = 1
+         WHERE {scorable_test_filter}
            AND i.target_symbol_id IS NOT NULL
            AND (json_extract(s_prod.metadata, '$.is_test') IS NULL
                 OR json_extract(s_prod.metadata, '$.is_test') != 1)",
-    )?;
+    ))?;
 
     let rows2 = stmt2.query_map([], |row| {
         Ok((
@@ -153,11 +176,12 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
             row.get::<_, String>(2)?,
             row.get::<_, String>(3)?,
             row.get::<_, String>(4)?,
+            row.get::<_, f64>(5)?,
         ))
     })?;
 
     for row in rows2 {
-        let (prod_id, test_id, test_name, test_file_path, tier) = row?;
+        let (prod_id, test_id, test_name, test_file_path, tier, confidence) = row?;
         add_linkage(
             &mut linkages,
             prod_id,
@@ -165,6 +189,7 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
             test_name,
             test_file_path,
             tier,
+            confidence,
             "resolved_identifier",
         );
     }
@@ -184,27 +209,30 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
     // runs on the same database. Combined with the explicit tie-breaker
     // below, `linked_tests` / `linked_test_paths` / `evidence_sources`
     // become reproducible — no SQLite row-order leakage.
-    let mut stmt3 = db.conn.prepare(
+    let mut stmt3 = db.conn.prepare(&format!(
         "SELECT s_prod.id, s_prod.file_path, s_test.id, s_test.name, i.file_path AS test_file,
                 COALESCE(json_extract(s_test.metadata, '$.test_quality.quality_tier'), 'unknown'),
                 i.name AS ident_name,
-                s_test.language, s_prod.language
+                s_test.language, s_prod.language,
+                COALESCE(json_extract(s_test.metadata, '$.test_quality.confidence'), 0.5)
          FROM identifiers i
          JOIN symbols s_test ON i.containing_symbol_id = s_test.id
          JOIN symbols s_prod ON s_prod.name = i.name
-         WHERE json_extract(s_test.metadata, '$.is_test') = 1
+         WHERE {scorable_test_filter}
            AND i.target_symbol_id IS NULL
            AND (json_extract(s_prod.metadata, '$.is_test') IS NULL
                 OR json_extract(s_prod.metadata, '$.is_test') != 1)
            AND s_prod.kind NOT IN ('import', 'export', 'module', 'namespace')
          ORDER BY s_prod.id, s_prod.file_path",
-    )?;
+    ))?;
 
     // Group by (test_id, identifier_name) → pick best prod match by directory proximity
-    // Key is (test_id, ident_name) — NOT (test_id, test_name) — so each identifier
+    // Key is (test_id, ident_name) -- NOT (test_id, test_name) -- so each identifier
     // reference disambiguates independently.
-    let mut name_matches: HashMap<(String, String), Vec<(String, String, String, String, String)>> =
-        HashMap::new();
+    let mut name_matches: HashMap<
+        (String, String),
+        Vec<(String, String, String, String, String, f64)>,
+    > = HashMap::new();
 
     let rows3 = stmt3.query_map([], |row| {
         Ok((
@@ -217,6 +245,7 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
             row.get::<_, String>(6)?, // ident_name
             row.get::<_, String>(7)?, // test_language
             row.get::<_, String>(8)?, // prod_language
+            row.get::<_, f64>(9)?,    // confidence
         ))
     })?;
 
@@ -231,15 +260,16 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
             ident_name,
             test_lang,
             prod_lang,
+            confidence,
         ) = row?;
-        // Language filter: skip cross-language matches (e.g. Python test → Rust symbol)
+        // Language filter: skip cross-language matches (e.g. Python test -> Rust symbol)
         if test_lang != prod_lang {
             continue;
         }
         name_matches
             .entry((test_id.clone(), ident_name))
             .or_default()
-            .push((prod_id, prod_path, test_path, tier, test_name));
+            .push((prod_id, prod_path, test_path, tier, test_name, confidence));
     }
 
     // For each (test, identifier_name), pick the production symbol with closest directory
@@ -256,7 +286,7 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
         // runs on the same database.
         let best = candidates
             .iter()
-            .max_by_key(|(prod_id, prod_path, test_path, _, _)| {
+            .max_by_key(|(prod_id, prod_path, test_path, _, _, _)| {
                 let dir_score = common_directory_depth(prod_path, test_path) * 10;
                 let test_file_stem = test_path
                     .rsplit('/')
@@ -284,7 +314,7 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
                     Reverse(prod_path.clone()),
                 )
             });
-        if let Some((prod_id, _, test_path, tier, test_name)) = best {
+        if let Some((prod_id, _, test_path, tier, test_name, confidence)) = best {
             add_linkage(
                 &mut linkages,
                 prod_id.clone(),
@@ -292,6 +322,7 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
                 test_name.clone(),
                 test_path.clone(),
                 tier.clone(),
+                *confidence,
                 "name_match_fallback",
             );
         }
@@ -324,6 +355,20 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
                 .iter()
                 .min_by_key(|t| tier_rank(t))
                 .unwrap_or(&"unknown");
+
+            // Pick the highest confidence among tests at the best tier.
+            // Defaults to 0.5 for data without confidence metadata (pre-Task 4).
+            let best_confidence: f64 = tests
+                .values()
+                .filter(|t| t.tier.as_str() == *best_tier)
+                .map(|t| t.confidence)
+                .fold(0.0_f64, f64::max);
+            let best_confidence = if best_confidence == 0.0 {
+                0.5
+            } else {
+                best_confidence
+            };
+
             let mut names: Vec<&str> = tests.values().map(|test| test.name.as_str()).collect();
             names.sort();
             names.dedup();
@@ -343,6 +388,7 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
                 "test_count": test_count,
                 "best_tier": best_tier,
                 "worst_tier": worst_tier,
+                "best_confidence": best_confidence,
                 "linked_tests": names,
                 "linked_test_paths": paths,
                 "evidence_sources": evidence_sources,

--- a/src/analysis/test_linkage.rs
+++ b/src/analysis/test_linkage.rs
@@ -444,7 +444,8 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
         "SELECT parent.id,
                 json_extract(child.metadata, '$.test_linkage.test_count'),
                 json_extract(child.metadata, '$.test_linkage.best_tier'),
-                json_extract(child.metadata, '$.test_linkage.worst_tier')
+                json_extract(child.metadata, '$.test_linkage.worst_tier'),
+                json_extract(child.metadata, '$.test_linkage.best_confidence')
          FROM symbols parent
          JOIN symbols child ON child.parent_id = parent.id
          WHERE parent.kind IN ('class', 'struct', 'interface', 'enum', 'trait')
@@ -452,26 +453,35 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
            AND (json_extract(parent.metadata, '$.test_linkage') IS NULL)",
     )?;
 
-    let mut parent_coverage: HashMap<String, (u32, String, String)> = HashMap::new();
+    // (total_tests, best_tier, worst_tier, best_confidence)
+    let mut parent_coverage: HashMap<String, (u32, String, String, f64)> = HashMap::new();
     let parent_rows = parent_stmt.query_map([], |row| {
         Ok((
             row.get::<_, String>(0)?,
             row.get::<_, u32>(1)?,
             row.get::<_, String>(2)?,
             row.get::<_, String>(3)?,
+            row.get::<_, Option<f64>>(4)?,
         ))
     })?;
 
     for row in parent_rows {
-        let (parent_id, child_count, child_best, child_worst) = row?;
+        let (parent_id, child_count, child_best, child_worst, child_confidence) = row?;
+        let child_confidence = child_confidence.unwrap_or(0.5);
         let entry = parent_coverage.entry(parent_id).or_insert((
             0,
             "stub".to_string(),
             "thorough".to_string(),
+            0.0,
         ));
         entry.0 += child_count;
         if tier_rank(&child_best) > tier_rank(&entry.1) {
-            entry.1 = child_best;
+            entry.1 = child_best.clone();
+            // When best_tier changes, reset best_confidence to this child's value
+            entry.3 = child_confidence;
+        } else if tier_rank(&child_best) == tier_rank(&entry.1) && child_confidence > entry.3 {
+            // Same tier, higher confidence wins
+            entry.3 = child_confidence;
         }
         if tier_rank(&child_worst) < tier_rank(&entry.2) {
             entry.2 = child_worst;
@@ -481,11 +491,12 @@ pub fn compute_test_linkage(db: &SymbolDatabase) -> Result<TestLinkageStats> {
     if !parent_coverage.is_empty() {
         db.conn.execute_batch("BEGIN")?;
         let agg_result = (|| -> Result<()> {
-            for (parent_id, (total_tests, best, worst)) in &parent_coverage {
+            for (parent_id, (total_tests, best, worst, confidence)) in &parent_coverage {
                 let linkage = serde_json::json!({
                     "test_count": total_tests,
                     "best_tier": best,
                     "worst_tier": worst,
+                    "best_confidence": confidence,
                     "linked_tests": [],
                     "linked_test_paths": [],
                     "evidence_sources": ["aggregated_from_methods"],

--- a/src/analysis/test_quality.rs
+++ b/src/analysis/test_quality.rs
@@ -558,8 +558,7 @@ pub fn assess_test_quality(
                 },
             }
         } else {
-            let tier =
-                classify_tier_from_counts(assertion_count, mock_count, has_error_testing);
+            let tier = classify_tier_from_counts(assertion_count, mock_count, has_error_testing);
             let confidence = if assertion_count >= 3 { 0.5 } else { 0.4 };
             TestQualityAssessment {
                 tier,
@@ -595,10 +594,7 @@ fn classify_tier_from_counts(
     }
     // Check thorough BEFORE thin: a test with error testing or mocks
     // is thorough even with low assertion counts.
-    if assertion_count >= 3
-        || has_error_testing
-        || (mock_count > 0 && assertion_count >= 2)
-    {
+    if assertion_count >= 3 || has_error_testing || (mock_count > 0 && assertion_count >= 2) {
         return TestQualityTier::Thorough;
     }
     if assertion_count == 1 {
@@ -609,9 +605,7 @@ fn classify_tier_from_counts(
 
 /// Count non-empty lines in a body string.
 fn count_non_empty_lines(body: &str) -> u32 {
-    body.lines()
-        .filter(|line| !line.trim().is_empty())
-        .count() as u32
+    body.lines().filter(|line| !line.trim().is_empty()).count() as u32
 }
 
 // =============================================================================
@@ -682,9 +676,7 @@ pub fn compute_test_quality_metrics(
                 .collect();
 
             // Match identifiers against framework-specific evidence config
-            let evidence_config = language_configs
-                .get(language)
-                .map(|cfg| &cfg.test_evidence);
+            let evidence_config = language_configs.get(language).map(|cfg| &cfg.test_evidence);
 
             let has_identifier_evidence = evidence_config.is_some() && !call_names.is_empty();
 
@@ -786,8 +778,14 @@ pub fn compute_test_quality_metrics(
 
     info!(
         "Test quality metrics: {} total, {} thorough, {} adequate, {} thin, {} stub, {} unknown, {} n/a, {} no_body",
-        stats.total_tests, stats.thorough, stats.adequate, stats.thin, stats.stub,
-        stats.unknown, stats.not_applicable, stats.no_body
+        stats.total_tests,
+        stats.thorough,
+        stats.adequate,
+        stats.thin,
+        stats.stub,
+        stats.unknown,
+        stats.not_applicable,
+        stats.no_body
     );
 
     Ok(stats)

--- a/src/analysis/test_quality.rs
+++ b/src/analysis/test_quality.rs
@@ -417,12 +417,6 @@ fn strip_comments_and_strings(body: &str) -> String {
 /// Counts assertions, mocks, error-testing patterns, and computes body lines.
 pub fn analyze_test_body(body: &str) -> TestQualityAssessment {
     let stripped = strip_comments_and_strings(body);
-    let non_empty_lines: Vec<&str> = stripped
-        .lines()
-        .filter(|line| !line.trim().is_empty())
-        .collect();
-    let body_lines = non_empty_lines.len() as u32;
-
     // Count assertion matches across all patterns (on stripped text)
     let assertion_count = count_pattern_matches(&stripped, assertion_patterns());
 

--- a/src/analysis/test_quality.rs
+++ b/src/analysis/test_quality.rs
@@ -4,6 +4,12 @@
 //! and quality tiering. Runs at post-indexing time after all symbols
 //! are stored in SQLite with their code_context.
 //!
+//! Two evidence paths:
+//! 1. **Identifier-based** (high confidence): counts Call-kind identifiers
+//!    matching framework-specific lists from TestEvidenceConfig TOML.
+//! 2. **Regex fallback** (low confidence): scans stripped body text with
+//!    language-agnostic patterns when identifier data is unavailable.
+//!
 //! Language-agnostic: patterns cover Rust, Python, Java, C#, JS/TS,
 //! Go, Ruby, Swift, PHP, Kotlin, and more.
 
@@ -14,20 +20,62 @@ use std::sync::OnceLock;
 use tracing::{debug, info, warn};
 
 use crate::database::SymbolDatabase;
+use crate::search::LanguageConfigs;
 
 // =============================================================================
 // Public types
 // =============================================================================
 
-/// Quality metrics computed from analyzing a test function's body.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TestQualityMetrics {
+/// Assessment of a test function's quality, with confidence scoring.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TestQualityAssessment {
+    pub tier: TestQualityTier,
+    pub confidence: f32,
+    pub evidence: QualityEvidence,
+}
+
+/// Quality tier classification for a test function.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum TestQualityTier {
+    Thorough,
+    Adequate,
+    Thin,
+    Stub,
+    Unknown,
+    NotApplicable,
+}
+
+impl TestQualityTier {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Thorough => "thorough",
+            Self::Adequate => "adequate",
+            Self::Thin => "thin",
+            Self::Stub => "stub",
+            Self::Unknown => "unknown",
+            Self::NotApplicable => "n/a",
+        }
+    }
+}
+
+/// Evidence collected from analyzing a test function body.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QualityEvidence {
     pub assertion_count: u32,
+    pub assertion_source: EvidenceSource,
+    pub has_error_testing: bool,
     pub mock_count: u32,
     pub body_lines: u32,
-    pub assertion_density: f32,
-    pub has_error_testing: bool,
-    pub quality_tier: String,
+}
+
+/// Where the assertion evidence came from.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceSource {
+    Identifier,
+    Regex,
+    None,
 }
 
 /// Summary stats from running quality analysis across all test symbols.
@@ -38,6 +86,8 @@ pub struct TestQualityStats {
     pub adequate: usize,
     pub thin: usize,
     pub stub: usize,
+    pub unknown: usize,
+    pub not_applicable: usize,
     pub no_body: usize,
 }
 
@@ -50,7 +100,7 @@ fn assertion_patterns() -> &'static [Regex] {
     static PATTERNS: OnceLock<Vec<Regex>> = OnceLock::new();
     PATTERNS.get_or_init(|| {
         let raw = [
-            // Rust macros (no trailing \b — `!` is non-word so \b won't match before `(`)
+            // Rust macros (no trailing \b -- `!` is non-word so \b won't match before `(`)
             r"\bassert_eq!",
             r"\bassert_ne!",
             r"\bassert!\(",
@@ -68,7 +118,7 @@ fn assertion_patterns() -> &'static [Regex] {
             r"\bassertNotNull\b",
             r"\bassertThrows\b",
             // JS / TS / Ruby (Jest, Vitest, Chai, RSpec)
-            // Count `expect(` as the assertion anchor — don't also count
+            // Count `expect(` as the assertion anchor -- don't also count
             // .toBe()/.toEqual() chains to avoid double-counting.
             r"\bexpect\(",
             // Go
@@ -78,7 +128,7 @@ fn assertion_patterns() -> &'static [Regex] {
             r"\brequire\.\w+\(",
             // Swift (XCTest)
             r"\bXCTAssert",
-            // PHP (PHPUnit) — assertEquals, assertTrue, etc. are already
+            // PHP (PHPUnit) -- assertEquals, assertTrue, etc. are already
             // matched by the Java/JUnit patterns above. No separate PHP
             // pattern needed to avoid double-counting.
             // C# FluentAssertions
@@ -156,6 +206,47 @@ fn error_testing_patterns() -> &'static [Regex] {
 }
 
 // =============================================================================
+// Placeholder detection
+// =============================================================================
+
+/// Placeholder patterns that indicate a stub test body.
+const PLACEHOLDER_PATTERNS: &[&str] = &[
+    "pass",
+    "...",
+    "todo!()",
+    "unimplemented!()",
+    "// todo",
+    "# todo",
+    "// fixme",
+    "# fixme",
+];
+
+/// Check if a body is a placeholder (empty, whitespace-only, or contains
+/// only a placeholder statement like `pass`, `todo!()`, etc.).
+fn is_placeholder_body(body: &str) -> bool {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+
+    // Strip leading/trailing braces for Rust/C-style function bodies
+    let inner = trimmed
+        .strip_prefix('{')
+        .and_then(|s| s.strip_suffix('}'))
+        .map(|s| s.trim())
+        .unwrap_or(trimmed);
+
+    if inner.is_empty() {
+        return true;
+    }
+
+    let lower = inner.to_lowercase();
+    PLACEHOLDER_PATTERNS
+        .iter()
+        .any(|p| lower == *p || lower.starts_with(&format!("{} ", p)))
+}
+
+// =============================================================================
 // Comment/string stripping (prevents false-positive pattern matches)
 // =============================================================================
 
@@ -163,7 +254,7 @@ fn error_testing_patterns() -> &'static [Regex] {
 ///
 /// Replaces content inside comments and strings with spaces, preserving
 /// newlines so that line counts remain accurate. Language-agnostic: handles
-/// the common comment/string syntaxes across all 33 supported languages.
+/// the common comment/string syntaxes across all 34 supported languages.
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum StripState {
     Normal,
@@ -181,9 +272,9 @@ enum StripState {
 /// - String literals (`"..."`, `'...'`): content replaced with spaces (delimiters kept)
 /// - Escaped quotes (`\"`, `\'`) within strings are handled
 ///
-/// This doesn't need to be perfect for every language edge case — it just
-/// prevents the most common false positives (assertions in comments, mock
-/// patterns in string literals).
+/// This doesn't need to be perfect for every language edge case; it prevents
+/// the most common false positives (assertions in comments, mock patterns in
+/// string literals).
 fn strip_comments_and_strings(body: &str) -> String {
     let chars: Vec<char> = body.chars().collect();
     let len = chars.len();
@@ -240,7 +331,7 @@ fn strip_comments_and_strings(body: &str) -> String {
                     state = StripState::SingleQuoteString;
                     i += 1;
                 }
-                // Normal character — keep as-is
+                // Normal character -- keep as-is
                 else {
                     result.push(c);
                     i += 1;
@@ -274,7 +365,7 @@ fn strip_comments_and_strings(body: &str) -> String {
 
             StripState::DoubleQuoteString => {
                 if c == '\\' && next.is_some() {
-                    // Escaped character — replace both with spaces
+                    // Escaped character -- replace both with spaces
                     result.push(' ');
                     result.push(' ');
                     i += 2;
@@ -293,7 +384,7 @@ fn strip_comments_and_strings(body: &str) -> String {
 
             StripState::SingleQuoteString => {
                 if c == '\\' && next.is_some() {
-                    // Escaped character — replace both with spaces
+                    // Escaped character -- replace both with spaces
                     result.push(' ');
                     result.push(' ');
                     i += 2;
@@ -316,16 +407,15 @@ fn strip_comments_and_strings(body: &str) -> String {
 }
 
 // =============================================================================
-// Core analysis function
+// Core analysis functions
 // =============================================================================
 
-/// Analyze a test function body and return quality metrics.
+/// Analyze a test function body using regex patterns (fallback path).
 ///
 /// Strips comments and string literal contents before scanning for patterns,
 /// preventing false positives from assertion/mock keywords in comments or strings.
-/// Counts assertions, mocks, error-testing patterns, computes density,
-/// and assigns a quality tier.
-pub fn analyze_test_body(body: &str) -> TestQualityMetrics {
+/// Counts assertions, mocks, error-testing patterns, and computes body lines.
+pub fn analyze_test_body(body: &str) -> TestQualityAssessment {
     let stripped = strip_comments_and_strings(body);
     let non_empty_lines: Vec<&str> = stripped
         .lines()
@@ -344,29 +434,15 @@ pub fn analyze_test_body(body: &str) -> TestQualityMetrics {
         .iter()
         .any(|pat| pat.is_match(&stripped));
 
-    // Compute density
-    let assertion_density = if body_lines > 0 {
-        assertion_count as f32 / body_lines as f32
-    } else {
-        0.0
-    };
-
-    // Classify quality tier
-    let quality_tier = classify_tier(
+    // Regex path: use assess_test_quality with no identifier evidence
+    assess_test_quality(
+        Some("test_case"),
+        Some(body),
         assertion_count,
-        mock_count,
         has_error_testing,
-        assertion_density,
-    );
-
-    TestQualityMetrics {
-        assertion_count,
         mock_count,
-        body_lines,
-        assertion_density,
-        has_error_testing,
-        quality_tier,
-    }
+        false, // no identifier evidence
+    )
 }
 
 /// Count total non-overlapping pattern matches across all patterns in a body.
@@ -378,30 +454,164 @@ fn count_pattern_matches(body: &str, patterns: &[Regex]) -> u32 {
     total
 }
 
-/// Classify test quality tier based on metrics.
+/// Core scoring function: classify test quality from evidence.
 ///
-/// - **stub**: 0 assertions
-/// - **thin**: 1 assertion OR assertion_density < 0.05
-/// - **thorough**: >=3 assertions, OR has_error_testing, OR (mock_count > 0 AND assertion_count >= 2)
-/// - **adequate**: everything else
-fn classify_tier(
+/// Supports two evidence paths:
+/// - **Identifier-based** (`has_identifier_evidence = true`): high confidence
+///   (0.8-0.9) using framework-specific identifier counts.
+/// - **Regex fallback** (`has_identifier_evidence = false`): lower confidence
+///   (0.3-0.5) using pattern matching on body text.
+///
+/// Key invariant: regex with 0 assertions yields Unknown, not Stub. We admit
+/// ignorance rather than claiming deficiency when evidence is weak.
+pub fn assess_test_quality(
+    test_role: Option<&str>,
+    body: Option<&str>,
+    assertion_count: u32,
+    has_error_testing: bool,
+    mock_count: u32,
+    has_identifier_evidence: bool,
+) -> TestQualityAssessment {
+    // Non-scorable roles are not applicable
+    match test_role {
+        Some("fixture_setup" | "fixture_teardown" | "test_container") => {
+            return TestQualityAssessment {
+                tier: TestQualityTier::NotApplicable,
+                confidence: 1.0,
+                evidence: QualityEvidence {
+                    assertion_count: 0,
+                    assertion_source: EvidenceSource::None,
+                    has_error_testing: false,
+                    mock_count: 0,
+                    body_lines: body.map(|b| count_non_empty_lines(b)).unwrap_or(0),
+                },
+            };
+        }
+        _ => {}
+    }
+
+    // No body or placeholder body -> Stub with full confidence
+    match body {
+        None => {
+            return TestQualityAssessment {
+                tier: TestQualityTier::Stub,
+                confidence: 1.0,
+                evidence: QualityEvidence {
+                    assertion_count: 0,
+                    assertion_source: EvidenceSource::None,
+                    has_error_testing: false,
+                    mock_count: 0,
+                    body_lines: 0,
+                },
+            };
+        }
+        Some(b) if is_placeholder_body(b) => {
+            return TestQualityAssessment {
+                tier: TestQualityTier::Stub,
+                confidence: 1.0,
+                evidence: QualityEvidence {
+                    assertion_count: 0,
+                    assertion_source: EvidenceSource::None,
+                    has_error_testing: false,
+                    mock_count: 0,
+                    body_lines: count_non_empty_lines(b),
+                },
+            };
+        }
+        _ => {}
+    }
+
+    let body_lines = body.map(|b| count_non_empty_lines(b)).unwrap_or(0);
+
+    if has_identifier_evidence {
+        // Identifier path: higher confidence
+        let tier = classify_tier_from_counts(assertion_count, mock_count, has_error_testing);
+        let confidence = if has_error_testing || assertion_count >= 3 {
+            0.9
+        } else {
+            0.85
+        };
+        TestQualityAssessment {
+            tier,
+            confidence,
+            evidence: QualityEvidence {
+                assertion_count,
+                assertion_source: EvidenceSource::Identifier,
+                has_error_testing,
+                mock_count,
+                body_lines,
+            },
+        }
+    } else {
+        // Regex fallback: lower confidence
+        if assertion_count == 0 {
+            // Key invariant: regex found nothing -> Unknown, not Stub
+            TestQualityAssessment {
+                tier: TestQualityTier::Unknown,
+                confidence: 0.3,
+                evidence: QualityEvidence {
+                    assertion_count: 0,
+                    assertion_source: EvidenceSource::Regex,
+                    has_error_testing,
+                    mock_count,
+                    body_lines,
+                },
+            }
+        } else {
+            let tier =
+                classify_tier_from_counts(assertion_count, mock_count, has_error_testing);
+            let confidence = if assertion_count >= 3 { 0.5 } else { 0.4 };
+            TestQualityAssessment {
+                tier,
+                confidence,
+                evidence: QualityEvidence {
+                    assertion_count,
+                    assertion_source: EvidenceSource::Regex,
+                    has_error_testing,
+                    mock_count,
+                    body_lines,
+                },
+            }
+        }
+    }
+}
+
+/// Classify quality tier from assertion/mock/error counts.
+///
+/// - 3+ assertions + error testing -> Thorough
+/// - 3+ assertions -> Thorough
+/// - mock_count > 0 + 2+ assertions -> Thorough
+/// - has_error_testing + 1+ assertions -> Thorough
+/// - 2+ assertions -> Adequate
+/// - 1 assertion -> Thin
+/// - 0 assertions -> Stub
+fn classify_tier_from_counts(
     assertion_count: u32,
     mock_count: u32,
     has_error_testing: bool,
-    assertion_density: f32,
-) -> String {
+) -> TestQualityTier {
     if assertion_count == 0 {
-        return "stub".to_string();
+        return TestQualityTier::Stub;
     }
-    // Check thorough BEFORE thin — a test with error testing or mocks
+    // Check thorough BEFORE thin: a test with error testing or mocks
     // is thorough even with low assertion counts.
-    if assertion_count >= 3 || has_error_testing || (mock_count > 0 && assertion_count >= 2) {
-        return "thorough".to_string();
+    if assertion_count >= 3
+        || has_error_testing
+        || (mock_count > 0 && assertion_count >= 2)
+    {
+        return TestQualityTier::Thorough;
     }
-    if assertion_count == 1 || (assertion_count > 0 && assertion_density < 0.05) {
-        return "thin".to_string();
+    if assertion_count == 1 {
+        return TestQualityTier::Thin;
     }
-    "adequate".to_string()
+    TestQualityTier::Adequate
+}
+
+/// Count non-empty lines in a body string.
+fn count_non_empty_lines(body: &str) -> u32 {
+    body.lines()
+        .filter(|line| !line.trim().is_empty())
+        .count() as u32
 }
 
 // =============================================================================
@@ -410,22 +620,28 @@ fn classify_tier(
 
 /// Compute quality metrics for all test symbols in the database.
 ///
-/// Queries symbols with `metadata["is_test"] = true`, analyzes their
-/// `code_context`, and updates their metadata with `test_quality` metrics.
-pub fn compute_test_quality_metrics(db: &SymbolDatabase) -> Result<TestQualityStats> {
+/// Queries symbols with `metadata["is_test"] = true`, gathers identifier
+/// evidence from the identifiers table, and updates metadata with quality
+/// assessments including confidence scores.
+pub fn compute_test_quality_metrics(
+    db: &SymbolDatabase,
+    language_configs: &LanguageConfigs,
+) -> Result<TestQualityStats> {
     let mut stats = TestQualityStats::default();
 
     // Query all test symbols
     let mut stmt = db.conn.prepare(
-        "SELECT id, code_context, metadata FROM symbols WHERE json_extract(metadata, '$.is_test') = 1",
+        "SELECT id, code_context, metadata, language FROM symbols \
+         WHERE json_extract(metadata, '$.is_test') = 1",
     )?;
 
-    let rows: Vec<(String, Option<String>, Option<String>)> = stmt
+    let rows: Vec<(String, Option<String>, Option<String>, String)> = stmt
         .query_map([], |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, Option<String>>(1)?,
                 row.get::<_, Option<String>>(2)?,
+                row.get::<_, String>(3)?,
             ))
         })?
         .filter_map(|r| r.ok())
@@ -436,37 +652,120 @@ pub fn compute_test_quality_metrics(db: &SymbolDatabase) -> Result<TestQualitySt
         rows.len()
     );
 
+    // Prepare identifier query (reused per symbol)
+    let mut id_stmt = db.conn.prepare(
+        "SELECT LOWER(name) FROM identifiers \
+         WHERE containing_symbol_id = ?1 AND kind = 'call'",
+    )?;
+
     // Wrap all UPDATEs in a single transaction for performance on large codebases
     db.conn.execute_batch("BEGIN")?;
     let result = (|| -> Result<()> {
-        for (id, code_context, metadata_str) in &rows {
+        for (id, code_context, metadata_str, language) in &rows {
             stats.total_tests += 1;
 
-            // Analyze the body (or treat None as empty)
-            let metrics = match code_context.as_deref() {
-                Some(body) if !body.trim().is_empty() => analyze_test_body(body),
-                _ => {
-                    stats.no_body += 1;
-                    analyze_test_body("")
-                }
-            };
-
-            // Track tier stats
-            match metrics.quality_tier.as_str() {
-                "thorough" => stats.thorough += 1,
-                "adequate" => stats.adequate += 1,
-                "thin" => stats.thin += 1,
-                "stub" => stats.stub += 1,
-                _ => {}
-            }
-
-            // Parse existing metadata, merge in test_quality, update
-            let mut meta: serde_json::Value = metadata_str
+            // Extract test_role from existing metadata
+            let existing_meta: serde_json::Value = metadata_str
                 .as_deref()
                 .and_then(|s| serde_json::from_str(s).ok())
                 .unwrap_or_else(|| serde_json::json!({}));
 
-            meta["test_quality"] = serde_json::to_value(&metrics)?;
+            let test_role = existing_meta
+                .get("test_role")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+
+            // Gather identifier evidence for this symbol
+            let call_names: Vec<String> = id_stmt
+                .query_map(rusqlite::params![id], |row| row.get::<_, String>(0))?
+                .filter_map(|r| r.ok())
+                .collect();
+
+            // Match identifiers against framework-specific evidence config
+            let evidence_config = language_configs
+                .get(language)
+                .map(|cfg| &cfg.test_evidence);
+
+            let has_identifier_evidence = evidence_config.is_some() && !call_names.is_empty();
+
+            let (id_assertion_count, id_error_count, id_mock_count) =
+                if let Some(ev_cfg) = evidence_config {
+                    count_identifier_evidence(&call_names, ev_cfg)
+                } else {
+                    (0, 0, 0)
+                };
+
+            // Determine body status
+            let body = code_context.as_deref().filter(|b| !b.trim().is_empty());
+            let has_body = body.is_some();
+
+            if !has_body {
+                stats.no_body += 1;
+            }
+
+            // Build assessment
+            let assessment = if has_identifier_evidence {
+                // Identifier path
+                assess_test_quality(
+                    test_role.as_deref(),
+                    body,
+                    id_assertion_count,
+                    id_error_count > 0,
+                    id_mock_count,
+                    true,
+                )
+            } else {
+                // Regex fallback: analyze body text
+                let (regex_assertions, regex_has_error, regex_mocks) = match body {
+                    Some(b) => {
+                        let stripped = strip_comments_and_strings(b);
+                        let a = count_pattern_matches(&stripped, assertion_patterns());
+                        let e = error_testing_patterns()
+                            .iter()
+                            .any(|pat| pat.is_match(&stripped));
+                        let m = count_pattern_matches(&stripped, mock_patterns());
+                        (a, e, m)
+                    }
+                    None => (0, false, 0),
+                };
+                assess_test_quality(
+                    test_role.as_deref(),
+                    body,
+                    regex_assertions,
+                    regex_has_error,
+                    regex_mocks,
+                    false,
+                )
+            };
+
+            // Track tier stats
+            match assessment.tier {
+                TestQualityTier::Thorough => stats.thorough += 1,
+                TestQualityTier::Adequate => stats.adequate += 1,
+                TestQualityTier::Thin => stats.thin += 1,
+                TestQualityTier::Stub => stats.stub += 1,
+                TestQualityTier::Unknown => stats.unknown += 1,
+                TestQualityTier::NotApplicable => stats.not_applicable += 1,
+            }
+
+            // Build quality JSON for metadata
+            let quality_json = serde_json::json!({
+                "quality_tier": assessment.tier.as_str(),
+                "confidence": assessment.confidence,
+                "assertion_count": assessment.evidence.assertion_count,
+                "assertion_source": match assessment.evidence.assertion_source {
+                    EvidenceSource::Identifier => "identifier",
+                    EvidenceSource::Regex => "regex",
+                    EvidenceSource::None => "none",
+                },
+                "has_error_testing": assessment.evidence.has_error_testing,
+                "mock_count": assessment.evidence.mock_count,
+                "body_lines": assessment.evidence.body_lines,
+            });
+
+            // Parse existing metadata, merge in test_quality, update
+            let mut meta = existing_meta.clone();
+            meta["test_quality"] = quality_json;
 
             let updated_metadata = serde_json::to_string(&meta)?;
             db.conn.execute(
@@ -486,9 +785,49 @@ pub fn compute_test_quality_metrics(db: &SymbolDatabase) -> Result<TestQualitySt
     }
 
     info!(
-        "Test quality metrics: {} total, {} thorough, {} adequate, {} thin, {} stub, {} no_body",
-        stats.total_tests, stats.thorough, stats.adequate, stats.thin, stats.stub, stats.no_body
+        "Test quality metrics: {} total, {} thorough, {} adequate, {} thin, {} stub, {} unknown, {} n/a, {} no_body",
+        stats.total_tests, stats.thorough, stats.adequate, stats.thin, stats.stub,
+        stats.unknown, stats.not_applicable, stats.no_body
     );
 
     Ok(stats)
+}
+
+/// Count identifier matches against framework-specific evidence lists.
+///
+/// Returns (assertion_count, error_assertion_count, mock_count).
+fn count_identifier_evidence(
+    call_names: &[String],
+    evidence_config: &crate::search::language_config::TestEvidenceConfig,
+) -> (u32, u32, u32) {
+    let mut assertion_count = 0u32;
+    let mut error_count = 0u32;
+    let mut mock_count = 0u32;
+
+    for name in call_names {
+        let lower = name.to_lowercase();
+        if evidence_config
+            .assertion_identifiers
+            .iter()
+            .any(|a| lower == *a || lower.contains(a.as_str()))
+        {
+            assertion_count += 1;
+        }
+        if evidence_config
+            .error_assertion_identifiers
+            .iter()
+            .any(|e| lower == *e || lower.contains(e.as_str()))
+        {
+            error_count += 1;
+        }
+        if evidence_config
+            .mock_identifiers
+            .iter()
+            .any(|m| lower == *m || lower.contains(m.as_str()))
+        {
+            mock_count += 1;
+        }
+    }
+
+    (assertion_count, error_count, mock_count)
 }

--- a/src/analysis/test_quality.rs
+++ b/src/analysis/test_quality.rs
@@ -672,7 +672,9 @@ pub fn compute_test_quality_metrics(
             // Match identifiers against framework-specific evidence config
             let evidence_config = language_configs.get(language).map(|cfg| &cfg.test_evidence);
 
-            let has_identifier_evidence = evidence_config.is_some() && !call_names.is_empty();
+            let has_identifier_evidence = evidence_config
+                .map(|cfg| !cfg.assertion_identifiers.is_empty() && !call_names.is_empty())
+                .unwrap_or(false);
 
             let (id_assertion_count, id_error_count, id_mock_count) =
                 if let Some(ev_cfg) = evidence_config {
@@ -801,21 +803,21 @@ fn count_identifier_evidence(
         if evidence_config
             .assertion_identifiers
             .iter()
-            .any(|a| lower == *a || lower.contains(a.as_str()))
+            .any(|a| lower == *a)
         {
             assertion_count += 1;
         }
         if evidence_config
             .error_assertion_identifiers
             .iter()
-            .any(|e| lower == *e || lower.contains(e.as_str()))
+            .any(|e| lower == *e)
         {
             error_count += 1;
         }
         if evidence_config
             .mock_identifiers
             .iter()
-            .any(|m| lower == *m || lower.contains(m.as_str()))
+            .any(|m| lower == *m)
         {
             mock_count += 1;
         }

--- a/src/analysis/test_quality.rs
+++ b/src/analysis/test_quality.rs
@@ -108,6 +108,7 @@ fn assertion_patterns() -> &'static [Regex] {
             r"\bassert\(",
             r"\bAssert\.",
             // Python
+            r"(?m)^\s*assert\s+",
             r"\bself\.assert",
             r"\bpytest\.raises\b",
             // Java / C# / JUnit
@@ -672,16 +673,13 @@ pub fn compute_test_quality_metrics(
             // Match identifiers against framework-specific evidence config
             let evidence_config = language_configs.get(language).map(|cfg| &cfg.test_evidence);
 
-            let has_identifier_evidence = evidence_config
-                .map(|cfg| !cfg.assertion_identifiers.is_empty() && !call_names.is_empty())
-                .unwrap_or(false);
-
             let (id_assertion_count, id_error_count, id_mock_count) =
                 if let Some(ev_cfg) = evidence_config {
                     count_identifier_evidence(&call_names, ev_cfg)
                 } else {
                     (0, 0, 0)
                 };
+            let has_identifier_evidence = id_assertion_count > 0;
 
             // Determine body status
             let body = code_context.as_deref().filter(|b| !b.trim().is_empty());
@@ -814,11 +812,7 @@ fn count_identifier_evidence(
         {
             error_count += 1;
         }
-        if evidence_config
-            .mock_identifiers
-            .iter()
-            .any(|m| lower == *m)
-        {
+        if evidence_config.mock_identifiers.iter().any(|m| lower == *m) {
             mock_count += 1;
         }
     }

--- a/src/analysis/test_roles.rs
+++ b/src/analysis/test_roles.rs
@@ -1,0 +1,179 @@
+//! Post-extraction test role classification.
+//!
+//! Classifies symbols into test roles (test case, fixture setup, etc.) using
+//! annotation-driven config from language TOMLs, with a convention-based fallback
+//! from the extractor's `is_test` metadata flag.
+//!
+//! Runs in the indexing pipeline AFTER extraction and BEFORE the database write.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::extractors::{Symbol, SymbolKind, TestRole};
+
+/// Config-driven test role classifier built from language TOML annotation classes.
+///
+/// Each field holds the set of annotation keys that map to that role.
+/// `classify_annotation` checks them in priority order so that a key
+/// appearing in multiple sets resolves deterministically.
+#[derive(Debug, Clone, Default)]
+pub struct TestRoleConfig {
+    pub test_case: HashSet<String>,
+    pub parameterized_test: HashSet<String>,
+    pub fixture_setup: HashSet<String>,
+    pub fixture_teardown: HashSet<String>,
+    pub test_container: HashSet<String>,
+}
+
+impl TestRoleConfig {
+    /// Look up an annotation key and return the matching test role, if any.
+    ///
+    /// Priority order: test_case > parameterized_test > fixture_setup >
+    /// fixture_teardown > test_container. This means if someone accidentally
+    /// lists the same key in two sets, the higher-priority role wins.
+    pub fn classify_annotation(&self, annotation_key: &str) -> Option<TestRole> {
+        if self.test_case.contains(annotation_key) {
+            Some(TestRole::TestCase)
+        } else if self.parameterized_test.contains(annotation_key) {
+            Some(TestRole::ParameterizedTest)
+        } else if self.fixture_setup.contains(annotation_key) {
+            Some(TestRole::FixtureSetup)
+        } else if self.fixture_teardown.contains(annotation_key) {
+            Some(TestRole::FixtureTeardown)
+        } else if self.test_container.contains(annotation_key) {
+            Some(TestRole::TestContainer)
+        } else {
+            None
+        }
+    }
+}
+
+/// Symbol kinds that represent containers (classes, modules, etc.).
+fn is_container_kind(kind: &SymbolKind) -> bool {
+    matches!(
+        kind,
+        SymbolKind::Class | SymbolKind::Struct | SymbolKind::Module | SymbolKind::Namespace
+    )
+}
+
+/// Symbol kinds that represent callable code (functions, methods, constructors).
+fn is_callable_kind(kind: &SymbolKind) -> bool {
+    matches!(
+        kind,
+        SymbolKind::Function | SymbolKind::Method | SymbolKind::Constructor
+    )
+}
+
+/// Classify a single symbol's test role.
+///
+/// 1. If `role_config` is provided, check each annotation against it.
+///    For `TestContainer`, the symbol must have a container kind (Class, Struct,
+///    Module, Namespace). For all other roles, the symbol must have a callable
+///    kind (Function, Method, Constructor).
+/// 2. Fall back to the extractor's `is_test` metadata flag (convention-based
+///    languages like Rust, Go, Python). If `is_test` was set, return `TestCase`.
+/// 3. Return `None` for non-test symbols.
+pub fn classify_test_role(
+    symbol: &Symbol,
+    role_config: Option<&TestRoleConfig>,
+) -> Option<TestRole> {
+    // Step 1: annotation-driven classification
+    if let Some(config) = role_config {
+        for marker in &symbol.annotations {
+            if let Some(role) = config.classify_annotation(&marker.annotation_key) {
+                // Validate kind compatibility
+                match role {
+                    TestRole::TestContainer => {
+                        if is_container_kind(&symbol.kind) {
+                            return Some(role);
+                        }
+                        // Container annotation on a callable: skip this annotation,
+                        // another annotation on the same symbol might match a callable role.
+                    }
+                    _ => {
+                        if is_callable_kind(&symbol.kind) {
+                            return Some(role);
+                        }
+                        // Callable role annotation on a container: skip similarly.
+                    }
+                }
+            }
+        }
+    }
+
+    // Step 2: convention-based fallback from extractor's is_test flag
+    let is_test = symbol
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("is_test"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if is_test && is_callable_kind(&symbol.kind) {
+        return Some(TestRole::TestCase);
+    }
+
+    // Step 3: not a test symbol
+    None
+}
+
+/// Classify all symbols in a batch and set metadata accordingly.
+///
+/// For each symbol that receives a role:
+/// - Sets `metadata["test_role"]` to the role's string form
+/// - Sets `metadata["is_test"] = true` for backward compatibility with
+///   existing consumers that check `is_test`
+pub fn classify_symbols_by_role(
+    symbols: &mut [Symbol],
+    role_configs: &HashMap<String, TestRoleConfig>,
+) {
+    for symbol in symbols.iter_mut() {
+        let config = role_configs.get(&symbol.language);
+        if let Some(role) = classify_test_role(symbol, config) {
+            let metadata = symbol.metadata.get_or_insert_with(HashMap::new);
+            metadata.insert(
+                "test_role".to_string(),
+                serde_json::Value::String(role.as_str().to_string()),
+            );
+            metadata.insert("is_test".to_string(), serde_json::Value::Bool(true));
+        }
+    }
+}
+
+/// Returns true if the symbol has any test role OR the legacy `is_test` flag.
+///
+/// Use for: excluding symbols from production rankings, filtering test code
+/// out of search results, etc.
+pub fn is_test_related(symbol: &Symbol) -> bool {
+    let metadata = match &symbol.metadata {
+        Some(m) => m,
+        None => return false,
+    };
+
+    if metadata.contains_key("test_role") {
+        return true;
+    }
+
+    metadata
+        .get("is_test")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+/// Returns true only for symbols with a scorable test role (test_case or
+/// parameterized_test).
+///
+/// Use for: quality scoring, test linkage, assert density analysis. Fixture
+/// setup/teardown and test containers are excluded because quality metrics
+/// like assert density don't apply to them.
+pub fn is_scorable_test(symbol: &Symbol) -> bool {
+    let metadata = match &symbol.metadata {
+        Some(m) => m,
+        None => return false,
+    };
+
+    metadata
+        .get("test_role")
+        .and_then(|v| v.as_str())
+        .map(|role| role == "test_case" || role == "parameterized_test")
+        .unwrap_or(false)
+}

--- a/src/cli_tools/output.rs
+++ b/src/cli_tools/output.rs
@@ -101,8 +101,9 @@ fn format_signals_text(report: &crate::analysis::EarlyWarningReport) -> String {
     let mut out = String::new();
     let s = &report.summary;
     out.push_str(&format!(
-        "Early Warning Signals  (entry_points: {}, auth_coverage_candidates: {}, review_markers: {})\n",
-        s.entry_points, s.auth_coverage_candidates, s.review_markers
+        "Early Warning Signals  (entry_points: {}, auth_coverage_candidates: {}, review_markers: {}, scheduler: {}, ep_linkage_gaps: {}, centrality_gaps: {})\n",
+        s.entry_points, s.auth_coverage_candidates, s.review_markers,
+        s.scheduler_signals, s.entry_point_linkage_gaps, s.high_centrality_linkage_gaps
     ));
     if report.from_cache {
         out.push_str("  (from cache)\n");
@@ -139,6 +140,39 @@ fn format_signals_text(report: &crate::analysis::EarlyWarningReport) -> String {
                 rm.symbol_name, rm.file_path, rm.start_line, rm.annotation
             ));
         }
+        out.push('\n');
+    }
+
+    if !report.scheduler_signals.is_empty() {
+        out.push_str("Scheduler Signals:\n");
+        for ss in &report.scheduler_signals {
+            out.push_str(&format!(
+                "  {} ({}:{}) [{}]\n",
+                ss.symbol_name, ss.file_path, ss.start_line, ss.annotation
+            ));
+        }
+        out.push('\n');
+    }
+
+    if !report.entry_point_linkage_gaps.is_empty() {
+        out.push_str("Entry Point Linkage Gaps:\n");
+        for gap in &report.entry_point_linkage_gaps {
+            out.push_str(&format!(
+                "  {} ({}:{}) [{}]\n",
+                gap.symbol_name, gap.file_path, gap.start_line, gap.entry_annotation
+            ));
+        }
+        out.push('\n');
+    }
+
+    if !report.high_centrality_linkage_gaps.is_empty() {
+        out.push_str("High Centrality Linkage Gaps:\n");
+        for gap in &report.high_centrality_linkage_gaps {
+            out.push_str(&format!(
+                "  {} ({}:{}) score={:.2}\n",
+                gap.symbol_name, gap.file_path, gap.start_line, gap.reference_score
+            ));
+        }
     }
 
     out
@@ -149,8 +183,9 @@ fn format_signals_markdown(report: &crate::analysis::EarlyWarningReport) -> Stri
     let s = &report.summary;
     out.push_str("# Early Warning Signals\n\n");
     out.push_str(&format!(
-        "| Metric | Count |\n|--------|-------|\n| Entry Points | {} |\n| Auth Coverage Candidates | {} |\n| Review Markers | {} |\n\n",
-        s.entry_points, s.auth_coverage_candidates, s.review_markers
+        "| Metric | Count |\n|--------|-------|\n| Entry Points | {} |\n| Auth Coverage Candidates | {} |\n| Review Markers | {} |\n| Scheduler Signals | {} |\n| Entry Point Linkage Gaps | {} |\n| High Centrality Linkage Gaps | {} |\n\n",
+        s.entry_points, s.auth_coverage_candidates, s.review_markers,
+        s.scheduler_signals, s.entry_point_linkage_gaps, s.high_centrality_linkage_gaps
     ));
 
     if !report.entry_points.is_empty() {
@@ -181,6 +216,39 @@ fn format_signals_markdown(report: &crate::analysis::EarlyWarningReport) -> Stri
             out.push_str(&format!(
                 "| {} | {} | {} | {} |\n",
                 rm.symbol_name, rm.file_path, rm.start_line, rm.annotation
+            ));
+        }
+        out.push('\n');
+    }
+
+    if !report.scheduler_signals.is_empty() {
+        out.push_str("## Scheduler Signals\n\n| Symbol | File | Line | Annotation |\n|--------|------|------|------------|\n");
+        for ss in &report.scheduler_signals {
+            out.push_str(&format!(
+                "| {} | {} | {} | {} |\n",
+                ss.symbol_name, ss.file_path, ss.start_line, ss.annotation
+            ));
+        }
+        out.push('\n');
+    }
+
+    if !report.entry_point_linkage_gaps.is_empty() {
+        out.push_str("## Entry Point Linkage Gaps\n\n| Symbol | File | Line | Entry Annotation |\n|--------|------|------|------------------|\n");
+        for gap in &report.entry_point_linkage_gaps {
+            out.push_str(&format!(
+                "| {} | {} | {} | {} |\n",
+                gap.symbol_name, gap.file_path, gap.start_line, gap.entry_annotation
+            ));
+        }
+        out.push('\n');
+    }
+
+    if !report.high_centrality_linkage_gaps.is_empty() {
+        out.push_str("## High Centrality Linkage Gaps\n\n| Symbol | File | Line | Reference Score |\n|--------|------|------|-----------------|\n");
+        for gap in &report.high_centrality_linkage_gaps {
+            out.push_str(&format!(
+                "| {} | {} | {} | {:.2} |\n",
+                gap.symbol_name, gap.file_path, gap.start_line, gap.reference_score
             ));
         }
     }

--- a/src/embeddings/metadata.rs
+++ b/src/embeddings/metadata.rs
@@ -81,21 +81,10 @@ pub fn is_embeddable_language(language: &str) -> bool {
 /// Check whether a symbol is test code that should be excluded from embeddings.
 ///
 /// Uses the same two-tier detection as search filtering:
-/// 1. Extractor-set `is_test` metadata (set by `is_test_symbol()` during extraction)
+/// 1. Metadata-based: `test_role` (preferred) or legacy `is_test` flag
 /// 2. Path-based fallback via `is_test_path()` for symbols extractors don't annotate
 pub fn is_test_symbol_for_embedding(symbol: &Symbol) -> bool {
-    // Check extractor-set metadata first (most precise)
-    if let Some(ref meta) = symbol.metadata {
-        if meta
-            .get("is_test")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false)
-        {
-            return true;
-        }
-    }
-    // Fall back to path-based detection
-    is_test_path(&symbol.file_path)
+    crate::analysis::test_roles::is_test_related(symbol) || is_test_path(&symbol.file_path)
 }
 
 /// Format a symbol's metadata into a natural language string for embedding.

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,10 +127,8 @@ async fn run_signals_command(
     cli_workspace: Option<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
     let output = julie::cli_tools::run_signals_report(args, cli_workspace).await?;
-    let formatted = julie::cli_tools::output::format_signals_report(
-        &output,
-        flags.effective_format(),
-    );
+    let formatted =
+        julie::cli_tools::output::format_signals_report(&output, flags.effective_format());
     println!("{}", formatted);
     Ok(())
 }

--- a/src/search/language_config.rs
+++ b/src/search/language_config.rs
@@ -69,6 +69,25 @@ pub struct EmbeddingsConfig {
     pub variable_ratio: Option<f64>,
 }
 
+/// Role-classified test annotation mappings.
+///
+/// Replaces the old flat `test: Vec<String>` + `fixture: Vec<String>` with
+/// per-role lists so downstream quality scoring can distinguish scorable
+/// test cases from non-scorable fixtures and containers.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct TestAnnotationClasses {
+    #[serde(default)]
+    pub test_case: Vec<String>,
+    #[serde(default)]
+    pub parameterized_test: Vec<String>,
+    #[serde(default)]
+    pub fixture_setup: Vec<String>,
+    #[serde(default)]
+    pub fixture_teardown: Vec<String>,
+    #[serde(default)]
+    pub test_container: Vec<String>,
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct AnnotationClassesConfig {
     #[serde(default)]
@@ -82,9 +101,7 @@ pub struct AnnotationClassesConfig {
     #[serde(default)]
     pub scheduler: Vec<String>,
     #[serde(default)]
-    pub test: Vec<String>,
-    #[serde(default)]
-    pub fixture: Vec<String>,
+    pub test: TestAnnotationClasses,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -283,8 +300,11 @@ meaningful_affixes = []
         assert!(config.annotation_classes.auth_bypass.is_empty());
         assert!(config.annotation_classes.middleware.is_empty());
         assert!(config.annotation_classes.scheduler.is_empty());
-        assert!(config.annotation_classes.test.is_empty());
-        assert!(config.annotation_classes.fixture.is_empty());
+        assert!(config.annotation_classes.test.test_case.is_empty());
+        assert!(config.annotation_classes.test.parameterized_test.is_empty());
+        assert!(config.annotation_classes.test.fixture_setup.is_empty());
+        assert!(config.annotation_classes.test.fixture_teardown.is_empty());
+        assert!(config.annotation_classes.test.test_container.is_empty());
         assert!(config.early_warnings.review_markers.is_empty());
         assert_eq!(config.early_warnings.schema_version, 1);
     }
@@ -304,8 +324,10 @@ auth = ["login_required"]
 auth_bypass = ["allowanonymous"]
 middleware = ["middleware"]
 scheduler = ["celery.task"]
-test = ["pytest.mark.parametrize"]
-fixture = ["pytest.fixture"]
+
+[annotation_classes.test]
+parameterized_test = ["pytest.mark.parametrize"]
+fixture_setup = ["pytest.fixture"]
 
 [early_warnings]
 review_markers = ["allowanonymous"]
@@ -323,10 +345,16 @@ schema_version = 7
         assert_eq!(config.annotation_classes.middleware, vec!["middleware"]);
         assert_eq!(config.annotation_classes.scheduler, vec!["celery.task"]);
         assert_eq!(
-            config.annotation_classes.test,
+            config.annotation_classes.test.parameterized_test,
             vec!["pytest.mark.parametrize"]
         );
-        assert_eq!(config.annotation_classes.fixture, vec!["pytest.fixture"]);
+        assert_eq!(
+            config.annotation_classes.test.fixture_setup,
+            vec!["pytest.fixture"]
+        );
+        assert!(config.annotation_classes.test.test_case.is_empty());
+        assert!(config.annotation_classes.test.fixture_teardown.is_empty());
+        assert!(config.annotation_classes.test.test_container.is_empty());
         assert_eq!(config.early_warnings.review_markers, vec!["allowanonymous"]);
         assert_eq!(config.early_warnings.schema_version, 7);
     }
@@ -352,7 +380,15 @@ schema_version = 7
             python
                 .annotation_classes
                 .test
+                .parameterized_test
                 .contains(&"pytest.mark.parametrize".into())
+        );
+        assert!(
+            python
+                .annotation_classes
+                .test
+                .fixture_setup
+                .contains(&"pytest.fixture".into())
         );
 
         let java = configs.get("java").expect("java config should exist");
@@ -451,6 +487,73 @@ schema_version = 7
 
         let rust = configs.get("rust").expect("rust config should exist");
         assert!(rust.annotation_classes.entrypoint.is_empty());
-        assert_eq!(rust.annotation_classes.test, vec!["test", "tokio::test"]);
+        assert!(
+            rust.annotation_classes
+                .test
+                .test_case
+                .contains(&"test".into())
+        );
+        assert!(
+            rust.annotation_classes
+                .test
+                .test_case
+                .contains(&"tokio::test".into())
+        );
+
+        // Verify Java has role-classified test annotations
+        assert!(
+            java.annotation_classes
+                .test
+                .test_case
+                .contains(&"test".into())
+        );
+        assert!(
+            java.annotation_classes
+                .test
+                .parameterized_test
+                .contains(&"parameterizedtest".into())
+        );
+        assert!(
+            java.annotation_classes
+                .test
+                .fixture_setup
+                .contains(&"beforeeach".into())
+        );
+        assert!(
+            java.annotation_classes
+                .test
+                .fixture_teardown
+                .contains(&"aftereach".into())
+        );
+
+        // Verify C# has role-classified test annotations
+        assert!(
+            csharp
+                .annotation_classes
+                .test
+                .test_case
+                .contains(&"fact".into())
+        );
+        assert!(
+            csharp
+                .annotation_classes
+                .test
+                .parameterized_test
+                .contains(&"theory".into())
+        );
+        assert!(
+            csharp
+                .annotation_classes
+                .test
+                .fixture_setup
+                .contains(&"setup".into())
+        );
+        assert!(
+            csharp
+                .annotation_classes
+                .test
+                .test_container
+                .contains(&"testfixture".into())
+        );
     }
 }

--- a/src/search/language_config.rs
+++ b/src/search/language_config.rs
@@ -20,6 +20,8 @@ pub struct LanguageConfig {
     #[serde(default)]
     pub annotation_classes: AnnotationClassesConfig,
     #[serde(default)]
+    pub test_evidence: TestEvidenceConfig,
+    #[serde(default)]
     pub early_warnings: EarlyWarningConfig,
 }
 
@@ -102,6 +104,21 @@ pub struct AnnotationClassesConfig {
     pub scheduler: Vec<String>,
     #[serde(default)]
     pub test: TestAnnotationClasses,
+}
+
+/// Framework-specific test evidence identifiers.
+///
+/// Used by downstream test quality scoring to recognize assertion calls,
+/// error-path assertions, and mock/stub setups within test bodies. All
+/// identifiers are stored lowercase for case-insensitive matching.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct TestEvidenceConfig {
+    #[serde(default)]
+    pub assertion_identifiers: Vec<String>,
+    #[serde(default)]
+    pub error_assertion_identifiers: Vec<String>,
+    #[serde(default)]
+    pub mock_identifiers: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -326,6 +343,9 @@ meaningful_affixes = []
         assert!(config.annotation_classes.test.fixture_setup.is_empty());
         assert!(config.annotation_classes.test.fixture_teardown.is_empty());
         assert!(config.annotation_classes.test.test_container.is_empty());
+        assert!(config.test_evidence.assertion_identifiers.is_empty());
+        assert!(config.test_evidence.error_assertion_identifiers.is_empty());
+        assert!(config.test_evidence.mock_identifiers.is_empty());
         assert!(config.early_warnings.review_markers.is_empty());
         assert_eq!(config.early_warnings.schema_version, 1);
     }
@@ -575,6 +595,157 @@ schema_version = 7
                 .test
                 .test_container
                 .contains(&"testfixture".into())
+        );
+    }
+
+    #[test]
+    fn test_evidence_config_defaults_empty_when_absent() {
+        let config: LanguageConfig = toml::from_str(
+            r#"
+[tokenizer]
+preserve_patterns = ["@"]
+naming_styles = ["snake_case"]
+meaningful_affixes = []
+"#,
+        )
+        .expect("config without test_evidence section should parse");
+
+        assert!(config.test_evidence.assertion_identifiers.is_empty());
+        assert!(config.test_evidence.error_assertion_identifiers.is_empty());
+        assert!(config.test_evidence.mock_identifiers.is_empty());
+    }
+
+    #[test]
+    fn test_evidence_config_loads_from_toml() {
+        let config: LanguageConfig = toml::from_str(
+            r#"
+[tokenizer]
+preserve_patterns = ["@"]
+naming_styles = ["snake_case"]
+meaningful_affixes = []
+
+[test_evidence]
+assertion_identifiers = ["assert_eq", "assert_ne"]
+error_assertion_identifiers = ["should_panic"]
+mock_identifiers = ["mock", "spy"]
+"#,
+        )
+        .expect("config with test_evidence section should parse");
+
+        assert_eq!(
+            config.test_evidence.assertion_identifiers,
+            vec!["assert_eq", "assert_ne"]
+        );
+        assert_eq!(
+            config.test_evidence.error_assertion_identifiers,
+            vec!["should_panic"]
+        );
+        assert_eq!(config.test_evidence.mock_identifiers, vec!["mock", "spy"]);
+    }
+
+    #[test]
+    fn test_evidence_rust_has_assertion_identifiers() {
+        let configs = LanguageConfigs::load_embedded();
+        let rust = configs.get("rust").expect("rust config should exist");
+
+        assert!(
+            rust.test_evidence
+                .assertion_identifiers
+                .contains(&"assert_eq".into()),
+            "Rust test_evidence should contain assert_eq"
+        );
+        assert!(
+            rust.test_evidence
+                .assertion_identifiers
+                .contains(&"assert_ne".into()),
+            "Rust test_evidence should contain assert_ne"
+        );
+        assert!(
+            rust.test_evidence
+                .assertion_identifiers
+                .contains(&"assert".into()),
+            "Rust test_evidence should contain assert"
+        );
+        assert!(
+            rust.test_evidence
+                .error_assertion_identifiers
+                .contains(&"should_panic".into()),
+            "Rust test_evidence should contain should_panic"
+        );
+        assert!(
+            rust.test_evidence.mock_identifiers.is_empty(),
+            "Rust test_evidence should have no mock identifiers"
+        );
+    }
+
+    #[test]
+    fn test_evidence_populated_for_all_configured_languages() {
+        let configs = LanguageConfigs::load_embedded();
+
+        // Python
+        let python = configs.get("python").expect("python config should exist");
+        assert!(
+            python
+                .test_evidence
+                .assertion_identifiers
+                .contains(&"assertequal".into())
+        );
+        assert!(
+            python
+                .test_evidence
+                .mock_identifiers
+                .contains(&"mock".into())
+        );
+        assert!(
+            python
+                .test_evidence
+                .error_assertion_identifiers
+                .contains(&"assertraises".into())
+        );
+
+        // Java
+        let java = configs.get("java").expect("java config should exist");
+        assert!(
+            java.test_evidence
+                .assertion_identifiers
+                .contains(&"assertequals".into())
+        );
+        assert!(java.test_evidence.mock_identifiers.contains(&"mock".into()));
+
+        // C#
+        let csharp = configs.get("csharp").expect("csharp config should exist");
+        assert!(
+            csharp
+                .test_evidence
+                .assertion_identifiers
+                .contains(&"equal".into())
+        );
+        assert!(
+            csharp
+                .test_evidence
+                .error_assertion_identifiers
+                .contains(&"throws".into())
+        );
+        assert!(
+            csharp
+                .test_evidence
+                .mock_identifiers
+                .contains(&"mock".into())
+        );
+
+        // Kotlin
+        let kotlin = configs.get("kotlin").expect("kotlin config should exist");
+        assert!(
+            kotlin
+                .test_evidence
+                .assertion_identifiers
+                .contains(&"assertequals".into())
+        );
+        assert!(
+            kotlin
+                .test_evidence
+                .mock_identifiers
+                .contains(&"every".into())
         );
     }
 }

--- a/src/search/language_config.rs
+++ b/src/search/language_config.rs
@@ -259,6 +259,27 @@ impl LanguageConfigs {
     pub fn embeddings_config(&self, language: &str) -> Option<&EmbeddingsConfig> {
         self.configs.get(language).map(|c| &c.embeddings)
     }
+
+    /// Build per-language test role configs from the annotation classes in each
+    /// language TOML. Used by `classify_symbols_by_role` in the indexing pipeline.
+    pub fn build_test_role_configs(
+        &self,
+    ) -> HashMap<String, crate::analysis::test_roles::TestRoleConfig> {
+        self.configs
+            .iter()
+            .map(|(lang, config)| {
+                let tc = &config.annotation_classes.test;
+                let role_config = crate::analysis::test_roles::TestRoleConfig {
+                    test_case: tc.test_case.iter().cloned().collect(),
+                    parameterized_test: tc.parameterized_test.iter().cloned().collect(),
+                    fixture_setup: tc.fixture_setup.iter().cloned().collect(),
+                    fixture_teardown: tc.fixture_teardown.iter().cloned().collect(),
+                    test_container: tc.test_container.iter().cloned().collect(),
+                };
+                (lang.clone(), role_config)
+            })
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/src/tests/analysis/change_risk_tests.rs
+++ b/src/tests/analysis/change_risk_tests.rs
@@ -198,6 +198,16 @@ mod tests {
         let risk = meta.get("change_risk").unwrap();
         let label = risk.get("label").unwrap().as_str().unwrap();
         assert_eq!(label, "HIGH");
+        assert_eq!(
+            risk.get("factors")
+                .unwrap()
+                .get("test_weakness")
+                .unwrap()
+                .as_f64()
+                .unwrap(),
+            1.0,
+            "symbols with no linkage metadata should get the full untested penalty"
+        );
 
         // Verify s2 is LOW risk
         let s2 = db.get_symbol_by_id("s2").unwrap().unwrap();

--- a/src/tests/analysis/change_risk_tests.rs
+++ b/src/tests/analysis/change_risk_tests.rs
@@ -28,12 +28,47 @@ mod tests {
     }
 
     #[test]
-    fn test_test_weakness_scores() {
-        assert_eq!(test_weakness_score(None), 1.0); // Untested
-        assert_eq!(test_weakness_score(Some("stub")), 0.8);
-        assert_eq!(test_weakness_score(Some("thin")), 0.6);
-        assert_eq!(test_weakness_score(Some("adequate")), 0.3);
-        assert_eq!(test_weakness_score(Some("thorough")), 0.1);
+    fn test_test_weakness_scores_full_confidence() {
+        // With confidence=1.0, raw weakness passes through unchanged
+        let eps = 0.01;
+        assert!((test_weakness_score(None, 1.0) - 1.0).abs() < eps); // Untested
+        assert!((test_weakness_score(Some("stub"), 1.0) - 0.9).abs() < eps);
+        assert!((test_weakness_score(Some("thin"), 1.0) - 0.6).abs() < eps);
+        assert!((test_weakness_score(Some("adequate"), 1.0) - 0.3).abs() < eps);
+        assert!((test_weakness_score(Some("thorough"), 1.0) - 0.1).abs() < eps);
+    }
+
+    #[test]
+    fn test_weakness_high_confidence_thorough() {
+        let score = test_weakness_score(Some("thorough"), 0.9);
+        // raw = 0.1, confidence 0.9: 0.5 + (0.1 - 0.5) * 0.9 = 0.14
+        assert!((score - 0.14).abs() < 0.02);
+    }
+
+    #[test]
+    fn test_weakness_low_confidence_converges_to_neutral() {
+        let score = test_weakness_score(Some("stub"), 0.0);
+        // confidence 0 -> always neutral
+        assert!((score - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_weakness_unknown_tier() {
+        let score = test_weakness_score(Some("unknown"), 0.3);
+        // raw = 0.5, so result = 0.5 + (0.5 - 0.5) * 0.3 = 0.5
+        assert!((score - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_weakness_no_linkage_full_penalty() {
+        let score = test_weakness_score(None, 1.0);
+        assert!((score - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_weakness_na_tier_is_neutral() {
+        let score = test_weakness_score(Some("n/a"), 1.0);
+        assert!((score - 0.5).abs() < 0.01);
     }
 
     #[test]
@@ -125,7 +160,7 @@ mod tests {
                 r#"
             INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, reference_score, visibility, metadata)
             VALUES ('s2', 'MY_CONST', 'constant', 'rust', 'src/config.rs', 1, 0, 1, 0, 0, 0, 0.0, 'private',
-                    '{"test_linkage": {"test_count": 2, "best_tier": "thorough", "worst_tier": "adequate", "linked_tests": ["test_a", "test_b"], "evidence_sources": ["relationship"]}}');
+                    '{"test_linkage": {"test_count": 2, "best_tier": "thorough", "worst_tier": "adequate", "best_confidence": 0.9, "linked_tests": ["test_a", "test_b"], "evidence_sources": ["relationship"]}}');
         "#,
             )
             .unwrap();

--- a/src/tests/analysis/early_warning_report_tests.rs
+++ b/src/tests/analysis/early_warning_report_tests.rs
@@ -277,7 +277,11 @@ fn early_warning_report_file_pattern_scopes_analysis() {
             &api_file.path,
             10,
             None,
-            vec![marker("app.route", "app.route", Some("@app.route(\"/users\")"))],
+            vec![marker(
+                "app.route",
+                "app.route",
+                Some("@app.route(\"/users\")"),
+            )],
         ),
         symbol(
             "util-route",
@@ -287,7 +291,11 @@ fn early_warning_report_file_pattern_scopes_analysis() {
             &util_file.path,
             5,
             None,
-            vec![marker("app.route", "app.route", Some("@app.route(\"/health\")"))],
+            vec![marker(
+                "app.route",
+                "app.route",
+                Some("@app.route(\"/health\")"),
+            )],
         ),
     ])
     .unwrap();

--- a/src/tests/analysis/early_warning_report_tests.rs
+++ b/src/tests/analysis/early_warning_report_tests.rs
@@ -2,6 +2,7 @@ use crate::analysis::early_warnings::{EarlyWarningReportOptions, generate_early_
 use crate::database::{FileInfo, SymbolDatabase};
 use crate::extractors::{AnnotationMarker, Symbol, SymbolKind};
 use crate::search::language_config::LanguageConfigs;
+use std::collections::HashMap;
 use tempfile::TempDir;
 
 fn file_info(path: &str, language: &str) -> FileInfo {
@@ -203,12 +204,21 @@ fn early_warning_report_empty_state_serializes_zero_counts() {
     assert_eq!(report.summary.entry_points, 0);
     assert_eq!(report.summary.auth_coverage_candidates, 0);
     assert_eq!(report.summary.review_markers, 0);
+    assert_eq!(report.summary.scheduler_signals, 0);
+    assert_eq!(report.summary.entry_point_linkage_gaps, 0);
+    assert_eq!(report.summary.high_centrality_linkage_gaps, 0);
     assert!(report.entry_points.is_empty());
     assert!(report.auth_coverage_candidates.is_empty());
     assert!(report.review_markers.is_empty());
+    assert!(report.scheduler_signals.is_empty());
+    assert!(report.entry_point_linkage_gaps.is_empty());
+    assert!(report.high_centrality_linkage_gaps.is_empty());
     assert!(json.contains("\"entry_points\":0"));
     assert!(json.contains("\"auth_coverage_candidates\":0"));
     assert!(json.contains("\"review_markers\":0"));
+    assert!(json.contains("\"scheduler_signals\":0"));
+    assert!(json.contains("\"entry_point_linkage_gaps\":0"));
+    assert!(json.contains("\"high_centrality_linkage_gaps\":0"));
 }
 
 #[test]
@@ -327,4 +337,233 @@ fn early_warning_report_file_pattern_scopes_analysis() {
         unscoped.summary.entry_points, 2,
         "no filter should include both"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Task 7: Scheduler signal tests
+// ---------------------------------------------------------------------------
+
+fn symbol_with_metadata(
+    id: &str,
+    name: &str,
+    kind: SymbolKind,
+    language: &str,
+    file_path: &str,
+    start_line: u32,
+    parent_id: Option<&str>,
+    annotations: Vec<AnnotationMarker>,
+    metadata: Option<HashMap<String, serde_json::Value>>,
+) -> Symbol {
+    Symbol {
+        id: id.to_string(),
+        name: name.to_string(),
+        kind,
+        language: language.to_string(),
+        file_path: file_path.to_string(),
+        start_line,
+        start_column: 4,
+        end_line: start_line + 3,
+        end_column: 1,
+        start_byte: 20,
+        end_byte: 80,
+        signature: Some(format!("{name}()")),
+        doc_comment: None,
+        visibility: None,
+        parent_id: parent_id.map(str::to_string),
+        metadata,
+        semantic_group: None,
+        confidence: Some(1.0),
+        code_context: Some(format!("{name}() {{}}")),
+        content_type: None,
+        annotations,
+    }
+}
+
+#[test]
+fn early_warning_report_scheduler_signal_detection() {
+    let (_temp_dir, mut db) = open_db();
+    let configs = LanguageConfigs::load_embedded();
+    let file = file_info("tasks/jobs.py", "python");
+    db.store_file_info(&file).unwrap();
+
+    let scheduled_task = symbol(
+        "task-1",
+        "send_daily_email",
+        SymbolKind::Function,
+        "python",
+        &file.path,
+        10,
+        None,
+        vec![marker("celery.task", "celery.task", Some("@celery.task"))],
+    );
+    let plain_func = symbol(
+        "plain-1",
+        "helper",
+        SymbolKind::Function,
+        "python",
+        &file.path,
+        20,
+        None,
+        Vec::new(),
+    );
+    db.store_symbols(&[scheduled_task, plain_func]).unwrap();
+
+    let report = generate_early_warning_report(&db, &configs, options()).unwrap();
+
+    assert_eq!(report.summary.scheduler_signals, 1);
+    assert_eq!(report.scheduler_signals.len(), 1);
+    assert_eq!(report.scheduler_signals[0].symbol_name, "send_daily_email");
+    assert_eq!(report.scheduler_signals[0].annotation_key, "celery.task");
+    assert_eq!(report.scheduler_signals[0].language, "python");
+}
+
+// ---------------------------------------------------------------------------
+// Task 8: Linkage gap tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn early_warning_report_entry_point_linkage_gap_no_test_linkage() {
+    let (_temp_dir, mut db) = open_db();
+    let configs = LanguageConfigs::load_embedded();
+    let file = file_info("Controllers/UsersController.cs", "csharp");
+    db.store_file_info(&file).unwrap();
+
+    // Entry point without test_linkage metadata => gap
+    let route = symbol(
+        "route-no-linkage",
+        "GetUsers",
+        SymbolKind::Method,
+        "csharp",
+        &file.path,
+        5,
+        None,
+        vec![marker("HttpGet", "httpget", Some("[HttpGet]"))],
+    );
+    db.store_symbols(&[route]).unwrap();
+
+    let report = generate_early_warning_report(&db, &configs, options()).unwrap();
+
+    assert_eq!(report.summary.entry_points, 1);
+    assert_eq!(report.summary.entry_point_linkage_gaps, 1);
+    assert_eq!(report.entry_point_linkage_gaps.len(), 1);
+    assert_eq!(report.entry_point_linkage_gaps[0].symbol_name, "GetUsers");
+    assert_eq!(
+        report.entry_point_linkage_gaps[0].entry_annotation,
+        "HttpGet"
+    );
+}
+
+#[test]
+fn early_warning_report_entry_point_with_test_linkage_is_not_a_gap() {
+    let (_temp_dir, mut db) = open_db();
+    let configs = LanguageConfigs::load_embedded();
+    let file = file_info("Controllers/OrdersController.cs", "csharp");
+    db.store_file_info(&file).unwrap();
+
+    // Entry point WITH test_linkage metadata => not a gap
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        "test_linkage".to_string(),
+        serde_json::json!({"tests": ["test_get_orders"]}),
+    );
+    let route = symbol_with_metadata(
+        "route-with-linkage",
+        "GetOrders",
+        SymbolKind::Method,
+        "csharp",
+        &file.path,
+        5,
+        None,
+        vec![marker("HttpGet", "httpget", Some("[HttpGet]"))],
+        Some(metadata),
+    );
+    db.store_symbols(&[route]).unwrap();
+
+    let report = generate_early_warning_report(&db, &configs, options()).unwrap();
+
+    assert_eq!(report.summary.entry_points, 1);
+    assert_eq!(report.summary.entry_point_linkage_gaps, 0);
+    assert!(report.entry_point_linkage_gaps.is_empty());
+}
+
+#[test]
+fn early_warning_report_high_centrality_linkage_gap_query() {
+    let (_temp_dir, mut db) = open_db();
+    let configs = LanguageConfigs::load_embedded();
+    let file = file_info("src/core/engine.rs", "rust");
+    db.store_file_info(&file).unwrap();
+
+    // Symbol with high centrality, no test_linkage => gap
+    let high_centrality = symbol(
+        "engine-run",
+        "run",
+        SymbolKind::Function,
+        "rust",
+        &file.path,
+        10,
+        None,
+        Vec::new(),
+    );
+    // Symbol with test_linkage => not a gap
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        "test_linkage".to_string(),
+        serde_json::json!({"tests": ["test_process"]}),
+    );
+    let linked = symbol_with_metadata(
+        "engine-process",
+        "process",
+        SymbolKind::Function,
+        "rust",
+        &file.path,
+        30,
+        None,
+        Vec::new(),
+        Some(metadata),
+    );
+    // Test symbol with high centrality => excluded (is_test)
+    let mut test_meta = HashMap::new();
+    test_meta.insert("is_test".to_string(), serde_json::json!(1));
+    let test_sym = symbol_with_metadata(
+        "test-engine",
+        "test_run",
+        SymbolKind::Function,
+        "rust",
+        &file.path,
+        50,
+        None,
+        Vec::new(),
+        Some(test_meta),
+    );
+
+    db.store_symbols(&[high_centrality, linked, test_sym])
+        .unwrap();
+
+    // Set reference_score on engine-run and test-engine to make them "high centrality"
+    db.conn
+        .execute(
+            "UPDATE symbols SET reference_score = 5.0 WHERE id = ?1",
+            rusqlite::params!["engine-run"],
+        )
+        .unwrap();
+    db.conn
+        .execute(
+            "UPDATE symbols SET reference_score = 3.0 WHERE id = ?1",
+            rusqlite::params!["engine-process"],
+        )
+        .unwrap();
+    db.conn
+        .execute(
+            "UPDATE symbols SET reference_score = 4.0 WHERE id = ?1",
+            rusqlite::params!["test-engine"],
+        )
+        .unwrap();
+
+    let report = generate_early_warning_report(&db, &configs, options()).unwrap();
+
+    // Only engine-run should appear: high centrality, no test_linkage, not a test
+    assert_eq!(report.summary.high_centrality_linkage_gaps, 1);
+    assert_eq!(report.high_centrality_linkage_gaps.len(), 1);
+    assert_eq!(report.high_centrality_linkage_gaps[0].symbol_name, "run");
+    assert_eq!(report.high_centrality_linkage_gaps[0].reference_score, 5.0);
 }

--- a/src/tests/analysis/early_warning_report_tests.rs
+++ b/src/tests/analysis/early_warning_report_tests.rs
@@ -487,6 +487,38 @@ fn early_warning_report_entry_point_with_test_linkage_is_not_a_gap() {
 }
 
 #[test]
+fn early_warning_report_entry_point_with_test_coverage_is_not_a_gap() {
+    let (_temp_dir, mut db) = open_db();
+    let configs = LanguageConfigs::load_embedded();
+    let file = file_info("Controllers/LegacyCoverageController.cs", "csharp");
+    db.store_file_info(&file).unwrap();
+
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        "test_coverage".to_string(),
+        serde_json::json!({"tests": ["test_get_legacy_orders"]}),
+    );
+    let route = symbol_with_metadata(
+        "route-with-legacy-coverage",
+        "GetLegacyOrders",
+        SymbolKind::Method,
+        "csharp",
+        &file.path,
+        5,
+        None,
+        vec![marker("HttpGet", "httpget", Some("[HttpGet]"))],
+        Some(metadata),
+    );
+    db.store_symbols(&[route]).unwrap();
+
+    let report = generate_early_warning_report(&db, &configs, options()).unwrap();
+
+    assert_eq!(report.summary.entry_points, 1);
+    assert_eq!(report.summary.entry_point_linkage_gaps, 0);
+    assert!(report.entry_point_linkage_gaps.is_empty());
+}
+
+#[test]
 fn early_warning_report_high_centrality_linkage_gap_query() {
     let (_temp_dir, mut db) = open_db();
     let configs = LanguageConfigs::load_embedded();
@@ -566,4 +598,154 @@ fn early_warning_report_high_centrality_linkage_gap_query() {
     assert_eq!(report.high_centrality_linkage_gaps.len(), 1);
     assert_eq!(report.high_centrality_linkage_gaps[0].symbol_name, "run");
     assert_eq!(report.high_centrality_linkage_gaps[0].reference_score, 5.0);
+}
+
+#[test]
+fn early_warning_report_high_centrality_with_test_coverage_is_not_a_gap() {
+    let (_temp_dir, mut db) = open_db();
+    let configs = LanguageConfigs::load_embedded();
+    let file = file_info("src/core/legacy.rs", "rust");
+    db.store_file_info(&file).unwrap();
+
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        "test_coverage".to_string(),
+        serde_json::json!({"tests": ["test_legacy_run"]}),
+    );
+    let covered = symbol_with_metadata(
+        "legacy-covered",
+        "legacy_run",
+        SymbolKind::Function,
+        "rust",
+        &file.path,
+        10,
+        None,
+        Vec::new(),
+        Some(metadata),
+    );
+    db.store_symbols(&[covered]).unwrap();
+    db.conn
+        .execute(
+            "UPDATE symbols SET reference_score = 10.0 WHERE id = ?1",
+            rusqlite::params!["legacy-covered"],
+        )
+        .unwrap();
+
+    let report = generate_early_warning_report(&db, &configs, options()).unwrap();
+
+    assert_eq!(report.summary.high_centrality_linkage_gaps, 0);
+    assert!(report.high_centrality_linkage_gaps.is_empty());
+}
+
+#[test]
+fn early_warning_report_high_centrality_file_pattern_searches_past_unscoped_limit() {
+    let (_temp_dir, mut db) = open_db();
+    let configs = LanguageConfigs::load_embedded();
+    let api_file = file_info("src/api/routes.rs", "rust");
+    let core_file = file_info("src/core/engine.rs", "rust");
+    db.store_file_info(&api_file).unwrap();
+    db.store_file_info(&core_file).unwrap();
+
+    let mut symbols = Vec::new();
+    for idx in 0..81 {
+        symbols.push(symbol(
+            &format!("core-{idx}"),
+            &format!("core_helper_{idx}"),
+            SymbolKind::Function,
+            "rust",
+            &core_file.path,
+            idx + 1,
+            None,
+            Vec::new(),
+        ));
+    }
+    symbols.push(symbol(
+        "api-route",
+        "serve_route",
+        SymbolKind::Function,
+        "rust",
+        &api_file.path,
+        200,
+        None,
+        Vec::new(),
+    ));
+    db.store_symbols(&symbols).unwrap();
+
+    for idx in 0..81 {
+        db.conn
+            .execute(
+                "UPDATE symbols SET reference_score = ?1 WHERE id = ?2",
+                rusqlite::params![100.0 - f64::from(idx), format!("core-{idx}")],
+            )
+            .unwrap();
+    }
+    db.conn
+        .execute(
+            "UPDATE symbols SET reference_score = 1.0 WHERE id = ?1",
+            rusqlite::params!["api-route"],
+        )
+        .unwrap();
+
+    let report = generate_early_warning_report(
+        &db,
+        &configs,
+        EarlyWarningReportOptions {
+            file_pattern: Some("src/api/**".to_string()),
+            ..options()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(report.summary.high_centrality_linkage_gaps, 1);
+    assert_eq!(report.high_centrality_linkage_gaps.len(), 1);
+    assert_eq!(
+        report.high_centrality_linkage_gaps[0].symbol_id,
+        "api-route"
+    );
+}
+
+#[test]
+fn early_warning_report_high_centrality_summary_counts_all_matching_gaps() {
+    let (_temp_dir, mut db) = open_db();
+    let configs = LanguageConfigs::load_embedded();
+    let file = file_info("src/core/many.rs", "rust");
+    db.store_file_info(&file).unwrap();
+
+    let mut symbols = Vec::new();
+    for idx in 0..25 {
+        symbols.push(symbol(
+            &format!("gap-{idx}"),
+            &format!("gap_symbol_{idx}"),
+            SymbolKind::Function,
+            "rust",
+            &file.path,
+            idx + 1,
+            None,
+            Vec::new(),
+        ));
+    }
+    db.store_symbols(&symbols).unwrap();
+
+    for idx in 0..25 {
+        db.conn
+            .execute(
+                "UPDATE symbols SET reference_score = ?1 WHERE id = ?2",
+                rusqlite::params![100.0 - f64::from(idx), format!("gap-{idx}")],
+            )
+            .unwrap();
+    }
+
+    let report = generate_early_warning_report(
+        &db,
+        &configs,
+        EarlyWarningReportOptions {
+            limit_per_section: Some(5),
+            ..options()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(report.summary.high_centrality_linkage_gaps, 25);
+    assert_eq!(report.high_centrality_linkage_gaps.len(), 5);
+    assert_eq!(report.high_centrality_linkage_gaps[0].symbol_id, "gap-0");
 }

--- a/src/tests/analysis/mod.rs
+++ b/src/tests/analysis/mod.rs
@@ -1,3 +1,4 @@
 pub mod early_warning_report_tests;
 pub mod test_linkage_tests;
 pub mod test_quality_tests;
+pub mod test_roles_tests;

--- a/src/tests/analysis/mod.rs
+++ b/src/tests/analysis/mod.rs
@@ -1,3 +1,4 @@
+pub mod change_risk_tests;
 pub mod early_warning_report_tests;
 pub mod test_linkage_tests;
 pub mod test_quality_tests;

--- a/src/tests/analysis/test_linkage_tests.rs
+++ b/src/tests/analysis/test_linkage_tests.rs
@@ -615,6 +615,78 @@ mod tests {
     }
 
     #[test]
+    fn test_parent_aggregation_includes_best_confidence() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let db = SymbolDatabase::new(&db_path).unwrap();
+
+        insert_file(&db, "src/services.rs");
+        insert_file(&db, "tests/services_test.rs");
+
+        db.conn.execute_batch(r#"
+            INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, metadata, reference_score, visibility)
+            VALUES ('class_agg', 'OrderService', 'class', 'csharp', 'src/services.rs', 1, 0, 60, 0, 0, 0, NULL, 5.0, 'public');
+
+            INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, metadata, reference_score, visibility, parent_id)
+            VALUES ('method_agg1', 'CreateOrder', 'method', 'csharp', 'src/services.rs', 5, 0, 20, 0, 0, 0, NULL, 3.0, 'public', 'class_agg');
+
+            INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, metadata, reference_score, visibility, parent_id)
+            VALUES ('method_agg2', 'CancelOrder', 'method', 'csharp', 'src/services.rs', 25, 0, 40, 0, 0, 0, NULL, 2.0, 'public', 'class_agg');
+
+            INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, metadata, reference_score, visibility)
+            VALUES ('test_agg1', 'test_create_order', 'method', 'csharp', 'tests/services_test.rs', 1, 0, 10, 0, 0, 0,
+                    '{"is_test": true, "test_quality": {"quality_tier": "thorough", "confidence": 0.92}}', 0.0, 'private');
+
+            INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, metadata, reference_score, visibility)
+            VALUES ('test_agg2', 'test_cancel_order', 'method', 'csharp', 'tests/services_test.rs', 15, 0, 25, 0, 0, 0,
+                    '{"is_test": true, "test_quality": {"quality_tier": "adequate", "confidence": 0.75}}', 0.0, 'private');
+
+            INSERT INTO relationships (id, from_symbol_id, to_symbol_id, kind, file_path, line_number)
+            VALUES ('rel_agg1', 'test_agg1', 'method_agg1', 'calls', 'tests/services_test.rs', 5);
+
+            INSERT INTO relationships (id, from_symbol_id, to_symbol_id, kind, file_path, line_number)
+            VALUES ('rel_agg2', 'test_agg2', 'method_agg2', 'calls', 'tests/services_test.rs', 18);
+        "#).unwrap();
+
+        crate::analysis::test_linkage::compute_test_linkage(&db).unwrap();
+
+        // The parent class should inherit aggregated linkage from its methods
+        let class_meta_str: Option<String> = db
+            .conn
+            .query_row(
+                "SELECT json_extract(metadata, '$.test_linkage') FROM symbols WHERE id = 'class_agg'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            class_meta_str.is_some(),
+            "Parent class should have aggregated test_linkage"
+        );
+
+        let linkage: serde_json::Value =
+            serde_json::from_str(&class_meta_str.unwrap()).unwrap();
+
+        // best_confidence should be present and reflect the best child's confidence
+        let best_confidence = linkage
+            .get("best_confidence")
+            .expect("best_confidence must be present in parent linkage")
+            .as_f64()
+            .unwrap();
+        assert!(
+            (best_confidence - 0.92).abs() < 0.001,
+            "Parent best_confidence should be 0.92 (from the thorough child), got {}",
+            best_confidence
+        );
+
+        // best_tier should be "thorough" (the best among children)
+        assert_eq!(
+            linkage.get("best_tier").unwrap().as_str().unwrap(),
+            "thorough"
+        );
+    }
+
+    #[test]
     fn test_best_confidence_defaults_when_metadata_absent() {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("test.db");

--- a/src/tests/analysis/test_linkage_tests.rs
+++ b/src/tests/analysis/test_linkage_tests.rs
@@ -504,4 +504,149 @@ mod tests {
             "parent aggregation should also be cleared when child linkage disappears"
         );
     }
+
+    #[test]
+    fn test_scorable_filter_excludes_fixture_includes_test_case_and_legacy() {
+        // Verifies the updated SQL filter:
+        // - test_role = "test_case" => included
+        // - test_role = "fixture_setup" with is_test = true => excluded
+        // - is_test = true with no test_role => included (backward compat)
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let db = SymbolDatabase::new(&db_path).unwrap();
+
+        insert_file(&db, "src/core.rs");
+        insert_file(&db, "tests/core_test.rs");
+
+        db.conn.execute_batch(r#"
+            INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, metadata, reference_score, visibility)
+            VALUES ('prod_core', 'do_work', 'function', 'rust', 'src/core.rs', 1, 0, 20, 0, 0, 0, NULL, 5.0, 'public');
+
+            -- Scorable test case (test_role = "test_case")
+            INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, metadata, reference_score, visibility)
+            VALUES ('test_case_1', 'test_do_work', 'function', 'rust', 'tests/core_test.rs', 5, 0, 15, 0, 0, 0,
+                    '{"is_test": true, "test_role": "test_case", "test_quality": {"quality_tier": "thorough", "confidence": 0.85}}', 0.0, 'private');
+
+            -- Fixture setup (test_role = "fixture_setup", is_test = true) => should be EXCLUDED
+            INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, metadata, reference_score, visibility)
+            VALUES ('fixture_1', 'setup_db', 'function', 'rust', 'tests/core_test.rs', 20, 0, 30, 0, 0, 0,
+                    '{"is_test": true, "test_role": "fixture_setup"}', 0.0, 'private');
+
+            -- Legacy test (is_test = true, no test_role) => should be INCLUDED
+            INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, metadata, reference_score, visibility)
+            VALUES ('legacy_test', 'test_do_work_legacy', 'function', 'rust', 'tests/core_test.rs', 35, 0, 45, 0, 0, 0,
+                    '{"is_test": true, "test_quality": {"quality_tier": "adequate"}}', 0.0, 'private');
+
+            -- All three call the production symbol
+            INSERT INTO relationships (id, from_symbol_id, to_symbol_id, kind, file_path, line_number)
+            VALUES ('rel_tc', 'test_case_1', 'prod_core', 'calls', 'tests/core_test.rs', 10);
+            INSERT INTO relationships (id, from_symbol_id, to_symbol_id, kind, file_path, line_number)
+            VALUES ('rel_fix', 'fixture_1', 'prod_core', 'calls', 'tests/core_test.rs', 25);
+            INSERT INTO relationships (id, from_symbol_id, to_symbol_id, kind, file_path, line_number)
+            VALUES ('rel_leg', 'legacy_test', 'prod_core', 'calls', 'tests/core_test.rs', 40);
+        "#).unwrap();
+
+        let stats = crate::analysis::test_linkage::compute_test_linkage(&db).unwrap();
+        assert_eq!(
+            stats.symbols_covered, 1,
+            "One production symbol should be covered"
+        );
+
+        let prod = db.get_symbol_by_id("prod_core").unwrap().unwrap();
+        let meta = prod.metadata.unwrap();
+        let linkage = meta.get("test_linkage").unwrap();
+
+        // Fixture should be excluded, so only test_case_1 and legacy_test
+        let test_count = linkage.get("test_count").unwrap().as_u64().unwrap();
+        assert_eq!(
+            test_count, 2,
+            "Fixture should be excluded; only test_case and legacy test should link"
+        );
+
+        let linked_tests = linkage.get("linked_tests").unwrap().as_array().unwrap();
+        let test_names: Vec<&str> = linked_tests.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(
+            test_names.contains(&"test_do_work"),
+            "test_case should be linked"
+        );
+        assert!(
+            test_names.contains(&"test_do_work_legacy"),
+            "legacy test should be linked (backward compat)"
+        );
+        assert!(
+            !test_names.contains(&"setup_db"),
+            "fixture should NOT be linked"
+        );
+    }
+
+    #[test]
+    fn test_best_confidence_present_in_linkage_output() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let db = SymbolDatabase::new(&db_path).unwrap();
+
+        insert_file(&db, "src/engine.rs");
+        insert_file(&db, "tests/engine_test.rs");
+
+        db.conn.execute_batch(r#"
+            INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, metadata, reference_score, visibility)
+            VALUES ('prod_eng', 'run_engine', 'function', 'rust', 'src/engine.rs', 1, 0, 20, 0, 0, 0, NULL, 3.0, 'public');
+
+            INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, metadata, reference_score, visibility)
+            VALUES ('test_eng', 'test_run_engine', 'function', 'rust', 'tests/engine_test.rs', 1, 0, 10, 0, 0, 0,
+                    '{"is_test": true, "test_quality": {"quality_tier": "thorough", "confidence": 0.92}}', 0.0, 'private');
+
+            INSERT INTO relationships (id, from_symbol_id, to_symbol_id, kind, file_path, line_number)
+            VALUES ('rel_eng', 'test_eng', 'prod_eng', 'calls', 'tests/engine_test.rs', 5);
+        "#).unwrap();
+
+        crate::analysis::test_linkage::compute_test_linkage(&db).unwrap();
+
+        let prod = db.get_symbol_by_id("prod_eng").unwrap().unwrap();
+        let meta = prod.metadata.unwrap();
+        let linkage = meta.get("test_linkage").unwrap();
+
+        let best_confidence = linkage.get("best_confidence").unwrap().as_f64().unwrap();
+        assert!(
+            (best_confidence - 0.92).abs() < 0.001,
+            "best_confidence should be 0.92 from the test's metadata, got {}",
+            best_confidence
+        );
+    }
+
+    #[test]
+    fn test_best_confidence_defaults_when_metadata_absent() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let db = SymbolDatabase::new(&db_path).unwrap();
+
+        insert_file(&db, "src/old.rs");
+        insert_file(&db, "tests/old_test.rs");
+
+        // Test symbol with no confidence field in test_quality
+        db.conn.execute_batch(r#"
+            INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, metadata, reference_score, visibility)
+            VALUES ('prod_old', 'old_function', 'function', 'rust', 'src/old.rs', 1, 0, 10, 0, 0, 0, NULL, 2.0, 'public');
+
+            INSERT INTO symbols (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, start_byte, end_byte, metadata, reference_score, visibility)
+            VALUES ('test_old', 'test_old_function', 'function', 'rust', 'tests/old_test.rs', 1, 0, 8, 0, 0, 0,
+                    '{"is_test": true, "test_quality": {"quality_tier": "adequate"}}', 0.0, 'private');
+
+            INSERT INTO relationships (id, from_symbol_id, to_symbol_id, kind, file_path, line_number)
+            VALUES ('rel_old', 'test_old', 'prod_old', 'calls', 'tests/old_test.rs', 3);
+        "#).unwrap();
+
+        crate::analysis::test_linkage::compute_test_linkage(&db).unwrap();
+
+        let prod = db.get_symbol_by_id("prod_old").unwrap().unwrap();
+        let meta = prod.metadata.unwrap();
+        let linkage = meta.get("test_linkage").unwrap();
+
+        let best_confidence = linkage.get("best_confidence").unwrap().as_f64().unwrap();
+        assert!(
+            (best_confidence - 0.5).abs() < 0.001,
+            "best_confidence should default to 0.5 when test has no confidence metadata, got {}",
+            best_confidence
+        );
+    }
 }

--- a/src/tests/analysis/test_linkage_tests.rs
+++ b/src/tests/analysis/test_linkage_tests.rs
@@ -664,8 +664,7 @@ mod tests {
             "Parent class should have aggregated test_linkage"
         );
 
-        let linkage: serde_json::Value =
-            serde_json::from_str(&class_meta_str.unwrap()).unwrap();
+        let linkage: serde_json::Value = serde_json::from_str(&class_meta_str.unwrap()).unwrap();
 
         // best_confidence should be present and reflect the best child's confidence
         let best_confidence = linkage

--- a/src/tests/analysis/test_quality_tests.rs
+++ b/src/tests/analysis/test_quality_tests.rs
@@ -1196,7 +1196,11 @@ mod tests {
         let go_cfg = configs.get("go");
         assert!(go_cfg.is_some(), "Go should have a LanguageConfig");
         assert!(
-            go_cfg.unwrap().test_evidence.assertion_identifiers.is_empty(),
+            go_cfg
+                .unwrap()
+                .test_evidence
+                .assertion_identifiers
+                .is_empty(),
             "Go test_evidence.assertion_identifiers should be empty"
         );
 
@@ -1262,6 +1266,80 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_identifier_evidence_without_matches_falls_back_to_regex_body() {
+        use crate::analysis::test_quality::compute_test_quality_metrics;
+        use crate::database::SymbolDatabase;
+        use crate::search::LanguageConfigs;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let db = SymbolDatabase::new(&db_path).unwrap();
+        let configs = LanguageConfigs::load_embedded();
+
+        db.conn
+            .execute(
+                "INSERT INTO files (path, language, hash, size, last_modified) VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params!["test_service.py", "python", "hash1", 200, 0],
+            )
+            .unwrap();
+
+        let code_body = "def test_service():\n    helper()\n    assert result == expected";
+        db.conn
+            .execute(
+                "INSERT INTO symbols (id, name, kind, language, file_path, code_context, metadata, reference_score) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0.0)",
+                rusqlite::params![
+                    "sym-python-test",
+                    "test_service",
+                    "function",
+                    "python",
+                    "test_service.py",
+                    code_body,
+                    r#"{"is_test":true,"test_role":"test_case"}"#,
+                ],
+            )
+            .unwrap();
+
+        db.conn
+            .execute(
+                "INSERT INTO identifiers (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, containing_symbol_id) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                rusqlite::params![
+                    "id-python-helper",
+                    "helper",
+                    "call",
+                    "python",
+                    "test_service.py",
+                    2,
+                    4,
+                    2,
+                    12,
+                    "sym-python-test",
+                ],
+            )
+            .unwrap();
+
+        let stats = compute_test_quality_metrics(&db, &configs).unwrap();
+        assert_eq!(stats.total_tests, 1);
+
+        let updated: String = db
+            .conn
+            .query_row(
+                "SELECT metadata FROM symbols WHERE id = 'sym-python-test'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let meta: serde_json::Value = serde_json::from_str(&updated).unwrap();
+        let tq = &meta["test_quality"];
+
+        assert_eq!(tq["assertion_source"].as_str().unwrap(), "regex");
+        assert_eq!(tq["assertion_count"].as_u64().unwrap(), 1);
+        assert_eq!(tq["quality_tier"].as_str().unwrap(), "thin");
+        assert!((tq["confidence"].as_f64().unwrap() - 0.4).abs() < 0.001);
+    }
+
     // =========================================================================
     // Identifier evidence: no substring matching
     // =========================================================================
@@ -1289,7 +1367,8 @@ mod tests {
             .unwrap();
 
         // Test body that has no regex-detectable assertions either
-        let code_body = "fn test_no_real_asserts() {\n    let r = assertion_report();\n    mock_database();\n}";
+        let code_body =
+            "fn test_no_real_asserts() {\n    let r = assertion_report();\n    mock_database();\n}";
         db.conn
             .execute(
                 "INSERT INTO symbols (id, name, kind, language, file_path, code_context, metadata, reference_score) \

--- a/src/tests/analysis/test_quality_tests.rs
+++ b/src/tests/analysis/test_quality_tests.rs
@@ -78,28 +78,15 @@ mod tests {
 
     #[test]
     fn test_placeholder_body_pass_is_stub() {
-        let assessment = assess_test_quality(
-            Some("test_case"),
-            Some("pass"),
-            0,
-            false,
-            0,
-            false,
-        );
+        let assessment = assess_test_quality(Some("test_case"), Some("pass"), 0, false, 0, false);
         assert_eq!(assessment.tier, TestQualityTier::Stub);
         assert_eq!(assessment.confidence, 1.0);
     }
 
     #[test]
     fn test_placeholder_body_todo_is_stub() {
-        let assessment = assess_test_quality(
-            Some("test_case"),
-            Some("todo!()"),
-            0,
-            false,
-            0,
-            false,
-        );
+        let assessment =
+            assess_test_quality(Some("test_case"), Some("todo!()"), 0, false, 0, false);
         assert_eq!(assessment.tier, TestQualityTier::Stub);
         assert_eq!(assessment.confidence, 1.0);
     }
@@ -120,42 +107,23 @@ mod tests {
 
     #[test]
     fn test_placeholder_body_ellipsis_is_stub() {
-        let assessment = assess_test_quality(
-            Some("test_case"),
-            Some("..."),
-            0,
-            false,
-            0,
-            false,
-        );
+        let assessment = assess_test_quality(Some("test_case"), Some("..."), 0, false, 0, false);
         assert_eq!(assessment.tier, TestQualityTier::Stub);
         assert_eq!(assessment.confidence, 1.0);
     }
 
     #[test]
     fn test_placeholder_body_todo_comment_is_stub() {
-        let assessment = assess_test_quality(
-            Some("test_case"),
-            Some("// TODO"),
-            0,
-            false,
-            0,
-            false,
-        );
+        let assessment =
+            assess_test_quality(Some("test_case"), Some("// TODO"), 0, false, 0, false);
         assert_eq!(assessment.tier, TestQualityTier::Stub);
         assert_eq!(assessment.confidence, 1.0);
     }
 
     #[test]
     fn test_placeholder_body_braces_with_pass_is_stub() {
-        let assessment = assess_test_quality(
-            Some("test_case"),
-            Some("{ pass }"),
-            0,
-            false,
-            0,
-            false,
-        );
+        let assessment =
+            assess_test_quality(Some("test_case"), Some("{ pass }"), 0, false, 0, false);
         assert_eq!(assessment.tier, TestQualityTier::Stub);
         assert_eq!(assessment.confidence, 1.0);
     }
@@ -181,7 +149,10 @@ mod tests {
             "confidence {} should be >= 0.85",
             assessment.confidence
         );
-        assert_eq!(assessment.evidence.assertion_source, EvidenceSource::Identifier);
+        assert_eq!(
+            assessment.evidence.assertion_source,
+            EvidenceSource::Identifier
+        );
         assert_eq!(assessment.evidence.assertion_count, 3);
         assert!(assessment.evidence.has_error_testing);
     }
@@ -199,7 +170,10 @@ mod tests {
         );
         assert_eq!(assessment.tier, TestQualityTier::Adequate);
         assert!(assessment.confidence >= 0.8);
-        assert_eq!(assessment.evidence.assertion_source, EvidenceSource::Identifier);
+        assert_eq!(
+            assessment.evidence.assertion_source,
+            EvidenceSource::Identifier
+        );
     }
 
     #[test]
@@ -215,7 +189,10 @@ mod tests {
         );
         assert_eq!(assessment.tier, TestQualityTier::Thin);
         assert!(assessment.confidence >= 0.8);
-        assert_eq!(assessment.evidence.assertion_source, EvidenceSource::Identifier);
+        assert_eq!(
+            assessment.evidence.assertion_source,
+            EvidenceSource::Identifier
+        );
     }
 
     #[test]
@@ -231,7 +208,10 @@ mod tests {
         );
         assert_eq!(assessment.tier, TestQualityTier::Stub);
         assert_eq!(assessment.confidence, 0.85);
-        assert_eq!(assessment.evidence.assertion_source, EvidenceSource::Identifier);
+        assert_eq!(
+            assessment.evidence.assertion_source,
+            EvidenceSource::Identifier
+        );
     }
 
     #[test]
@@ -329,7 +309,10 @@ mod tests {
             assert!(result > 0);
         "#;
         let assessment = analyze_test_body(body);
-        assert_eq!(assessment.evidence.assertion_count, 2, "Rust assert_eq! + assert! = 2");
+        assert_eq!(
+            assessment.evidence.assertion_count, 2,
+            "Rust assert_eq! + assert! = 2"
+        );
     }
 
     #[test]
@@ -369,7 +352,10 @@ mod tests {
             t.Fatal("should not reach here")
         "#;
         let assessment = analyze_test_body(body);
-        assert_eq!(assessment.evidence.assertion_count, 2, "Go require.Equal + t.Fatal = 2");
+        assert_eq!(
+            assessment.evidence.assertion_count, 2,
+            "Go require.Equal + t.Fatal = 2"
+        );
     }
 
     #[test]
@@ -395,7 +381,10 @@ mod tests {
             Expect(result).To.BeGreaterThan(0);
         "#;
         let assessment = analyze_test_body(body);
-        assert_eq!(assessment.evidence.assertion_count, 2, "C# Should + Expect( = 2");
+        assert_eq!(
+            assessment.evidence.assertion_count, 2,
+            "C# Should + Expect( = 2"
+        );
     }
 
     #[test]
@@ -448,7 +437,10 @@ mod tests {
             println!("hello");
         "#;
         let assessment = analyze_test_body(body);
-        assert_eq!(assessment.evidence.assertion_count, 0, "No assertions in body");
+        assert_eq!(
+            assessment.evidence.assertion_count, 0,
+            "No assertions in body"
+        );
         // Regex path with 0 assertions => Unknown
         assert_eq!(assessment.tier, TestQualityTier::Unknown);
     }
@@ -465,7 +457,10 @@ mod tests {
             service.get_user.returns(42);
         "#;
         let assessment = analyze_test_body(body);
-        assert_eq!(assessment.evidence.mock_count, 3, "mock + jest.fn( + spy = 3");
+        assert_eq!(
+            assessment.evidence.mock_count, 3,
+            "mock + jest.fn( + spy = 3"
+        );
     }
 
     #[test]
@@ -478,7 +473,10 @@ mod tests {
             Mockito.when(service.getUser(1)).thenReturn(user);
         "#;
         let assessment = analyze_test_body(body);
-        assert_eq!(assessment.evidence.mock_count, 3, "@Mock + @InjectMocks + Mockito = 3");
+        assert_eq!(
+            assessment.evidence.mock_count, 3,
+            "@Mock + @InjectMocks + Mockito = 3"
+        );
     }
 
     #[test]
@@ -489,7 +487,10 @@ mod tests {
                 result = controller.handle()
         "#;
         let assessment = analyze_test_body(body);
-        assert!(assessment.evidence.mock_count >= 1, "Python patch( should be detected");
+        assert!(
+            assessment.evidence.mock_count >= 1,
+            "Python patch( should be detected"
+        );
     }
 
     #[test]
@@ -510,7 +511,10 @@ mod tests {
         "#;
         let assessment = analyze_test_body(body);
         // Moq matches \bMoq\b, Mock in "Moq.Mock" matches \bMock\b.
-        assert!(assessment.evidence.mock_count >= 2, "C# Moq + Mock should be detected");
+        assert!(
+            assessment.evidence.mock_count >= 2,
+            "C# Moq + Mock should be detected"
+        );
     }
 
     // =========================================================================
@@ -788,10 +792,7 @@ mod tests {
             meta["test_quality"].is_object(),
             "test_quality should be added"
         );
-        assert_eq!(
-            meta["test_quality"]["assertion_count"].as_u64().unwrap(),
-            2
-        );
+        assert_eq!(meta["test_quality"]["assertion_count"].as_u64().unwrap(), 2);
         // Regex fallback with 2 assertions -> adequate
         assert_eq!(
             meta["test_quality"]["quality_tier"].as_str().unwrap(),
@@ -946,7 +947,8 @@ mod tests {
             .unwrap();
 
         // Insert a test symbol
-        let code_body = "fn test_with_identifiers() {\n    let x = compute();\n    assert_eq!(x, 42);\n}";
+        let code_body =
+            "fn test_with_identifiers() {\n    let x = compute();\n    assert_eq!(x, 42);\n}";
         let metadata = r#"{"is_test":true}"#;
         db.conn
             .execute(
@@ -1071,7 +1073,10 @@ mod tests {
             )
             .unwrap();
         let meta: serde_json::Value = serde_json::from_str(&updated).unwrap();
-        assert_eq!(meta["test_quality"]["quality_tier"].as_str().unwrap(), "n/a");
+        assert_eq!(
+            meta["test_quality"]["quality_tier"].as_str().unwrap(),
+            "n/a"
+        );
         assert_eq!(meta["test_quality"]["confidence"].as_f64().unwrap(), 1.0);
     }
 

--- a/src/tests/analysis/test_quality_tests.rs
+++ b/src/tests/analysis/test_quality_tests.rs
@@ -1173,6 +1173,189 @@ mod tests {
     }
 
     // =========================================================================
+    // Identifier evidence: empty config falls back to regex
+    // =========================================================================
+
+    #[test]
+    fn test_empty_evidence_config_falls_back_to_regex() {
+        // A Go test has a LanguageConfig but its test_evidence has empty
+        // assertion_identifiers. Even with call identifiers present, the
+        // pipeline should fall back to the regex path. With no regex
+        // assertions in the body either, the result should be Unknown
+        // (not high-confidence Stub from the identifier path seeing 0 matches).
+        use crate::analysis::test_quality::compute_test_quality_metrics;
+        use crate::database::SymbolDatabase;
+        use crate::search::LanguageConfigs;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let db = SymbolDatabase::new(&db_path).unwrap();
+        let configs = LanguageConfigs::load_embedded();
+
+        // Verify Go has a config but empty assertion_identifiers
+        let go_cfg = configs.get("go");
+        assert!(go_cfg.is_some(), "Go should have a LanguageConfig");
+        assert!(
+            go_cfg.unwrap().test_evidence.assertion_identifiers.is_empty(),
+            "Go test_evidence.assertion_identifiers should be empty"
+        );
+
+        db.conn
+            .execute(
+                "INSERT INTO files (path, language, hash, size, last_modified) VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params!["handler_test.go", "go", "hash1", 200, 0],
+            )
+            .unwrap();
+
+        // Go test with a body that has no regex-detectable assertions
+        let code_body = "func TestHandler(t *testing.T) {\n    h := NewHandler()\n    h.Run()\n}";
+        db.conn
+            .execute(
+                "INSERT INTO symbols (id, name, kind, language, file_path, code_context, metadata, reference_score) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0.0)",
+                rusqlite::params![
+                    "sym-go-test",
+                    "TestHandler",
+                    "function",
+                    "go",
+                    "handler_test.go",
+                    code_body,
+                    r#"{"is_test":true}"#,
+                ],
+            )
+            .unwrap();
+
+        // Insert call identifiers (simulating tree-sitter extraction)
+        db.conn
+            .execute(
+                "INSERT INTO identifiers (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, containing_symbol_id) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                rusqlite::params![
+                    "id-go-1", "NewHandler", "call", "go", "handler_test.go", 2, 8, 2, 20, "sym-go-test",
+                ],
+            )
+            .unwrap();
+
+        let stats = compute_test_quality_metrics(&db, &configs).unwrap();
+        assert_eq!(stats.total_tests, 1);
+
+        let updated: String = db
+            .conn
+            .query_row(
+                "SELECT metadata FROM symbols WHERE id = 'sym-go-test'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let meta: serde_json::Value = serde_json::from_str(&updated).unwrap();
+        let tq = &meta["test_quality"];
+
+        assert_eq!(
+            tq["assertion_source"].as_str().unwrap(),
+            "regex",
+            "Go with empty evidence config should fall back to regex path"
+        );
+        assert_eq!(
+            tq["quality_tier"].as_str().unwrap(),
+            "unknown",
+            "No regex assertions found => Unknown, not high-confidence Stub"
+        );
+    }
+
+    // =========================================================================
+    // Identifier evidence: no substring matching
+    // =========================================================================
+
+    #[test]
+    fn test_identifier_evidence_no_substring_matching() {
+        // "assertion_report" should NOT match config entry "assert".
+        // "mock_database" should NOT match config entry "mock".
+        // This tests through the pipeline (compute_test_quality_metrics)
+        // to verify that exact-match-only semantics hold end-to-end.
+        use crate::analysis::test_quality::compute_test_quality_metrics;
+        use crate::database::SymbolDatabase;
+        use crate::search::LanguageConfigs;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let db = SymbolDatabase::new(&db_path).unwrap();
+        let configs = LanguageConfigs::load_embedded();
+
+        db.conn
+            .execute(
+                "INSERT INTO files (path, language, hash, size, last_modified) VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params!["test_file.rs", "rust", "abc123", 100, 0],
+            )
+            .unwrap();
+
+        // Test body that has no regex-detectable assertions either
+        let code_body = "fn test_no_real_asserts() {\n    let r = assertion_report();\n    mock_database();\n}";
+        db.conn
+            .execute(
+                "INSERT INTO symbols (id, name, kind, language, file_path, code_context, metadata, reference_score) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0.0)",
+                rusqlite::params![
+                    "sym-substr",
+                    "test_no_real_asserts",
+                    "function",
+                    "rust",
+                    "test_file.rs",
+                    code_body,
+                    r#"{"is_test":true}"#,
+                ],
+            )
+            .unwrap();
+
+        // Insert identifiers that are substrings of config entries but not exact matches
+        db.conn
+            .execute(
+                "INSERT INTO identifiers (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, containing_symbol_id) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                rusqlite::params![
+                    "id-sub-1", "assertion_report", "call", "rust", "test_file.rs", 2, 12, 2, 30, "sym-substr",
+                ],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO identifiers (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, containing_symbol_id) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                rusqlite::params![
+                    "id-sub-2", "mock_database", "call", "rust", "test_file.rs", 3, 4, 3, 18, "sym-substr",
+                ],
+            )
+            .unwrap();
+
+        let stats = compute_test_quality_metrics(&db, &configs).unwrap();
+        assert_eq!(stats.total_tests, 1);
+
+        let updated: String = db
+            .conn
+            .query_row(
+                "SELECT metadata FROM symbols WHERE id = 'sym-substr'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let meta: serde_json::Value = serde_json::from_str(&updated).unwrap();
+        let tq = &meta["test_quality"];
+
+        // With exact matching, "assertion_report" does NOT match "assert",
+        // and "mock_database" does NOT match "mock". So identifier path
+        // sees 0 assertions and 0 mocks.
+        assert_eq!(
+            tq["assertion_count"].as_u64().unwrap(),
+            0,
+            "assertion_report should not match config entry 'assert'"
+        );
+        assert_eq!(
+            tq["mock_count"].as_u64().unwrap(),
+            0,
+            "mock_database should not match config entry 'mock'"
+        );
+    }
+
+    // =========================================================================
     // TestQualityTier::as_str
     // =========================================================================
 

--- a/src/tests/analysis/test_quality_tests.rs
+++ b/src/tests/analysis/test_quality_tests.rs
@@ -1,14 +1,324 @@
 //! Tests for the test quality metrics engine.
 //!
-//! TDD: These tests define the expected behavior for analyzing test function bodies
-//! for assertion density, mock usage, and quality tiering.
+//! Covers both the evidence-based assessment model (assess_test_quality)
+//! and the regex fallback path (analyze_test_body), plus pipeline integration.
 
 #[cfg(test)]
 mod tests {
-    use crate::analysis::test_quality::analyze_test_body;
+    use crate::analysis::test_quality::{
+        EvidenceSource, TestQualityTier, analyze_test_body, assess_test_quality,
+    };
 
     // =========================================================================
-    // Assertion counting — language-agnostic pattern matching
+    // assess_test_quality: role-based short circuits
+    // =========================================================================
+
+    #[test]
+    fn test_fixture_setup_is_not_applicable() {
+        let assessment = assess_test_quality(
+            Some("fixture_setup"),
+            Some("do_setup();"),
+            0,
+            false,
+            0,
+            false,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::NotApplicable);
+        assert_eq!(assessment.confidence, 1.0);
+        assert_eq!(assessment.evidence.assertion_source, EvidenceSource::None);
+    }
+
+    #[test]
+    fn test_teardown_is_not_applicable() {
+        let assessment = assess_test_quality(
+            Some("fixture_teardown"),
+            Some("cleanup();"),
+            0,
+            false,
+            0,
+            false,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::NotApplicable);
+        assert_eq!(assessment.confidence, 1.0);
+    }
+
+    #[test]
+    fn test_container_is_not_applicable() {
+        let assessment = assess_test_quality(
+            Some("test_container"),
+            Some("describe('suite', () => { ... });"),
+            0,
+            false,
+            0,
+            false,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::NotApplicable);
+        assert_eq!(assessment.confidence, 1.0);
+    }
+
+    // =========================================================================
+    // assess_test_quality: stub detection (no body / placeholder body)
+    // =========================================================================
+
+    #[test]
+    fn test_empty_body_is_stub() {
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            None, // no body
+            0,
+            false,
+            0,
+            false,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Stub);
+        assert_eq!(assessment.confidence, 1.0);
+        assert_eq!(assessment.evidence.assertion_source, EvidenceSource::None);
+        assert_eq!(assessment.evidence.body_lines, 0);
+    }
+
+    #[test]
+    fn test_placeholder_body_pass_is_stub() {
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("pass"),
+            0,
+            false,
+            0,
+            false,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Stub);
+        assert_eq!(assessment.confidence, 1.0);
+    }
+
+    #[test]
+    fn test_placeholder_body_todo_is_stub() {
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("todo!()"),
+            0,
+            false,
+            0,
+            false,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Stub);
+        assert_eq!(assessment.confidence, 1.0);
+    }
+
+    #[test]
+    fn test_placeholder_body_unimplemented_is_stub() {
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("unimplemented!()"),
+            0,
+            false,
+            0,
+            false,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Stub);
+        assert_eq!(assessment.confidence, 1.0);
+    }
+
+    #[test]
+    fn test_placeholder_body_ellipsis_is_stub() {
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("..."),
+            0,
+            false,
+            0,
+            false,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Stub);
+        assert_eq!(assessment.confidence, 1.0);
+    }
+
+    #[test]
+    fn test_placeholder_body_todo_comment_is_stub() {
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("// TODO"),
+            0,
+            false,
+            0,
+            false,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Stub);
+        assert_eq!(assessment.confidence, 1.0);
+    }
+
+    #[test]
+    fn test_placeholder_body_braces_with_pass_is_stub() {
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("{ pass }"),
+            0,
+            false,
+            0,
+            false,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Stub);
+        assert_eq!(assessment.confidence, 1.0);
+    }
+
+    // =========================================================================
+    // assess_test_quality: identifier-based evidence (high confidence)
+    // =========================================================================
+
+    #[test]
+    fn test_identifier_thorough() {
+        // 3 assertions + error testing from identifiers
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("let x = compute();\nassert_eq!(x, 1);\nassert!(ok);\nassert_ne!(a, b);"),
+            3,    // assertion_count
+            true, // has_error_testing
+            0,    // mock_count
+            true, // has_identifier_evidence
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Thorough);
+        assert!(
+            assessment.confidence >= 0.85,
+            "confidence {} should be >= 0.85",
+            assessment.confidence
+        );
+        assert_eq!(assessment.evidence.assertion_source, EvidenceSource::Identifier);
+        assert_eq!(assessment.evidence.assertion_count, 3);
+        assert!(assessment.evidence.has_error_testing);
+    }
+
+    #[test]
+    fn test_identifier_adequate() {
+        // 2 assertions, no error testing, no mocks
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("let x = compute();\nassert_eq!(x, 1);\nassert!(ok);"),
+            2,
+            false,
+            0,
+            true,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Adequate);
+        assert!(assessment.confidence >= 0.8);
+        assert_eq!(assessment.evidence.assertion_source, EvidenceSource::Identifier);
+    }
+
+    #[test]
+    fn test_identifier_thin() {
+        // 1 assertion from identifiers
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("let x = compute();\nassert_eq!(x, 1);"),
+            1,
+            false,
+            0,
+            true,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Thin);
+        assert!(assessment.confidence >= 0.8);
+        assert_eq!(assessment.evidence.assertion_source, EvidenceSource::Identifier);
+    }
+
+    #[test]
+    fn test_identifier_stub() {
+        // 0 assertions from identifiers (but we have identifier evidence)
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("let x = compute();\nprintln!(\"done\");"),
+            0,
+            false,
+            0,
+            true,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Stub);
+        assert_eq!(assessment.confidence, 0.85);
+        assert_eq!(assessment.evidence.assertion_source, EvidenceSource::Identifier);
+    }
+
+    #[test]
+    fn test_identifier_thorough_with_mocks() {
+        // 2 assertions + mocks from identifiers -> Thorough
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("let mock = mock_service();\nassert_eq!(result, 42);\nassert!(ok);"),
+            2,
+            false,
+            1,
+            true,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Thorough);
+        assert_eq!(assessment.evidence.mock_count, 1);
+    }
+
+    // =========================================================================
+    // assess_test_quality: regex fallback (low confidence)
+    // =========================================================================
+
+    #[test]
+    fn test_regex_zero_assertions_is_unknown() {
+        // No identifier evidence, regex finds nothing -> Unknown, NOT Stub
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("let x = compute(42);\nprintln!(\"result: {}\", x);"),
+            0,     // regex found 0 assertions
+            false, // no error testing
+            0,     // no mocks
+            false, // no identifier evidence
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Unknown);
+        assert_eq!(assessment.confidence, 0.3);
+        assert_eq!(assessment.evidence.assertion_source, EvidenceSource::Regex);
+    }
+
+    #[test]
+    fn test_regex_with_assertions_thorough() {
+        // No identifier evidence, regex finds 3+ assertions -> Thorough at low confidence
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("assert_eq!(a, 1);\nassert_eq!(b, 2);\nassert_eq!(c, 3);"),
+            3,
+            false,
+            0,
+            false,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Thorough);
+        assert!(
+            assessment.confidence <= 0.5,
+            "regex confidence {} should be <= 0.5",
+            assessment.confidence
+        );
+        assert_eq!(assessment.evidence.assertion_source, EvidenceSource::Regex);
+    }
+
+    #[test]
+    fn test_regex_with_assertions_adequate() {
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("assert_eq!(a, 1);\nassert_eq!(b, 2);"),
+            2,
+            false,
+            0,
+            false,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Adequate);
+        assert_eq!(assessment.confidence, 0.4);
+    }
+
+    #[test]
+    fn test_regex_with_assertions_thin() {
+        let assessment = assess_test_quality(
+            Some("test_case"),
+            Some("let x = compute();\nassert_eq!(x, 42);"),
+            1,
+            false,
+            0,
+            false,
+        );
+        assert_eq!(assessment.tier, TestQualityTier::Thin);
+        assert_eq!(assessment.confidence, 0.4);
+    }
+
+    // =========================================================================
+    // analyze_test_body: regex-based analysis (backward compatibility)
     // =========================================================================
 
     #[test]
@@ -18,8 +328,8 @@ mod tests {
             assert_eq!(result, 84);
             assert!(result > 0);
         "#;
-        let metrics = analyze_test_body(body);
-        assert_eq!(metrics.assertion_count, 2, "Rust assert_eq! + assert! = 2");
+        let assessment = analyze_test_body(body);
+        assert_eq!(assessment.evidence.assertion_count, 2, "Rust assert_eq! + assert! = 2");
     }
 
     #[test]
@@ -30,9 +340,9 @@ mod tests {
             with pytest.raises(ValueError):
                 compute(-1)
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert_eq!(
-            metrics.assertion_count, 2,
+            assessment.evidence.assertion_count, 2,
             "Python self.assertEqual + pytest.raises = 2"
         );
     }
@@ -44,9 +354,9 @@ mod tests {
             expect(result).toBe(84);
             expect(result).toEqual(84);
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert_eq!(
-            metrics.assertion_count, 2,
+            assessment.evidence.assertion_count, 2,
             "JS expect().toBe() + expect().toEqual() = 2"
         );
     }
@@ -58,8 +368,8 @@ mod tests {
             require.Equal(t, 84, result)
             t.Fatal("should not reach here")
         "#;
-        let metrics = analyze_test_body(body);
-        assert_eq!(metrics.assertion_count, 2, "Go require.Equal + t.Fatal = 2");
+        let assessment = analyze_test_body(body);
+        assert_eq!(assessment.evidence.assertion_count, 2, "Go require.Equal + t.Fatal = 2");
     }
 
     #[test]
@@ -70,9 +380,9 @@ mod tests {
             assertTrue(result > 0);
             assertNotNull(result);
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert_eq!(
-            metrics.assertion_count, 3,
+            assessment.evidence.assertion_count, 3,
             "Java assertEquals + assertTrue + assertNotNull = 3"
         );
     }
@@ -84,8 +394,8 @@ mod tests {
             result.Should().Be(84);
             Expect(result).To.BeGreaterThan(0);
         "#;
-        let metrics = analyze_test_body(body);
-        assert_eq!(metrics.assertion_count, 2, "C# Should + Expect( = 2");
+        let assessment = analyze_test_body(body);
+        assert_eq!(assessment.evidence.assertion_count, 2, "C# Should + Expect( = 2");
     }
 
     #[test]
@@ -95,9 +405,9 @@ mod tests {
             XCTAssertEqual(result, 84)
             XCTAssertTrue(result > 0)
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert_eq!(
-            metrics.assertion_count, 2,
+            assessment.evidence.assertion_count, 2,
             "Swift XCTAssertEqual + XCTAssertTrue = 2"
         );
     }
@@ -108,11 +418,10 @@ mod tests {
             result = compute(42)
             expect(result).to eq(84)
         "#;
-        let metrics = analyze_test_body(body);
-        // Ruby uses expect() chains — counted once via the expect( anchor pattern.
-        // Chain methods (.to eq) are not separately counted to avoid double-counting.
+        let assessment = analyze_test_body(body);
+        // Ruby uses expect() chains, counted once via the expect( anchor pattern.
         assert_eq!(
-            metrics.assertion_count, 1,
+            assessment.evidence.assertion_count, 1,
             "Ruby expect().to eq = 1 (counted via expect( anchor)"
         );
     }
@@ -124,10 +433,10 @@ mod tests {
             $this->assertEquals(84, $result);
             $this->assertTrue($result > 0);
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         // PHP's assertEquals/assertTrue match the Java/JUnit assertion patterns.
         assert_eq!(
-            metrics.assertion_count, 2,
+            assessment.evidence.assertion_count, 2,
             "PHP assertEquals + assertTrue = 2 (matched via JUnit patterns)"
         );
     }
@@ -138,12 +447,14 @@ mod tests {
             let x = 42;
             println!("hello");
         "#;
-        let metrics = analyze_test_body(body);
-        assert_eq!(metrics.assertion_count, 0, "No assertions in body");
+        let assessment = analyze_test_body(body);
+        assert_eq!(assessment.evidence.assertion_count, 0, "No assertions in body");
+        // Regex path with 0 assertions => Unknown
+        assert_eq!(assessment.tier, TestQualityTier::Unknown);
     }
 
     // =========================================================================
-    // Mock/stub counting
+    // Mock/stub counting (via analyze_test_body regex path)
     // =========================================================================
 
     #[test]
@@ -153,8 +464,8 @@ mod tests {
             let spy = jest.fn();
             service.get_user.returns(42);
         "#;
-        let metrics = analyze_test_body(body);
-        assert_eq!(metrics.mock_count, 3, "mock + jest.fn( + spy = 3");
+        let assessment = analyze_test_body(body);
+        assert_eq!(assessment.evidence.mock_count, 3, "mock + jest.fn( + spy = 3");
     }
 
     #[test]
@@ -166,8 +477,8 @@ mod tests {
             private UserController controller;
             Mockito.when(service.getUser(1)).thenReturn(user);
         "#;
-        let metrics = analyze_test_body(body);
-        assert_eq!(metrics.mock_count, 3, "@Mock + @InjectMocks + Mockito = 3");
+        let assessment = analyze_test_body(body);
+        assert_eq!(assessment.evidence.mock_count, 3, "@Mock + @InjectMocks + Mockito = 3");
     }
 
     #[test]
@@ -177,14 +488,8 @@ mod tests {
                 mock_service.get_user.return_value = user
                 result = controller.handle()
         "#;
-        let metrics = analyze_test_body(body);
-        // patch( + mock (in mock_service variable name won't match \bmock\b... let's check)
-        // Actually "mock_service" starts with "mock" so \bmock\b won't match "mock_service"
-        // because \b is a word boundary. The word "mock" in "mock_service" is followed by "_",
-        // not a word boundary. Wait, underscore IS a word character. So \bmock\b won't match
-        // "mock_service". It will only match standalone "mock".
-        // But patch( matches.
-        assert!(metrics.mock_count >= 1, "Python patch( should be detected");
+        let assessment = analyze_test_body(body);
+        assert!(assessment.evidence.mock_count >= 1, "Python patch( should be detected");
     }
 
     #[test]
@@ -193,8 +498,8 @@ mod tests {
             let result = compute(42);
             assert_eq!(result, 84);
         "#;
-        let metrics = analyze_test_body(body);
-        assert_eq!(metrics.mock_count, 0, "No mocks in body");
+        let assessment = analyze_test_body(body);
+        assert_eq!(assessment.evidence.mock_count, 0, "No mocks in body");
     }
 
     #[test]
@@ -203,14 +508,13 @@ mod tests {
             var mockService = new Moq.Mock<IUserService>();
             mockService.Setup(s => s.GetUser(1)).Returns(user);
         "#;
-        let metrics = analyze_test_body(body);
-        // Moq + mock (in mockService? no, "mockService" — \bmock\b won't match)
-        // Actually "Moq" matches \bMoq\b. And "Mock" in "Moq.Mock" matches \bMock\b.
-        assert!(metrics.mock_count >= 2, "C# Moq + Mock should be detected");
+        let assessment = analyze_test_body(body);
+        // Moq matches \bMoq\b, Mock in "Moq.Mock" matches \bMock\b.
+        assert!(assessment.evidence.mock_count >= 2, "C# Moq + Mock should be detected");
     }
 
     // =========================================================================
-    // Error testing detection
+    // Error testing detection (via analyze_test_body regex path)
     // =========================================================================
 
     #[test]
@@ -220,9 +524,9 @@ mod tests {
             assert!(result.is_err());
             result.should_err();
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert!(
-            metrics.has_error_testing,
+            assessment.evidence.has_error_testing,
             "Rust should_err should be detected"
         );
     }
@@ -233,9 +537,9 @@ mod tests {
             with pytest.raises(ValueError):
                 compute(-1)
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert!(
-            metrics.has_error_testing,
+            assessment.evidence.has_error_testing,
             "Python pytest.raises should trigger error testing"
         );
     }
@@ -247,9 +551,9 @@ mod tests {
                 compute(-1);
             });
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert!(
-            metrics.has_error_testing,
+            assessment.evidence.has_error_testing,
             "Java assertThrows should trigger error testing"
         );
     }
@@ -259,9 +563,9 @@ mod tests {
         let body = r#"
             expect(() => compute(-1)).toThrow();
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert!(
-            metrics.has_error_testing,
+            assessment.evidence.has_error_testing,
             "JS .toThrow() should trigger error testing"
         );
     }
@@ -271,9 +575,9 @@ mod tests {
         let body = r#"
             await expect(computeAsync(-1)).rejects.toThrow();
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert!(
-            metrics.has_error_testing,
+            assessment.evidence.has_error_testing,
             "JS .rejects should trigger error testing"
         );
     }
@@ -284,26 +588,27 @@ mod tests {
             let result = compute(42);
             assert_eq!(result, 84);
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert!(
-            !metrics.has_error_testing,
+            !assessment.evidence.has_error_testing,
             "No error testing patterns in body"
         );
     }
 
     // =========================================================================
-    // Quality tier classification
+    // Quality tier classification (via analyze_test_body regex path)
     // =========================================================================
 
     #[test]
-    fn test_quality_tier_stub() {
+    fn test_quality_tier_zero_assertions_is_unknown() {
+        // Changed from old behavior: regex with 0 assertions -> Unknown, not Stub
         let body = r#"
             // TODO: implement this test
             let x = 42;
         "#;
-        let metrics = analyze_test_body(body);
-        assert_eq!(metrics.assertion_count, 0);
-        assert_eq!(metrics.quality_tier, "stub");
+        let assessment = analyze_test_body(body);
+        assert_eq!(assessment.evidence.assertion_count, 0);
+        assert_eq!(assessment.tier, TestQualityTier::Unknown);
     }
 
     #[test]
@@ -312,45 +617,9 @@ mod tests {
             let result = compute(42);
             assert_eq!(result, 84);
         "#;
-        let metrics = analyze_test_body(body);
-        assert_eq!(metrics.assertion_count, 1);
-        assert_eq!(metrics.quality_tier, "thin");
-    }
-
-    #[test]
-    fn test_quality_tier_thin_low_density() {
-        // 1 assertion in a very long body => assertion_density < 0.05
-        let body = "let x = 1;\n".repeat(25) + "assert_eq!(x, 1);\n";
-        let metrics = analyze_test_body(&body);
-        assert_eq!(metrics.assertion_count, 1);
-        assert_eq!(
-            metrics.quality_tier, "thin",
-            "1 assertion always produces thin tier"
-        );
-    }
-
-    #[test]
-    fn test_quality_tier_thin_low_density_multiple_assertions() {
-        // 2 assertions in 100 non-empty lines => density = 0.02 < 0.05 => thin
-        let mut lines: Vec<String> = (0..98)
-            .map(|i| format!("    let x{} = {};", i, i))
-            .collect();
-        lines.push("    assert_eq!(x0, 0);".to_string());
-        lines.push("    assert_eq!(x1, 1);".to_string());
-        let body = lines.join("\n");
-
-        let metrics = analyze_test_body(&body);
-        assert_eq!(metrics.assertion_count, 2);
-        assert_eq!(metrics.body_lines, 100);
-        assert!(
-            metrics.assertion_density < 0.05,
-            "density {} should be < 0.05",
-            metrics.assertion_density
-        );
-        assert_eq!(
-            metrics.quality_tier, "thin",
-            "2 assertions in 100 lines (density 0.02) should be thin"
-        );
+        let assessment = analyze_test_body(body);
+        assert_eq!(assessment.evidence.assertion_count, 1);
+        assert_eq!(assessment.tier, TestQualityTier::Thin);
     }
 
     #[test]
@@ -363,9 +632,9 @@ mod tests {
             let c = compute(3);
             assert_eq!(c, 9);
         "#;
-        let metrics = analyze_test_body(body);
-        assert_eq!(metrics.assertion_count, 3);
-        assert_eq!(metrics.quality_tier, "thorough");
+        let assessment = analyze_test_body(body);
+        assert_eq!(assessment.evidence.assertion_count, 3);
+        assert_eq!(assessment.tier, TestQualityTier::Thorough);
     }
 
     #[test]
@@ -375,9 +644,9 @@ mod tests {
             assert!(result.is_err());
             result.should_err();
         "#;
-        let metrics = analyze_test_body(body);
-        assert!(metrics.has_error_testing);
-        assert_eq!(metrics.quality_tier, "thorough");
+        let assessment = analyze_test_body(body);
+        assert!(assessment.evidence.has_error_testing);
+        assert_eq!(assessment.tier, TestQualityTier::Thorough);
     }
 
     #[test]
@@ -388,10 +657,10 @@ mod tests {
             assert_eq!(result, 84);
             assert!(result > 0);
         "#;
-        let metrics = analyze_test_body(body);
-        assert!(metrics.mock_count > 0);
-        assert!(metrics.assertion_count >= 2);
-        assert_eq!(metrics.quality_tier, "thorough");
+        let assessment = analyze_test_body(body);
+        assert!(assessment.evidence.mock_count > 0);
+        assert!(assessment.evidence.assertion_count >= 2);
+        assert_eq!(assessment.tier, TestQualityTier::Thorough);
     }
 
     #[test]
@@ -401,67 +670,33 @@ mod tests {
             assert_eq!(result, 84);
             assert!(result > 0);
         "#;
-        let metrics = analyze_test_body(body);
-        assert_eq!(metrics.assertion_count, 2);
-        assert_eq!(metrics.mock_count, 0);
-        assert!(!metrics.has_error_testing);
-        assert_eq!(metrics.quality_tier, "adequate");
+        let assessment = analyze_test_body(body);
+        assert_eq!(assessment.evidence.assertion_count, 2);
+        assert_eq!(assessment.evidence.mock_count, 0);
+        assert!(!assessment.evidence.has_error_testing);
+        assert_eq!(assessment.tier, TestQualityTier::Adequate);
     }
 
     // =========================================================================
-    // Assertion density
+    // Empty/None body handling (via analyze_test_body)
     // =========================================================================
 
     #[test]
-    fn test_assertion_density_calculation() {
-        // 3 assertions in 20 lines => density = 0.15
-        let mut lines = Vec::new();
-        for i in 0..17 {
-            lines.push(format!("    let x{} = {};", i, i));
-        }
-        lines.push("    assert_eq!(x0, 0);".to_string());
-        lines.push("    assert_eq!(x1, 1);".to_string());
-        lines.push("    assert_eq!(x2, 2);".to_string());
-        let body = lines.join("\n");
-
-        let metrics = analyze_test_body(&body);
-        assert_eq!(metrics.assertion_count, 3);
-        assert_eq!(metrics.body_lines, 20);
-        let expected_density = 3.0 / 20.0;
-        assert!(
-            (metrics.assertion_density - expected_density).abs() < 0.001,
-            "Expected density ~{}, got {}",
-            expected_density,
-            metrics.assertion_density
-        );
+    fn test_empty_body_produces_stub_via_analyze() {
+        let assessment = analyze_test_body("");
+        assert_eq!(assessment.evidence.assertion_count, 0);
+        assert_eq!(assessment.evidence.mock_count, 0);
+        assert_eq!(assessment.evidence.body_lines, 0);
+        assert!(!assessment.evidence.has_error_testing);
+        assert_eq!(assessment.tier, TestQualityTier::Stub);
+        assert_eq!(assessment.confidence, 1.0);
     }
 
     #[test]
-    fn test_assertion_density_empty_body() {
-        let metrics = analyze_test_body("");
-        assert_eq!(metrics.assertion_density, 0.0, "Empty body => density 0.0");
-        assert_eq!(metrics.body_lines, 0);
-    }
-
-    // =========================================================================
-    // Empty/None body handling
-    // =========================================================================
-
-    #[test]
-    fn test_empty_body_produces_stub() {
-        let metrics = analyze_test_body("");
-        assert_eq!(metrics.assertion_count, 0);
-        assert_eq!(metrics.mock_count, 0);
-        assert_eq!(metrics.body_lines, 0);
-        assert!(!metrics.has_error_testing);
-        assert_eq!(metrics.quality_tier, "stub");
-    }
-
-    #[test]
-    fn test_whitespace_only_body_produces_stub() {
-        let metrics = analyze_test_body("   \n  \n   ");
-        assert_eq!(metrics.quality_tier, "stub");
-        assert_eq!(metrics.assertion_count, 0);
+    fn test_whitespace_only_body_produces_stub_via_analyze() {
+        let assessment = analyze_test_body("   \n  \n   ");
+        assert_eq!(assessment.tier, TestQualityTier::Stub);
+        assert_eq!(assessment.evidence.assertion_count, 0);
     }
 
     // =========================================================================
@@ -472,11 +707,13 @@ mod tests {
     fn test_pipeline_integration_updates_metadata() {
         use crate::analysis::test_quality::compute_test_quality_metrics;
         use crate::database::SymbolDatabase;
+        use crate::search::LanguageConfigs;
 
         // Create an in-memory database with the full schema
         let tmp = tempfile::TempDir::new().unwrap();
         let db_path = tmp.path().join("test.db");
         let db = SymbolDatabase::new(&db_path).unwrap();
+        let configs = LanguageConfigs::load_embedded();
 
         // Insert a fake file first (foreign key constraint)
         db.conn
@@ -527,14 +764,10 @@ mod tests {
             .unwrap();
 
         // Run the pipeline function
-        let stats = compute_test_quality_metrics(&db).unwrap();
+        let stats = compute_test_quality_metrics(&db, &configs).unwrap();
 
         // Verify stats
         assert_eq!(stats.total_tests, 1, "Should have analyzed 1 test symbol");
-        assert_eq!(
-            stats.adequate, 1,
-            "2 assertions, no mocks, no error testing = adequate"
-        );
 
         // Verify metadata was updated on the test symbol
         let updated_metadata: String = db
@@ -555,10 +788,25 @@ mod tests {
             meta["test_quality"].is_object(),
             "test_quality should be added"
         );
-        assert_eq!(meta["test_quality"]["assertion_count"].as_u64().unwrap(), 2);
+        assert_eq!(
+            meta["test_quality"]["assertion_count"].as_u64().unwrap(),
+            2
+        );
+        // Regex fallback with 2 assertions -> adequate
         assert_eq!(
             meta["test_quality"]["quality_tier"].as_str().unwrap(),
             "adequate"
+        );
+        // Should have confidence field
+        assert!(
+            meta["test_quality"]["confidence"].as_f64().is_some(),
+            "confidence should be present"
+        );
+        // Should have assertion_source
+        assert_eq!(
+            meta["test_quality"]["assertion_source"].as_str().unwrap(),
+            "regex",
+            "No identifiers inserted, so should be regex path"
         );
 
         // Verify non-test symbol was NOT modified
@@ -581,10 +829,12 @@ mod tests {
     fn test_pipeline_integration_no_body() {
         use crate::analysis::test_quality::compute_test_quality_metrics;
         use crate::database::SymbolDatabase;
+        use crate::search::LanguageConfigs;
 
         let tmp = tempfile::TempDir::new().unwrap();
         let db_path = tmp.path().join("test.db");
         let db = SymbolDatabase::new(&db_path).unwrap();
+        let configs = LanguageConfigs::load_embedded();
 
         db.conn
             .execute(
@@ -609,7 +859,7 @@ mod tests {
             )
             .unwrap();
 
-        let stats = compute_test_quality_metrics(&db).unwrap();
+        let stats = compute_test_quality_metrics(&db, &configs).unwrap();
         assert_eq!(stats.total_tests, 1);
         assert_eq!(
             stats.no_body, 1,
@@ -622,10 +872,12 @@ mod tests {
     fn test_pipeline_integration_preserves_existing_metadata() {
         use crate::analysis::test_quality::compute_test_quality_metrics;
         use crate::database::SymbolDatabase;
+        use crate::search::LanguageConfigs;
 
         let tmp = tempfile::TempDir::new().unwrap();
         let db_path = tmp.path().join("test.db");
         let db = SymbolDatabase::new(&db_path).unwrap();
+        let configs = LanguageConfigs::load_embedded();
 
         db.conn
             .execute(
@@ -652,7 +904,7 @@ mod tests {
             )
             .unwrap();
 
-        compute_test_quality_metrics(&db).unwrap();
+        compute_test_quality_metrics(&db, &configs).unwrap();
 
         let updated: String = db
             .conn
@@ -675,8 +927,156 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_pipeline_integration_with_identifier_evidence() {
+        use crate::analysis::test_quality::compute_test_quality_metrics;
+        use crate::database::SymbolDatabase;
+        use crate::search::LanguageConfigs;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let db = SymbolDatabase::new(&db_path).unwrap();
+        let configs = LanguageConfigs::load_embedded();
+
+        db.conn
+            .execute(
+                "INSERT INTO files (path, language, hash, size, last_modified) VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params!["test_file.rs", "rust", "abc123", 100, 0],
+            )
+            .unwrap();
+
+        // Insert a test symbol
+        let code_body = "fn test_with_identifiers() {\n    let x = compute();\n    assert_eq!(x, 42);\n}";
+        let metadata = r#"{"is_test":true}"#;
+        db.conn
+            .execute(
+                "INSERT INTO symbols (id, name, kind, language, file_path, code_context, metadata, reference_score) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0.0)",
+                rusqlite::params![
+                    "sym-test-ids",
+                    "test_with_identifiers",
+                    "function",
+                    "rust",
+                    "test_file.rs",
+                    code_body,
+                    metadata,
+                ],
+            )
+            .unwrap();
+
+        // Insert Call-kind identifiers for this test symbol
+        // These simulate what the extractor would produce
+        db.conn
+            .execute(
+                "INSERT INTO identifiers (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, containing_symbol_id) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                rusqlite::params![
+                    "id-1", "assert_eq", "call", "rust", "test_file.rs", 3, 4, 3, 20, "sym-test-ids",
+                ],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO identifiers (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, containing_symbol_id) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                rusqlite::params![
+                    "id-2", "assert", "call", "rust", "test_file.rs", 4, 4, 4, 15, "sym-test-ids",
+                ],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO identifiers (id, name, kind, language, file_path, start_line, start_col, end_line, end_col, containing_symbol_id) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                rusqlite::params![
+                    "id-3", "assert_ne", "call", "rust", "test_file.rs", 5, 4, 5, 15, "sym-test-ids",
+                ],
+            )
+            .unwrap();
+
+        let stats = compute_test_quality_metrics(&db, &configs).unwrap();
+        assert_eq!(stats.total_tests, 1);
+
+        let updated_metadata: String = db
+            .conn
+            .query_row(
+                "SELECT metadata FROM symbols WHERE id = 'sym-test-ids'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let meta: serde_json::Value = serde_json::from_str(&updated_metadata).unwrap();
+        let tq = &meta["test_quality"];
+        assert_eq!(
+            tq["assertion_source"].as_str().unwrap(),
+            "identifier",
+            "Should use identifier evidence path"
+        );
+        assert!(
+            tq["confidence"].as_f64().unwrap() >= 0.85,
+            "Identifier path should have high confidence"
+        );
+        assert!(
+            tq["assertion_count"].as_u64().unwrap() >= 2,
+            "Should have counted identifier assertions"
+        );
+    }
+
+    #[test]
+    fn test_pipeline_integration_fixture_not_applicable() {
+        use crate::analysis::test_quality::compute_test_quality_metrics;
+        use crate::database::SymbolDatabase;
+        use crate::search::LanguageConfigs;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let db = SymbolDatabase::new(&db_path).unwrap();
+        let configs = LanguageConfigs::load_embedded();
+
+        db.conn
+            .execute(
+                "INSERT INTO files (path, language, hash, size, last_modified) VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params!["test_file.py", "python", "abc123", 100, 0],
+            )
+            .unwrap();
+
+        // Insert a fixture_setup test symbol
+        let metadata = r#"{"is_test":true,"test_role":"fixture_setup"}"#;
+        db.conn
+            .execute(
+                "INSERT INTO symbols (id, name, kind, language, file_path, code_context, metadata, reference_score) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0.0)",
+                rusqlite::params![
+                    "sym-fixture",
+                    "setUp",
+                    "function",
+                    "python",
+                    "test_file.py",
+                    "self.db = create_test_db()",
+                    metadata,
+                ],
+            )
+            .unwrap();
+
+        let stats = compute_test_quality_metrics(&db, &configs).unwrap();
+        assert_eq!(stats.total_tests, 1);
+        assert_eq!(stats.not_applicable, 1, "Fixture should be not_applicable");
+
+        let updated: String = db
+            .conn
+            .query_row(
+                "SELECT metadata FROM symbols WHERE id = 'sym-fixture'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let meta: serde_json::Value = serde_json::from_str(&updated).unwrap();
+        assert_eq!(meta["test_quality"]["quality_tier"].as_str().unwrap(), "n/a");
+        assert_eq!(meta["test_quality"]["confidence"].as_f64().unwrap(), 1.0);
+    }
+
     // =========================================================================
-    // Comment/string stripping — false positive prevention
+    // Comment/string stripping -- false positive prevention
     // =========================================================================
 
     #[test]
@@ -684,12 +1084,12 @@ mod tests {
         let body = r#"
             let result = do_something();
             // assert_eq!(result, expected)  <-- commented out
-            // should_err is just a note
+            // should_err is a note
             println!("done");
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert_eq!(
-            metrics.assertion_count, 0,
+            assessment.evidence.assertion_count, 0,
             "commented-out assertions should not count"
         );
     }
@@ -701,9 +1101,9 @@ mod tests {
             let desc = "when(something).thenReturn(value)";
             do_real_work();
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert_eq!(
-            metrics.mock_count, 0,
+            assessment.evidence.mock_count, 0,
             "mock patterns inside strings should not count"
         );
     }
@@ -716,9 +1116,9 @@ mod tests {
                expect(x).toBe(1); */
             println!("test");
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert_eq!(
-            metrics.assertion_count, 0,
+            assessment.evidence.assertion_count, 0,
             "block-commented assertions should not count"
         );
     }
@@ -731,9 +1131,9 @@ mod tests {
             assert_eq!(result, true);
             assert!(result.is_ok());
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert_eq!(
-            metrics.assertion_count, 2,
+            assessment.evidence.assertion_count, 2,
             "real assertions should still count after stripping comments"
         );
     }
@@ -749,9 +1149,9 @@ mod tests {
             let assertion_helper = setup();
             let assertive = true;
         "#;
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert_eq!(
-            metrics.assertion_count, 0,
+            assessment.evidence.assertion_count, 0,
             "assert in variable names should not match"
         );
     }
@@ -760,10 +1160,24 @@ mod tests {
     fn test_multiple_assertions_on_same_line() {
         // Each pattern match counts independently
         let body = "assert_eq!(a, b); assert_ne!(c, d);";
-        let metrics = analyze_test_body(body);
+        let assessment = analyze_test_body(body);
         assert_eq!(
-            metrics.assertion_count, 2,
+            assessment.evidence.assertion_count, 2,
             "Two assertions on same line should both count"
         );
+    }
+
+    // =========================================================================
+    // TestQualityTier::as_str
+    // =========================================================================
+
+    #[test]
+    fn test_tier_as_str() {
+        assert_eq!(TestQualityTier::Thorough.as_str(), "thorough");
+        assert_eq!(TestQualityTier::Adequate.as_str(), "adequate");
+        assert_eq!(TestQualityTier::Thin.as_str(), "thin");
+        assert_eq!(TestQualityTier::Stub.as_str(), "stub");
+        assert_eq!(TestQualityTier::Unknown.as_str(), "unknown");
+        assert_eq!(TestQualityTier::NotApplicable.as_str(), "n/a");
     }
 }

--- a/src/tests/analysis/test_roles_tests.rs
+++ b/src/tests/analysis/test_roles_tests.rs
@@ -1,0 +1,468 @@
+//! Tests for post-extraction test role classification.
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use crate::analysis::test_roles::*;
+    use crate::extractors::{AnnotationMarker, SymbolKind, TestRole};
+
+    /// Build a minimal symbol for testing classification.
+    fn make_symbol(
+        kind: SymbolKind,
+        language: &str,
+        annotations: Vec<AnnotationMarker>,
+        metadata: Option<HashMap<String, serde_json::Value>>,
+    ) -> crate::extractors::Symbol {
+        crate::extractors::Symbol {
+            id: "test-id".to_string(),
+            name: "test_fn".to_string(),
+            kind,
+            language: language.to_string(),
+            file_path: "test.cs".to_string(),
+            start_line: 1,
+            start_column: 0,
+            end_line: 10,
+            end_column: 0,
+            start_byte: 0,
+            end_byte: 100,
+            signature: None,
+            doc_comment: None,
+            visibility: None,
+            parent_id: None,
+            metadata,
+            annotations,
+            semantic_group: None,
+            confidence: None,
+            code_context: None,
+            content_type: None,
+        }
+    }
+
+    fn annotation(key: &str) -> AnnotationMarker {
+        AnnotationMarker {
+            annotation: key.to_string(),
+            annotation_key: key.to_string(),
+            raw_text: None,
+            carrier: None,
+        }
+    }
+
+    fn csharp_config() -> TestRoleConfig {
+        TestRoleConfig {
+            test_case: HashSet::from([
+                "test".to_string(),
+                "fact".to_string(),
+                "test_method".to_string(),
+            ]),
+            parameterized_test: HashSet::from(["theory".to_string(), "inline_data".to_string()]),
+            fixture_setup: HashSet::from(["setup".to_string(), "test_initialize".to_string()]),
+            fixture_teardown: HashSet::from(["teardown".to_string(), "test_cleanup".to_string()]),
+            test_container: HashSet::from(["test_class".to_string(), "test_fixture".to_string()]),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // classify_test_role tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_classify_test_role_csharp_fact_annotation() {
+        let config = csharp_config();
+        let symbol = make_symbol(SymbolKind::Method, "csharp", vec![annotation("fact")], None);
+
+        let role = classify_test_role(&symbol, Some(&config));
+        assert_eq!(role, Some(TestRole::TestCase));
+    }
+
+    #[test]
+    fn test_classify_test_role_csharp_setup_annotation() {
+        let config = csharp_config();
+        let symbol = make_symbol(
+            SymbolKind::Method,
+            "csharp",
+            vec![annotation("setup")],
+            None,
+        );
+
+        let role = classify_test_role(&symbol, Some(&config));
+        assert_eq!(role, Some(TestRole::FixtureSetup));
+    }
+
+    #[test]
+    fn test_classify_test_role_csharp_teardown_annotation() {
+        let config = csharp_config();
+        let symbol = make_symbol(
+            SymbolKind::Method,
+            "csharp",
+            vec![annotation("teardown")],
+            None,
+        );
+
+        let role = classify_test_role(&symbol, Some(&config));
+        assert_eq!(role, Some(TestRole::FixtureTeardown));
+    }
+
+    #[test]
+    fn test_classify_test_role_csharp_theory_annotation() {
+        let config = csharp_config();
+        let symbol = make_symbol(
+            SymbolKind::Method,
+            "csharp",
+            vec![annotation("theory")],
+            None,
+        );
+
+        let role = classify_test_role(&symbol, Some(&config));
+        assert_eq!(role, Some(TestRole::ParameterizedTest));
+    }
+
+    #[test]
+    fn test_classify_test_role_container_on_class() {
+        let config = csharp_config();
+        let symbol = make_symbol(
+            SymbolKind::Class,
+            "csharp",
+            vec![annotation("test_fixture")],
+            None,
+        );
+
+        let role = classify_test_role(&symbol, Some(&config));
+        assert_eq!(role, Some(TestRole::TestContainer));
+    }
+
+    #[test]
+    fn test_classify_test_role_container_annotation_on_method_skipped() {
+        // A container annotation on a Method should not match TestContainer
+        let config = csharp_config();
+        let symbol = make_symbol(
+            SymbolKind::Method,
+            "csharp",
+            vec![annotation("test_fixture")],
+            None,
+        );
+
+        let role = classify_test_role(&symbol, Some(&config));
+        assert_eq!(role, None);
+    }
+
+    #[test]
+    fn test_classify_test_role_callable_annotation_on_class_skipped() {
+        // A callable-role annotation (test_case) on a Class should not match
+        let config = csharp_config();
+        let symbol = make_symbol(SymbolKind::Class, "csharp", vec![annotation("fact")], None);
+
+        let role = classify_test_role(&symbol, Some(&config));
+        assert_eq!(role, None);
+    }
+
+    #[test]
+    fn test_classify_test_role_no_annotations_no_is_test() {
+        let config = csharp_config();
+        let symbol = make_symbol(SymbolKind::Method, "csharp", vec![], None);
+
+        let role = classify_test_role(&symbol, Some(&config));
+        assert_eq!(role, None);
+    }
+
+    #[test]
+    fn test_classify_test_role_no_annotations_no_config() {
+        let symbol = make_symbol(SymbolKind::Function, "rust", vec![], None);
+
+        let role = classify_test_role(&symbol, None);
+        assert_eq!(role, None);
+    }
+
+    #[test]
+    fn test_classify_test_role_convention_fallback_is_test_true() {
+        // Convention-based language: no annotations, but extractor set is_test=true
+        let mut metadata = HashMap::new();
+        metadata.insert("is_test".to_string(), serde_json::Value::Bool(true));
+        let symbol = make_symbol(SymbolKind::Function, "rust", vec![], Some(metadata));
+
+        let role = classify_test_role(&symbol, None);
+        assert_eq!(role, Some(TestRole::TestCase));
+    }
+
+    #[test]
+    fn test_classify_test_role_convention_fallback_is_test_on_class_ignored() {
+        // is_test on a Class shouldn't produce a TestCase (callable role)
+        let mut metadata = HashMap::new();
+        metadata.insert("is_test".to_string(), serde_json::Value::Bool(true));
+        let symbol = make_symbol(SymbolKind::Class, "python", vec![], Some(metadata));
+
+        let role = classify_test_role(&symbol, None);
+        assert_eq!(role, None);
+    }
+
+    #[test]
+    fn test_classify_test_role_annotation_overrides_convention() {
+        // If both annotation and is_test are present, annotation wins
+        let config = csharp_config();
+        let mut metadata = HashMap::new();
+        metadata.insert("is_test".to_string(), serde_json::Value::Bool(true));
+        let symbol = make_symbol(
+            SymbolKind::Method,
+            "csharp",
+            vec![annotation("setup")],
+            Some(metadata),
+        );
+
+        // Should be FixtureSetup from annotation, not TestCase from is_test
+        let role = classify_test_role(&symbol, Some(&config));
+        assert_eq!(role, Some(TestRole::FixtureSetup));
+    }
+
+    // ---------------------------------------------------------------
+    // is_scorable_test tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_is_scorable_test_true_for_test_case() {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "test_role".to_string(),
+            serde_json::Value::String("test_case".to_string()),
+        );
+        let symbol = make_symbol(SymbolKind::Function, "rust", vec![], Some(metadata));
+
+        assert!(is_scorable_test(&symbol));
+    }
+
+    #[test]
+    fn test_is_scorable_test_true_for_parameterized_test() {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "test_role".to_string(),
+            serde_json::Value::String("parameterized_test".to_string()),
+        );
+        let symbol = make_symbol(SymbolKind::Method, "csharp", vec![], Some(metadata));
+
+        assert!(is_scorable_test(&symbol));
+    }
+
+    #[test]
+    fn test_is_scorable_test_false_for_fixture_setup() {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "test_role".to_string(),
+            serde_json::Value::String("fixture_setup".to_string()),
+        );
+        let symbol = make_symbol(SymbolKind::Method, "csharp", vec![], Some(metadata));
+
+        assert!(!is_scorable_test(&symbol));
+    }
+
+    #[test]
+    fn test_is_scorable_test_false_for_test_container() {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "test_role".to_string(),
+            serde_json::Value::String("test_container".to_string()),
+        );
+        let symbol = make_symbol(SymbolKind::Class, "csharp", vec![], Some(metadata));
+
+        assert!(!is_scorable_test(&symbol));
+    }
+
+    #[test]
+    fn test_is_scorable_test_false_no_metadata() {
+        let symbol = make_symbol(SymbolKind::Function, "rust", vec![], None);
+
+        assert!(!is_scorable_test(&symbol));
+    }
+
+    // ---------------------------------------------------------------
+    // is_test_related tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_is_test_related_true_for_test_case() {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "test_role".to_string(),
+            serde_json::Value::String("test_case".to_string()),
+        );
+        let symbol = make_symbol(SymbolKind::Function, "rust", vec![], Some(metadata));
+
+        assert!(is_test_related(&symbol));
+    }
+
+    #[test]
+    fn test_is_test_related_true_for_fixture_setup() {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "test_role".to_string(),
+            serde_json::Value::String("fixture_setup".to_string()),
+        );
+        let symbol = make_symbol(SymbolKind::Method, "csharp", vec![], Some(metadata));
+
+        assert!(is_test_related(&symbol));
+    }
+
+    #[test]
+    fn test_is_test_related_true_for_legacy_is_test() {
+        // Backward compat: symbols with only is_test (no test_role) are still test-related
+        let mut metadata = HashMap::new();
+        metadata.insert("is_test".to_string(), serde_json::Value::Bool(true));
+        let symbol = make_symbol(SymbolKind::Function, "rust", vec![], Some(metadata));
+
+        assert!(is_test_related(&symbol));
+    }
+
+    #[test]
+    fn test_is_test_related_false_no_metadata() {
+        let symbol = make_symbol(SymbolKind::Function, "rust", vec![], None);
+
+        assert!(!is_test_related(&symbol));
+    }
+
+    #[test]
+    fn test_is_test_related_false_is_test_false() {
+        let mut metadata = HashMap::new();
+        metadata.insert("is_test".to_string(), serde_json::Value::Bool(false));
+        let symbol = make_symbol(SymbolKind::Function, "rust", vec![], Some(metadata));
+
+        assert!(!is_test_related(&symbol));
+    }
+
+    // ---------------------------------------------------------------
+    // classify_symbols_by_role (batch) tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_classify_symbols_by_role_sets_metadata() {
+        let config = csharp_config();
+        let mut configs = HashMap::new();
+        configs.insert("csharp".to_string(), config);
+
+        let mut symbols = vec![
+            // Should get TestCase from [Fact]
+            make_symbol(SymbolKind::Method, "csharp", vec![annotation("fact")], None),
+            // Should get FixtureSetup from [SetUp]
+            make_symbol(
+                SymbolKind::Method,
+                "csharp",
+                vec![annotation("setup")],
+                None,
+            ),
+            // No annotations, no is_test: should remain unchanged
+            make_symbol(SymbolKind::Method, "csharp", vec![], None),
+            // Convention-based: is_test=true, no annotations, no config match
+            {
+                let mut m = HashMap::new();
+                m.insert("is_test".to_string(), serde_json::Value::Bool(true));
+                make_symbol(SymbolKind::Function, "rust", vec![], Some(m))
+            },
+            // Container with test_fixture annotation
+            make_symbol(
+                SymbolKind::Class,
+                "csharp",
+                vec![annotation("test_fixture")],
+                None,
+            ),
+        ];
+
+        classify_symbols_by_role(&mut symbols, &configs);
+
+        // Symbol 0: TestCase
+        let meta0 = symbols[0].metadata.as_ref().unwrap();
+        assert_eq!(
+            meta0.get("test_role").unwrap().as_str().unwrap(),
+            "test_case"
+        );
+        assert_eq!(meta0.get("is_test").unwrap().as_bool().unwrap(), true);
+
+        // Symbol 1: FixtureSetup
+        let meta1 = symbols[1].metadata.as_ref().unwrap();
+        assert_eq!(
+            meta1.get("test_role").unwrap().as_str().unwrap(),
+            "fixture_setup"
+        );
+        assert_eq!(meta1.get("is_test").unwrap().as_bool().unwrap(), true);
+
+        // Symbol 2: no role assigned
+        assert!(symbols[2].metadata.is_none());
+
+        // Symbol 3: convention fallback to TestCase
+        let meta3 = symbols[3].metadata.as_ref().unwrap();
+        assert_eq!(
+            meta3.get("test_role").unwrap().as_str().unwrap(),
+            "test_case"
+        );
+        assert_eq!(meta3.get("is_test").unwrap().as_bool().unwrap(), true);
+
+        // Symbol 4: TestContainer
+        let meta4 = symbols[4].metadata.as_ref().unwrap();
+        assert_eq!(
+            meta4.get("test_role").unwrap().as_str().unwrap(),
+            "test_container"
+        );
+        assert_eq!(meta4.get("is_test").unwrap().as_bool().unwrap(), true);
+    }
+
+    #[test]
+    fn test_classify_symbols_by_role_preserves_existing_metadata() {
+        let config = csharp_config();
+        let mut configs = HashMap::new();
+        configs.insert("csharp".to_string(), config);
+
+        let mut existing_meta = HashMap::new();
+        existing_meta.insert(
+            "custom_key".to_string(),
+            serde_json::Value::String("custom_value".to_string()),
+        );
+
+        let mut symbols = vec![make_symbol(
+            SymbolKind::Method,
+            "csharp",
+            vec![annotation("fact")],
+            Some(existing_meta),
+        )];
+
+        classify_symbols_by_role(&mut symbols, &configs);
+
+        let meta = symbols[0].metadata.as_ref().unwrap();
+        // Original metadata preserved
+        assert_eq!(
+            meta.get("custom_key").unwrap().as_str().unwrap(),
+            "custom_value"
+        );
+        // New metadata added
+        assert_eq!(
+            meta.get("test_role").unwrap().as_str().unwrap(),
+            "test_case"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // TestRoleConfig::classify_annotation tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_classify_annotation_priority_order() {
+        // If the same key is in both test_case and fixture_setup, test_case wins
+        let config = TestRoleConfig {
+            test_case: HashSet::from(["ambiguous".to_string()]),
+            fixture_setup: HashSet::from(["ambiguous".to_string()]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            config.classify_annotation("ambiguous"),
+            Some(TestRole::TestCase)
+        );
+    }
+
+    #[test]
+    fn test_classify_annotation_unknown_key() {
+        let config = csharp_config();
+        assert_eq!(config.classify_annotation("unknown_annotation"), None);
+    }
+
+    #[test]
+    fn test_classify_annotation_empty_config() {
+        let config = TestRoleConfig::default();
+        assert_eq!(config.classify_annotation("test"), None);
+    }
+}

--- a/src/tests/core/early_warning_report_cache.rs
+++ b/src/tests/core/early_warning_report_cache.rs
@@ -243,7 +243,7 @@ fn early_warning_report_cache_invalidation() {
     let after_config_change = generate_early_warning_report(&db, &configs, options(false)).unwrap();
 
     assert!(!after_config_change.from_cache);
-    assert_eq!(after_config_change.config_schema_version, 1);
+    assert_eq!(after_config_change.config_schema_version, 2);
     assert_eq!(cache_row_count(&db), 1);
 
     db.conn

--- a/src/tests/tools/deep_dive_tests.rs
+++ b/src/tests/tools/deep_dive_tests.rs
@@ -1217,10 +1217,12 @@ mod formatting_tests {
         );
         let mut metadata = std::collections::HashMap::new();
         metadata.insert("is_test".to_string(), serde_json::json!(true));
+        metadata.insert("test_role".to_string(), serde_json::json!("test_case"));
         metadata.insert(
             "test_quality".to_string(),
             serde_json::json!({
                 "quality_tier": "thorough",
+                "confidence": 0.85,
                 "assertion_count": 5,
                 "mock_count": 1,
                 "assertion_density": 0.25
@@ -1231,23 +1233,54 @@ mod formatting_tests {
         let ctx = empty_context(sym);
         let output = format_symbol_context(&ctx, "full");
         assert!(
-            output.contains("Test quality: thorough"),
-            "should show test quality line for test symbol, got: {}",
+            output.contains("[test_case]"),
+            "should show test role, got: {}",
             output
         );
         assert!(
-            output.contains("5 assertions"),
-            "should show assertion count, got: {}",
+            output.contains("[thorough confidence:85%]"),
+            "should show quality tier with confidence, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_quality_info_no_confidence_shows_tier_only() {
+        let mut sym = make_symbol(
+            "test_process_payment",
+            SymbolKind::Function,
+            "tests/payment_tests.rs",
+            45,
+            Some("fn test_process_payment()"),
+            None,
+            None,
+        );
+        let mut metadata = std::collections::HashMap::new();
+        metadata.insert("is_test".to_string(), serde_json::json!(true));
+        metadata.insert(
+            "test_quality".to_string(),
+            serde_json::json!({
+                "quality_tier": "adequate"
+            }),
+        );
+        sym.metadata = Some(metadata);
+
+        let ctx = empty_context(sym);
+        let output = format_symbol_context(&ctx, "full");
+        // With is_test but no test_role, role defaults to "test"
+        assert!(
+            output.contains("[test]"),
+            "should show default role 'test' when test_role not set, got: {}",
             output
         );
         assert!(
-            output.contains("1 mocks"),
-            "should show mock count, got: {}",
+            output.contains("[adequate]"),
+            "should show quality tier without confidence, got: {}",
             output
         );
         assert!(
-            output.contains("0.25 density"),
-            "should show assertion density, got: {}",
+            !output.contains("confidence"),
+            "should NOT show confidence when not present, got: {}",
             output
         );
     }

--- a/src/tests/tools/deep_dive_tests.rs
+++ b/src/tests/tools/deep_dive_tests.rs
@@ -1245,6 +1245,61 @@ mod formatting_tests {
     }
 
     #[test]
+    fn test_quality_info_includes_stored_metrics_for_test_symbol_self() {
+        let mut sym = make_symbol(
+            "test_process_payment",
+            SymbolKind::Function,
+            "tests/payment_tests.rs",
+            45,
+            Some("fn test_process_payment()"),
+            None,
+            None,
+        );
+        let mut metadata = std::collections::HashMap::new();
+        metadata.insert("is_test".to_string(), serde_json::json!(true));
+        metadata.insert("test_role".to_string(), serde_json::json!("test_case"));
+        metadata.insert(
+            "test_quality".to_string(),
+            serde_json::json!({
+                "quality_tier": "thorough",
+                "confidence": 0.85,
+                "assertion_count": 5,
+                "mock_count": 1,
+                "assertion_density": 0.25
+            }),
+        );
+        sym.metadata = Some(metadata);
+
+        let ctx = empty_context(sym);
+        let output = format_symbol_context(&ctx, "full");
+        assert!(
+            output.contains("[test_case]"),
+            "should retain test role, got: {}",
+            output
+        );
+        assert!(
+            output.contains("[thorough confidence:85%]"),
+            "should retain quality tier and confidence, got: {}",
+            output
+        );
+        assert!(
+            output.contains("5 assertions"),
+            "should show stored assertion count, got: {}",
+            output
+        );
+        assert!(
+            output.contains("1 mocks"),
+            "should show stored mock count, got: {}",
+            output
+        );
+        assert!(
+            output.contains("0.25 density"),
+            "should show stored assertion density, got: {}",
+            output
+        );
+    }
+
+    #[test]
     fn test_quality_info_no_confidence_shows_tier_only() {
         let mut sym = make_symbol(
             "test_process_payment",

--- a/src/tools/deep_dive/data.rs
+++ b/src/tools/deep_dive/data.rs
@@ -320,13 +320,7 @@ fn is_container_kind(kind: &SymbolKind) -> bool {
 }
 
 fn symbol_is_test(symbol: &Symbol) -> bool {
-    symbol
-        .metadata
-        .as_ref()
-        .and_then(|metadata| metadata.get("is_test"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
-        || is_test_path(&symbol.file_path)
+    crate::analysis::test_roles::is_test_related(symbol) || is_test_path(&symbol.file_path)
 }
 
 /// Build test location refs by querying identifiers linked from test symbols.

--- a/src/tools/deep_dive/formatting.rs
+++ b/src/tools/deep_dive/formatting.rs
@@ -182,25 +182,32 @@ fn extract_quality_tier(
         .unwrap_or_default()
 }
 
-/// Format test quality info line when the primary symbol IS a test
+/// Format test quality info line when the primary symbol IS a test.
+///
+/// Shows test role, quality tier, and confidence when available.
 fn format_test_quality_info(out: &mut String, symbol: &crate::extractors::base::Symbol) {
     let metadata = match &symbol.metadata {
         Some(m) => m,
         None => return,
     };
 
-    // Only show for test symbols
-    let is_test = metadata
-        .get("is_test")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    if !is_test {
+    // Only show for test-related symbols
+    if !crate::analysis::test_roles::is_test_related(symbol) {
         return;
     }
 
+    let role = metadata
+        .get("test_role")
+        .and_then(|v| v.as_str())
+        .unwrap_or("test");
+
     let tq = match metadata.get("test_quality") {
         Some(v) => v,
-        None => return,
+        None => {
+            // No quality data, but still show the role
+            out.push_str(&format!("  [{}]\n", role));
+            return;
+        }
     };
 
     let tier = tq
@@ -208,26 +215,16 @@ fn format_test_quality_info(out: &mut String, symbol: &crate::extractors::base::
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
 
-    // Build detail parts from available metrics
-    let mut details = Vec::new();
-    if let Some(count) = tq.get("assertion_count").and_then(|v| v.as_u64()) {
-        details.push(format!("{} assertions", count));
-    }
-    if let Some(count) = tq.get("mock_count").and_then(|v| v.as_u64()) {
-        details.push(format!("{} mocks", count));
-    }
-    if let Some(density) = tq.get("assertion_density").and_then(|v| v.as_f64()) {
-        details.push(format!("{:.2} density", density));
-    }
+    let confidence = tq.get("confidence").and_then(|v| v.as_f64());
 
-    if details.is_empty() {
-        out.push_str(&format!("  Test quality: {}\n", tier));
-    } else {
-        out.push_str(&format!(
-            "  Test quality: {} ({})\n",
+    match confidence {
+        Some(c) => out.push_str(&format!(
+            "  [{}] [{} confidence:{:.0}%]\n",
+            role,
             tier,
-            details.join(", ")
-        ));
+            c * 100.0
+        )),
+        None => out.push_str(&format!("  [{}] [{}]\n", role, tier)),
     }
 }
 

--- a/src/tools/deep_dive/formatting.rs
+++ b/src/tools/deep_dive/formatting.rs
@@ -184,7 +184,7 @@ fn extract_quality_tier(
 
 /// Format test quality info line when the primary symbol IS a test.
 ///
-/// Shows test role, quality tier, and confidence when available.
+/// Shows test role, quality tier, confidence, and stored metrics when available.
 fn format_test_quality_info(out: &mut String, symbol: &crate::extractors::base::Symbol) {
     let metadata = match &symbol.metadata {
         Some(m) => m,
@@ -216,15 +216,31 @@ fn format_test_quality_info(out: &mut String, symbol: &crate::extractors::base::
         .unwrap_or("unknown");
 
     let confidence = tq.get("confidence").and_then(|v| v.as_f64());
+    let mut details = Vec::new();
+    if let Some(count) = tq.get("assertion_count").and_then(|v| v.as_u64()) {
+        details.push(format!("{} assertions", count));
+    }
+    if let Some(count) = tq.get("mock_count").and_then(|v| v.as_u64()) {
+        details.push(format!("{} mocks", count));
+    }
+    if let Some(density) = tq.get("assertion_density").and_then(|v| v.as_f64()) {
+        details.push(format!("{:.2} density", density));
+    }
+    let details = if details.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", details.join(", "))
+    };
 
     match confidence {
         Some(c) => out.push_str(&format!(
-            "  [{}] [{} confidence:{:.0}%]\n",
+            "  [{}] [{} confidence:{:.0}%]{}\n",
             role,
             tier,
-            c * 100.0
+            c * 100.0,
+            details
         )),
-        None => out.push_str(&format!("  [{}] [{}]\n", role, tier)),
+        None => out.push_str(&format!("  [{}] [{}]{}\n", role, tier, details)),
     }
 }
 

--- a/src/tools/impact/mod.rs
+++ b/src/tools/impact/mod.rs
@@ -446,11 +446,5 @@ fn sort_identifier_refs(refs: &mut [IdentifierRef]) {
 }
 
 fn is_test_symbol(symbol: &crate::extractors::Symbol) -> bool {
-    symbol
-        .metadata
-        .as_ref()
-        .and_then(|metadata| metadata.get("is_test"))
-        .and_then(|value| value.as_bool())
-        .unwrap_or(false)
-        || is_test_path(&symbol.file_path)
+    crate::analysis::test_roles::is_test_related(symbol) || is_test_path(&symbol.file_path)
 }

--- a/src/tools/impact/ranking.rs
+++ b/src/tools/impact/ranking.rs
@@ -1,5 +1,3 @@
-use serde_json::Value;
-
 use super::walk::ImpactCandidate;
 use crate::extractors::{RelationshipKind, Symbol, Visibility};
 use crate::search::scoring::is_test_path;
@@ -104,11 +102,5 @@ fn relationship_label(kind: &RelationshipKind) -> &'static str {
 }
 
 fn is_test_symbol(symbol: &Symbol) -> bool {
-    symbol
-        .metadata
-        .as_ref()
-        .and_then(|metadata| metadata.get("is_test"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
-        || is_test_path(&symbol.file_path)
+    crate::analysis::test_roles::is_test_related(symbol) || is_test_path(&symbol.file_path)
 }

--- a/src/tools/workspace/indexing/pipeline.rs
+++ b/src/tools/workspace/indexing/pipeline.rs
@@ -65,9 +65,20 @@ pub(crate) async fn run_indexing_pipeline(
     info!("🚀 Processing {} languages", files_by_language.len());
 
     transition_stage(&mut state, route, IndexingStage::Extracting);
-    let batch = tool
+    let mut batch = tool
         .extract_index_batch(files_by_language, &route.workspace_root, &mut state)
         .await?;
+
+    // Classify test roles from annotation configs before persisting.
+    // This enriches symbol metadata with test_role and is_test fields.
+    {
+        let configs = crate::search::LanguageConfigs::load_embedded();
+        let role_configs = configs.build_test_role_configs();
+        crate::analysis::test_roles::classify_symbols_by_role(
+            &mut batch.all_symbols,
+            &role_configs,
+        );
+    }
 
     let Some(db) = route.database_for_write(handler).await? else {
         transition_stage(&mut state, route, IndexingStage::Completed);

--- a/src/tools/workspace/indexing/pipeline.rs
+++ b/src/tools/workspace/indexing/pipeline.rs
@@ -634,8 +634,9 @@ fn analyze_batch(
         t.elapsed().as_secs_f64()
     );
 
+    let language_configs = crate::search::LanguageConfigs::load_embedded();
     let t = std::time::Instant::now();
-    if let Err(e) = crate::analysis::compute_test_quality_metrics(&db_lock) {
+    if let Err(e) = crate::analysis::compute_test_quality_metrics(&db_lock, &language_configs) {
         warn!("Failed to compute test quality metrics: {}", e);
     }
     info!(


### PR DESCRIPTION
## Summary

Replaces Julie's test/fixture conflation and regex-based quality oracle with config-driven role classification and evidence-based quality assessment, then adds security and test coverage signals on the trustworthy foundation.

- **TestRole taxonomy** (TestCase, ParameterizedTest, FixtureSetup, FixtureTeardown, TestContainer) replaces flat test/fixture config across 5 language TOMLs (Java, Kotlin, C#, Python, Rust)
- **Post-extraction pipeline step** classifies test roles from TOML annotations with convention-based fallback; extractors stay pure
- **Evidence-based quality model** uses identifier data (filtered on kind=Call) matched against framework-specific assertion configs, with regex fallback at lower confidence. Fixtures return NotApplicable; Unknown replaces false Stub
- **Confidence flows end-to-end**: test_quality -> test_linkage (aggregated best_confidence) -> change_risk (gated test_weakness_score)
- **Three new signals**: SchedulerSignal, EntryPointLinkageGap, HighCentralityLinkageGap with honest framing language

## External review (codex, adversarial)

5 findings, 3 fixed (835bbdf6), 2 dismissed as out-of-scope:
- Fixed: empty evidence config false Stub, substring matching in identifier evidence, parent aggregation missing confidence
- Dismissed: non-call identifiers in test_linkage (pre-existing), stale metadata suppression (migration concern)

Full report: `.memories/autonomous-run-2026-04-24-test-intelligence-foundation.md`

## Test plan
- [x] 110+ new tests across test_roles, test_quality, test_linkage, change_risk, early_warnings
- [x] Dev tier: 6/7 buckets pass (tools-misc timeout is pre-existing calibration issue)
- [x] clippy clean on changed files
- [x] cargo fmt clean
- [ ] Verify fixtures classified as fixture_setup in live MCP session
- [ ] Verify deep_dive displays role + confidence
- [ ] Verify signals CLI shows scheduler and linkage gap sections