### PR TITLE
Julie Rescue Phase 3b: Resident Embedding-Host (opt-in, one sidecar serves N)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ julie-server
 *.db-wal
 *.db-journal
 .julie/
+.miller/
 .coa/
 .clawpatch/
 

--- a/.memories/2026-06-04/205106_07e6.md
+++ b/.memories/2026-06-04/205106_07e6.md
@@ -1,0 +1,58 @@
+---
+id: checkpoint_07e648da
+timestamp: 2026-06-04T20:51:06.993Z
+tags:
+  - julie-rescue
+  - phase3
+  - daemon-teardown
+  - pr-3a
+  - dead-code-purge
+  - fast-tests
+  - per-crate-gates
+  - test-friction
+  - tantivy
+  - embedding-host
+git:
+  branch: main
+  commit: 0f0d588b
+  files:
+    - .codex/config.toml
+    - .miller/.symbols.db.init.lock
+    - .miller/indexer.lock
+    - .miller/logs/miller-20260531.jsonl
+    - .miller/logs/miller-20260603.jsonl
+    - .miller/logs/miller-35698-20260531.jsonl
+    - .miller/logs/miller-38072-20260531.jsonl
+    - .miller/logs/miller-43360-20260531.jsonl
+    - .miller/symbols.db
+    - .miller/symbols.db.julie-extract.lock
+summary: "Phase 3: both 3a + orphan-purge PRs shipped; pivoted off the slow dev tier"
+briefId: julie-rescue-de-slop-packaging-keep-the-moat
+type: checkpoint
+evidence:
+  - "PR #27 (3a) opened; PR #28 (orphan purge, 16249 LOC) opened"
+  - "3a validated: 929 tests p julie-index+julie-tools+julie-runtime in ~21s;
+    21/21 stale_index_detection integration"
+  - "purge proven dead: cargo check -p julie clean (10.9s), cargo nextest -p
+    xtask 170/170"
+  - "#26 (Phase 2c) merged at session start"
+next: "Await owner merge of #27 (+ #28), then start 3b — resident
+  embedding-host: extract EmbeddingService out of daemon/, add UDS/named-pipe
+  front door + thin RPC client, reuse sidecar provider/protocol as-is.
+  Optionally start 3b off main now (independent of merge) if owner wants
+  momentum."
+---
+
+## Phase 3: both 3a + orphan-purge PRs shipped; pivoted off the slow dev tier
+
+Continuation of checkpoint_508d08c0 (3a implemented). Since then both PRs are pushed, opened, and awaiting human merge. On `main`, team `julie-phase3` shut down.
+
+### Shipped
+- **PR #27 — 3a de-risk** (branch `julie-rescue-phase3`, commit 87ee97be): hang fix (embed before SearchIndex lock, get_context + fast_search) + R1 cross-process Tantivy proof (works via 500ms poll, no reader.reload() needed) + recovery hardening (watcher stamps projected_revision; startup `reconcile_projection_lag_if_needed` runs ensure_current_from_database on lag).
+- **PR #28 — orphan purge** (branch `chore/purge-tools-orphans`, commit d19dbac6): deleted the entire dead `src/tools/` tool tree — 10 modules / 54 files / **16,249 LOC** — orphaned by Phase 2b's copy-not-move. Pure deletion, confirmed dead (`cargo check -p julie` + xtask 170/170). Off `main`, independent of #27.
+
+### Key process pivot (owner feedback)
+Owner pushed back: *"these terribly long running test runs are exactly what we're trying to get rid of."* The full `cargo xtask test dev` tier flaked twice on cold-compile-vs-timeout (xtask 60s, julie-core 28s-compile-vs-30s-wall) and aborted before validating anything. **Killed it and validated 3a via fast per-crate gates** — 929 tests across julie-index+julie-tools+julie-runtime in ~21s + the one relevant top-crate integration module (21/21). Recorded as standing guidance (`feedback_prefer_fast_per_crate_gates`). The crate split exists for exactly this fast feedback.
+
+### Discovery preserved
+The top-crate integration tests are still the slow part (~68s, some >60s) because they instantiate full handlers — that handler-bound weight is what 3b/3c (embedding-host + in-process cutover) will relieve.

--- a/.memories/2026-06-04/212814_f5b0.md
+++ b/.memories/2026-06-04/212814_f5b0.md
@@ -1,0 +1,41 @@
+---
+id: checkpoint_f5b0803f
+timestamp: 2026-06-04T21:28:14.321Z
+tags:
+  - julie-rescue
+  - phase3b
+  - embedding-host
+  - crate-split
+  - team-dispatch
+  - contract-locked
+git:
+  branch: julie-rescue-phase3b
+  commit: 392b6cb4
+  files:
+    - .codex/config.toml
+    - docs/plans/2026-06-04-julie-phase3b-embedding-host.md
+summary: Phase 3b kickoff — merges done, contract locked, team dispatched
+briefId: julie-rescue-de-slop-packaging-keep-the-moat
+type: checkpoint
+next: "Await rpc-client-dev (T3) + host-server-dev (T4) reports; inline-review
+  each; then dispatch T5→T6→T7→T8 sequentially. After all green: branch-gate
+  (cargo xtask test dev) + codex pre-merge review, then
+  finishing-a-development-branch (PR for human merge)."
+---
+
+## Phase 3b kickoff — merges done, contract locked, team dispatched
+
+**Merged to main:** PR #27 (Phase 3a de-risk) + #28 (orphan purge). Local main fast-forwarded (HEAD merge `70478bca`). Branch `julie-rescue-phase3b` cut off it; `.miller/` (235MB stray Miller index) added to .gitignore.
+
+**3b plan** approved (`docs/plans/2026-06-04-julie-phase3b-embedding-host.md`), pre-merge reviewer = **codex**. Scope: resident embedding-host process + UDS/named-pipe front door + thin RPC-client provider, **opt-in/additive** (env `JULIE_EMBEDDING_USE_HOST`); does NOT flip daemon default or rewire stdio (that's 3c).
+
+**Lead-owned contract committed (Tasks 1-2):**
+- T1 (`5013aa7a`): `DaemonPaths::embedding_host_socket/lock/pipe_name` in julie-core (reuses daemon_shutdown_event FNV hash). GREEN.
+- T2 (`392b6cb4`): `host_transport.rs` — blocking `HostClientConn` + async `HostListener`/`HostServerConn` (unix UDS proven+tested 3/3; windows named-pipe cfg-gated, documented untested). **Ungated `sidecar_protocol`** so the thin client compiles WITHOUT `embeddings-sidecar` (verified `cargo check -p julie-pipeline --no-default-features`). Added `tokio-util` (already vendored). Stub `rpc_client.rs`/`host_server.rs` + test files registered; **lead owns all `embeddings/mod.rs` wiring** to prevent worker collisions.
+
+**Team `phase3b` (Opus lead + Sonnet teammates), dispatched in parallel:**
+- `rpc-client-dev` → T3 RpcEmbeddingProvider (rpc_client.rs)
+- `host-server-dev` → T4 host_server.rs
+Then sequential: T5 bin → T6 connect_or_spawn_host → T7 daemon opt-in wiring → T8 acceptance (one sidecar / 3 sessions, HARD GATE).
+
+**Key frozen decisions:** reuse RequestEnvelope as-is (newline JSON v1); client=blocking/host=async; global-per-$JULIE_HOME socket; placement obeys DAG (client+transport+server in julie-pipeline, bin+launch-glue in top crate, 2 path helpers in core).

--- a/.memories/2026-06-04/213917_a8d0.md
+++ b/.memories/2026-06-04/213917_a8d0.md
@@ -1,0 +1,71 @@
+---
+id: checkpoint_a8d02f40
+timestamp: 2026-06-04T21:39:17.378Z
+tags:
+  - feature
+  - phase3b
+  - task3
+  - rpc-client
+  - embedding
+  - ipc
+  - reconnect
+  - mutex
+  - oncelock
+  - transport
+  - julie-pipeline
+git:
+  branch: julie-rescue-phase3b
+  commit: e58e2e44
+  files:
+    - .codex/config.toml
+    - crates/julie-pipeline/src/embeddings/rpc_client.rs
+    - crates/julie-pipeline/src/tests/rpc_client_test.rs
+summary: "Task 3 complete: RpcEmbeddingProvider thin RPC client"
+briefId: julie-rescue-de-slop-packaging-keep-the-moat
+type: checkpoint
+evidence:
+  - "cargo check -p julie-pipeline: clean (0.90s)"
+  - "2/2 tests PASS in 16ms: embed_query_batch_and_cached_info_reflect_health,
+    broken_pipe_triggers_exactly_one_reconnect_and_succeeds"
+symbols:
+  - RpcEmbeddingProvider
+  - ConnInner
+  - CachedHealth
+  - ensure_connected
+  - do_health_handshake
+  - attempt_once
+  - send_request
+  - is_connection_dropped
+  - embed_query_batch_and_cached_info_reflect_health
+  - broken_pipe_triggers_exactly_one_reconnect_and_succeeds
+next: "Commit rpc_client.rs + rpc_client_test.rs with feat(rescue-3b): Task 3 —
+  RpcEmbeddingProvider"
+---
+
+## Task 3 complete: RpcEmbeddingProvider thin RPC client
+
+Implemented the thin blocking RPC client that connects session processes to the resident embedding-host over the IPC transport seam built in Task 2.
+
+### What was built
+
+- **`crates/julie-pipeline/src/embeddings/rpc_client.rs`** — full implementation replacing the stub
+- **`crates/julie-pipeline/src/tests/rpc_client_test.rs`** — two tests replacing the stub
+
+### Key design choices
+
+- `ConnInner { conn: HostClientConn, request_seq: u64 }` lives inside `Mutex<Option<ConnInner>>` — single lock covers both the connection and the per-connection ID counter
+- `OnceLock<CachedHealth>` holds dimensions/device_info/accelerated/degraded_reason populated from first health handshake; never re-populated on reconnect (host identity doesn't change)
+- `ensure_connected()` is a free fn taking `(&mut Option<ConnInner>, &HostAddress, &OnceLock<CachedHealth>)` so it can be called both from `send_request` and from `get_cached` without holding `self`
+- `send_request` serializes params → `serde_json::Value` before locking, so the envelope can be rebuilt for the retry without re-locking
+- Broken-pipe detection: `is_connection_dropped()` matches `BrokenPipe | UnexpectedEof | ConnectionReset | ConnectionAborted`
+- `validate_query_response` / `validate_batch_response` called after `send_request` returns using `self.dimensions()` — cache already populated, no deadlock risk
+
+### Verification
+
+- `cargo check -p julie-pipeline` — clean
+- `cargo nextest run -p julie-pipeline embed_query_batch_and_cached_info_reflect_health broken_pipe_triggers_exactly_one_reconnect_and_succeeds` — **2/2 PASS** (~15ms)
+
+### Tests
+
+1. `embed_query_batch_and_cached_info_reflect_health` — happy path: fake host serves health+embed_query+embed_batch on one connection; asserts correct vectors, dimensions, device_info
+2. `broken_pipe_triggers_exactly_one_reconnect_and_succeeds` — server drops conn after health; client gets UnexpectedEof on embed_query, reconnects, retries — succeeds

--- a/.memories/2026-06-04/220452_7b95.md
+++ b/.memories/2026-06-04/220452_7b95.md
@@ -1,0 +1,39 @@
+---
+id: checkpoint_7b957781
+timestamp: 2026-06-04T22:04:52.328Z
+tags:
+  - julie-rescue
+  - phase3b
+  - embedding-host
+  - subagent-dispatch
+git:
+  branch: julie-rescue-phase3b
+  commit: 46e31f3e
+  files:
+    - .codex/config.toml
+    - src/daemon/app.rs
+    - src/daemon/app/helpers.rs
+summary: "Phase 3b: T7 + T8 dispatched in parallel (final two tasks)"
+briefId: julie-rescue-de-slop-packaging-keep-the-moat
+type: checkpoint
+next: Await T7 (rpc-client-dev) + T8 (host-server-dev) reports; inline-review
+  each; then branch-gate + codex pre-merge review +
+  finishing-a-development-branch PR.
+---
+
+## Phase 3b: T7 + T8 dispatched in parallel (final two tasks)
+
+Resident embedding-host (one PyTorch sidecar serves N Julie processes), additive/opt-in, branch `julie-rescue-phase3b`. T1–T6 all committed (HEAD `46e31f3e`).
+
+**In flight (subagent-driven-development, visible team `phase3b`):**
+- **T7 → rpc-client-dev** — additive opt-in wiring in `src/daemon/app/helpers.rs::spawn_embedding_init`: branch on truthy `JULIE_EMBEDDING_USE_HOST` → build provider via `connect_or_spawn_host(&DaemonPaths::try_new())` instead of `create_embedding_provider()`, route both into the EXISTING match unchanged. Env-unset path byte-for-byte unchanged. Test: `embedding_host_optin.rs` asserts `use_embedding_host()` gate. No new params to spawn_embedding_init.
+- **T8 → host-server-dev (HARD GATE)** — (1) lock-first refactor of `host_server.rs`: `run_embedding_host_with_factory(make_provider: FnOnce)` acquires fs2 lock FIRST, builds provider AFTER (existing `run_embedding_host(provider)` becomes thin wrapper `|| Ok(provider)`; `run_embedding_host_default` uses factory). Fixes the race where 3 concurrent hosts each spawn a sidecar before failing the lock. (2) Acceptance test `embedding_host_multi_session.rs`: 3 concurrent `connect_or_spawn_host` → exactly ONE sidecar (counter file) + all 3 embed (dims==4) + clean SIGTERM shutdown.
+
+**Key design decisions baked into the specs:**
+- Cross-process sidecar count via a **counter FILE** (in-process AtomicU32 can't see a separate-process host's spawns); stub also writes `os.getppid()` → recovers winning host PID for SIGTERM cleanup.
+- Stub sidecar = python via `JULIE_EMBEDDING_SIDECAR_PROGRAM=python3` + `JULIE_EMBEDDING_SIDECAR_SCRIPT=stub.py` (NON-raw ⇒ args=[script]); speaks envelope protocol copied from `sidecar_provider.rs:587–612`.
+- Host bin found by prepending `current_exe().parent().parent()` (=target/debug) to PATH.
+
+**Lead owns:** `src/tests/daemon/mod.rs` (already registers both test files); affected-change + branch-gate; the official acceptance-gate run (`cargo nextest run -p julie --features embeddings-sidecar <test>`).
+
+**After both green:** lead branch-gate (`cargo xtask test dev` + dep tripwire scan + `--no-run` + full `-p` dev tier since `--no-run` skips integration tripwires) → **codex pre-merge review** (razorback:pre-merge-review, reviewer_choice=codex) → razorback:finishing-a-development-branch (PR for human merge). #27/#28 already merged.

--- a/.memories/2026-06-04/220853_b5dd.md
+++ b/.memories/2026-06-04/220853_b5dd.md
@@ -1,0 +1,57 @@
+---
+id: checkpoint_b5dda3ac
+timestamp: 2026-06-04T22:08:53.919Z
+tags:
+  - feature
+  - phase3b
+  - embedding-host
+  - daemon
+  - spawn_embedding_init
+  - opt-in
+  - env-var
+  - coexistence
+git:
+  branch: julie-rescue-phase3b
+  commit: 46e31f3e
+  files:
+    - .codex/config.toml
+    - src/daemon/app.rs
+    - src/daemon/app/helpers.rs
+    - src/tests/daemon/embedding_host_optin.rs
+summary: "Task 7 complete: opt-in host path in spawn_embedding_init"
+briefId: julie-rescue-de-slop-packaging-keep-the-moat
+evidence:
+  - cargo nextest run --lib host_path_taken_when_env_set
+    existing_path_taken_when_env_unset → 2/2 PASS in 18ms
+symbols:
+  - spawn_embedding_init
+  - is_use_host_enabled
+  - connect_or_spawn_host
+  - EmbeddingService::publish_ready
+next: "T8: acceptance test — one sidecar serves 3 sessions (hard gate)"
+---
+
+## Task 7 complete: opt-in host path in spawn_embedding_init
+
+Phase 3b coexistence wiring — `JULIE_EMBEDDING_USE_HOST` env var gates the new host path inside `spawn_embedding_init`.
+
+### WHAT
+- Added `paths: DaemonPaths` parameter to `spawn_embedding_init` in `src/daemon/app/helpers.rs`
+- Added early-return host branch: if `is_use_host_enabled()` is true, calls `connect_or_spawn_host(&paths)` in `spawn_blocking`, wraps in `Arc<dyn EmbeddingProvider>`, synthesizes `EmbeddingRuntimeStatus { Sidecar, Sidecar, accelerated: false }`, then `publish_ready` (or `publish_unavailable` on error), then returns
+- Added `is_use_host_enabled()` helper at end of file: matches `"1" | "true" | "yes" | "on"` case-insensitively
+- Updated call site in `src/daemon/app.rs` line 447: added `self.paths.clone()` as 4th arg; also promoted `spawn_embedding_init` into `pub(crate) use helpers::{...}` so tests can reach it
+- Wrote two tests in `src/tests/daemon/embedding_host_optin.rs`: host path taken (env=1 + fake HostListener → Ready) and existing path taken (env unset + JULIE_EMBEDDING_PROVIDER=none → Unavailable)
+
+### WHY
+Phase 3b requires sessions to share one resident embedding-host. The daemon's `spawn_embedding_init` is the bootstrap point. Opt-in via env var allows gradual rollout without touching the existing sidecar path.
+
+### HOW
+- `is_host_live()` inside `connect_or_spawn_host` does a blocking connect/drop, so tests just need `HostListener::bind` before setting the env var — no fake protocol server needed
+- `unsafe` blocks required for `set_var`/`remove_var` (Rust 2024 edition)
+- `static Mutex<()>` serializes env-var mutation across parallel test runs
+- Existing `create_embedding_provider` path is byte-for-byte unchanged
+
+### IMPACT
+- `spawn_embedding_init` now has the host path wired and tested
+- Two tests 2/2 green in 18ms
+- Unblocks T8 (acceptance test: one sidecar serves 3 sessions)

--- a/.memories/2026-06-04/221353_a928.md
+++ b/.memories/2026-06-04/221353_a928.md
@@ -1,0 +1,72 @@
+---
+id: checkpoint_a9287c26
+timestamp: 2026-06-04T22:13:53.825Z
+tags:
+  - feature
+  - phase3b
+  - embedding-host
+  - daemon
+  - spawn_embedding_init
+  - opt-in
+  - env-var
+  - architecture-correction
+git:
+  branch: julie-rescue-phase3b
+  commit: f1db6d0e
+  files:
+    - .codex/config.toml
+    - src/daemon/app.rs
+    - src/daemon/app/helpers.rs
+    - src/tests/daemon/embedding_host_optin.rs
+summary: "Task 7 revised: approved architecture — no new param, init_result
+  feeds existing match"
+briefId: julie-rescue-de-slop-packaging-keep-the-moat
+evidence:
+  - cargo nextest run --lib false_when_env_unset true_for_all_truthy_values
+    false_for_falsy_and_unrecognised_values → 3/3 PASS in 17ms
+  - cargo check → clean, no warnings
+symbols:
+  - spawn_embedding_init
+  - use_embedding_host
+  - DaemonPaths::try_new
+  - connect_or_spawn_host
+next: "T8: acceptance test — one sidecar serves 3 sessions (hard gate)"
+---
+
+## Task 7 revised: approved architecture — no new param, init_result feeds existing match
+
+Replaced the early-return / extra-param implementation with the lead-approved shape.
+
+### WHAT CHANGED from first pass
+- Removed `paths: DaemonPaths` parameter from `spawn_embedding_init` — signature stays original
+- Reverted `self.paths.clone()` from call site in `app.rs`
+- Replaced early-return host branch with `init_result = if use_embedding_host() { ... } else { create_embedding_provider }` — both branches produce same type, existing match is byte-for-byte unchanged
+- Renamed `is_use_host_enabled` → `use_embedding_host` (pub(crate), cfg(test)-gated re-export in app.rs)
+- Replaced integration-style tests (wait_until_settled) with unit tests calling `use_embedding_host()` directly
+
+### Architecture — approved shape
+```rust
+let init_result = if use_embedding_host() {
+    tokio::task::spawn_blocking(|| {
+        // DaemonPaths::try_new() inside branch — no param needed
+        match DaemonPaths::try_new().map_err(...).and_then(|p| connect_or_spawn_host(&p)) {
+            Ok(rpc)  => (Some(Arc::new(rpc) as Arc<dyn EmbeddingProvider>), Some(status)),
+            Err(e)   => (None, Some(status_with_degraded_reason)),
+        }
+    }).await
+} else {
+    tokio::task::spawn_blocking(|| create_embedding_provider()).await
+};
+// existing match unchanged ↓
+```
+
+### Tests (3/3 green, 17ms)
+- `false_when_env_unset` — env absent → `use_embedding_host()` returns false
+- `true_for_all_truthy_values` — `1`, `true`, `on`, various cases → true
+- `false_for_falsy_and_unrecognised_values` — `0`, `false`, `off`, `no`, `yes`, `maybe` → false
+- Pattern: serial_test + local EnvGuard (mirrors paths.rs pattern)
+
+### Lessons
+- `pub(crate)` on an item in a private `mod helpers` is NOT accessible from outside without re-export via `pub(crate) use`
+- Gate test-only re-exports with `#[cfg(test)]` to suppress unused-import warnings in lib mode
+- `spawn_blocking` closure can return the same tuple type as `create_embedding_provider` — no need for outer Result wrapping

--- a/.memories/2026-06-04/222211_09f6.md
+++ b/.memories/2026-06-04/222211_09f6.md
@@ -1,0 +1,50 @@
+---
+id: checkpoint_09f6c83e
+timestamp: 2026-06-04T22:22:11.926Z
+tags:
+  - phase3b
+  - task8
+  - hard-gate
+  - embedding-host
+  - acceptance-test
+git:
+  branch: julie-rescue-phase3b
+  commit: d056b7c4
+  files:
+    - .codex/config.toml
+    - src/daemon/app.rs
+    - src/daemon/app/helpers.rs
+    - src/tests/daemon/embedding_host_optin.rs
+summary: "T8 — Acceptance test: one sidecar serves three sessions [HARD GATE]"
+briefId: julie-rescue-de-slop-packaging-keep-the-moat
+type: checkpoint
+evidence:
+  - cargo nextest run -p julie --features embeddings-sidecar
+    one_sidecar_serves_three_sessions → 1/1 PASS 0.312s
+  - commit d056b7c4
+symbols:
+  - one_sidecar_serves_three_sessions
+  - run_embedding_host_default
+  - connect_or_spawn_host
+---
+
+## T8 — Acceptance test: one sidecar serves three sessions [HARD GATE]
+
+### WHAT
+Implemented `src/tests/daemon/embedding_host_multi_session.rs` — the Phase 3b HARD GATE acceptance test proving one resident embedding-host serves multiple concurrent sessions backed by exactly one sidecar.
+
+### HOW
+- **Stub sidecar**: self-contained Python script (`stub_sidecar.py`) written to tempdir at test time. Launched via `JULIE_EMBEDDING_SIDECAR_PROGRAM=<path>` + `JULIE_EMBEDDING_SIDECAR_RAW_PROGRAM=1` (raw executable mode — no extra Python args). On startup appends `"launch\n"` to `$JULIE_SIDECAR_COUNTER_FILE` for cross-process launch counting. Serves `health`/`embed_query`/`embed_batch`/`shutdown` via the sidecar wire protocol.
+- **In-process host**: `tokio::spawn(run_embedding_host_default(&addr, &lock, cancel))`. Avoids binary-location complexity while still exercising the full embedding host code path including `fs2` singleton lock and `SidecarEmbeddingProvider`.
+- **Three sessions**: `connect_or_spawn_host(&paths)` called 3× concurrently via `spawn_blocking`. Since host is live, all three take the fast path (`is_host_live → true → RpcEmbeddingProvider::new`).
+- **Concurrent embeds**: `tokio::join!` on 3 `spawn_blocking` tasks each calling `embed_query` + `embed_batch` with distinct inputs.
+
+### HARD GATE RESULTS
+- **(a) Correct dims**: All 3 sessions return `STUB_DIMS=4` vectors; actual values verified (`[len(text) as f32; 4]`)
+- **(b) Exactly 1 sidecar launch**: Counter file has exactly 1 line
+- **(c) Clean shutdown**: `cancel()` → host task exits → socket removed → fs2 lock re-acquirable
+
+### IMPACT
+- All 3 HARD GATE assertions PASS
+- Test runs in 0.312s (stub sidecar, no GPU/Python model load)
+- Proves the Phase 3b invariant: N concurrent sessions share 1 host and 1 sidecar

--- a/.memories/2026-06-04/223653_bf73.md
+++ b/.memories/2026-06-04/223653_bf73.md
@@ -1,0 +1,61 @@
+---
+id: checkpoint_bf739f77
+timestamp: 2026-06-04T22:36:53.933Z
+tags:
+  - bug-fix
+  - phase3b
+  - deadlock
+  - spawn_blocking
+  - async
+  - embedding-host
+  - tokio
+git:
+  branch: julie-rescue-phase3b
+  commit: d056b7c4
+  files:
+    - .codex/config.toml
+    - crates/julie-pipeline/src/embeddings/host_server.rs
+    - src/daemon/app.rs
+    - src/daemon/app/helpers.rs
+    - src/tests/daemon/embedding_host_multi_session.rs
+    - src/tests/daemon/embedding_host_optin.rs
+summary: "T7 final: deadlock fix — blocking health calls must be inside spawn_blocking"
+briefId: julie-rescue-de-slop-packaging-keep-the-moat
+evidence:
+  - cargo nextest run --lib embedding_host_optin → 2/2 PASS in 21ms
+symbols:
+  - spawn_embedding_init
+  - use_embedding_host
+  - RpcEmbeddingProvider::accelerated
+  - RpcEmbeddingProvider::get_cached
+next: Stand by for lead branch-gate after T8 lands
+---
+
+## T7 final: deadlock fix — blocking health calls must be inside spawn_blocking
+
+### Root cause of hang
+`provider.accelerated()` / `provider.degraded_reason()` in the `.map()` closure ran on the **async runtime** (outside spawn_blocking). These call `get_cached()` → `ensure_connected()` → `HostClientConn::connect()` (blocking I/O). Blocking the tokio runtime prevented the async fake-server task from processing `accept()` / `read_line()` / `write_line()` → deadlock.
+
+### Fix
+Moved the full `match Ok(rpc) / Err(e)` block INSIDE the `spawn_blocking` closure so all blocking I/O (connect + health handshake) runs on a thread-pool thread, leaving the tokio runtime free to drive the async server.
+
+```rust
+tokio::task::spawn_blocking(move || {
+    match connect_or_spawn_host(&paths) {
+        Ok(rpc) => {
+            let provider = Arc::new(rpc) as Arc<dyn EmbeddingProvider>;
+            // accelerated() → get_cached() → ensure_connected() → health (blocking!)
+            let status = EmbeddingRuntimeStatus { accelerated: provider.accelerated()... };
+            (Some(provider), Some(status))
+        }
+        Err(e) => (None, Some(status_with_degraded_reason))
+    }
+}).await
+```
+
+### Tests — 2/2 green (21ms)
+- `host_path_taken_when_env_set` — fake host serves health handshake; asserts Ready
+- `existing_path_taken_when_env_unset` — env unset + provider=none; asserts Unavailable, reason doesn't contain "embedding-host"
+
+### Lesson
+Never call blocking socket I/O (HostClientConn methods, get_cached()) from async context without spawn_blocking. Even `Option<bool>` accessors on RpcEmbeddingProvider are secretly blocking.

--- a/.memories/2026-06-04/223902_c280.md
+++ b/.memories/2026-06-04/223902_c280.md
@@ -1,0 +1,74 @@
+---
+id: checkpoint_c280b3f6
+timestamp: 2026-06-04T22:39:02.798Z
+tags:
+  - phase3b
+  - T8
+  - hard-gate
+  - embedding-host
+  - lock-first
+  - acceptance-test
+git:
+  branch: julie-rescue-phase3b
+  commit: 7b46ee01
+  files:
+    - .codex/config.toml
+summary: T8 HARD GATE — lock-first refactor + binary-spawn acceptance test (PASS)
+briefId: julie-rescue-de-slop-packaging-keep-the-moat
+type: checkpoint
+alternatives:
+  - In-process tokio::spawn approach (rejected by lead — doesn't test real
+    binary or prove lock-first correctness under genuine concurrent spawning)
+evidence:
+  - cargo nextest run -p julie-pipeline host_server → 4/4 PASS
+  - cargo nextest run -p julie --features embeddings-sidecar
+    one_sidecar_serves_three_sessions → 1/1 PASS 0.645s
+  - commit 7b46ee01
+symbols:
+  - run_embedding_host_with_factory
+  - run_embedding_host_default
+  - connect_or_spawn_host
+  - one_sidecar_serves_three_sessions
+next: Report to team-lead. T8 complete. Phase 3b tasks T3-T8 all done.
+---
+
+## T8 HARD GATE — lock-first refactor + binary-spawn acceptance test (PASS)
+
+### WHAT
+Completed Phase 3b Task 8 — the HARD GATE acceptance test proving one resident embedding-host serves 3 concurrent sessions backed by exactly one sidecar.
+
+Two commits:
+1. **`7b46ee01`** — lock-first refactor + binary-spawn acceptance test (this session)
+2. **`d056b7c4`** — previous in-process approach (rejected by lead, superseded)
+
+### WHY
+The original T8 implementation used `tokio::spawn(run_embedding_host_default(...))` in-process. The team-lead rejected this because it didn't test the real binary and didn't prove the lock-first correctness property under genuine concurrent spawning.
+
+### HOW
+
+**PART 1 — Lock-first refactor** (`crates/julie-pipeline/src/embeddings/host_server.rs`):
+- Introduced `run_embedding_host_with_factory(addr, lock_path, cancel, make_provider)` that acquires the fs2 singleton lock BEFORE calling the provider factory
+- Competing host processes fail `try_lock_exclusive` and exit without ever calling `create_embedding_provider` → exactly one sidecar per $JULIE_HOME
+- `run_embedding_host(provider)` is now a thin wrapper (keeps T4 tests passing)
+- `run_embedding_host_default` uses the factory pattern
+
+**PART 2 — Binary-spawn acceptance test** (`src/tests/daemon/embedding_host_multi_session.rs`):
+- 3 `std::thread::spawn` threads each call `connect_or_spawn_host`
+- Stub: `JULIE_EMBEDDING_SIDECAR_PROGRAM=python3 + JULIE_EMBEDDING_SIDECAR_SCRIPT=stub.py` (NOT RAW_PROGRAM)
+- Stub writes counter file + os.getppid() to ppid file
+- PATH prepended with `current_exe().parent().parent()` = `target/debug/`
+- Shutdown: `libc::kill(host_pid, SIGTERM)` → poll until socket gone
+- `#[serial_test::serial]` + `EnvGuard` RAII restore
+
+### IMPACT
+All HARD GATE assertions PASS:
+- (a) All 3 clients return STUB_DIMS=4 vectors for embed_query + embed_batch
+- (b) Counter file: exactly 1 line — one sidecar launch despite 3 concurrent spawns
+- (c) SIGTERM → socket removed → fs2 lock re-acquirable
+
+T4 host_server tests: 4/4 PASS (unchanged by lock-first refactor)
+T8 acceptance test: 1/1 PASS, 0.645s
+
+### Key technical discovery
+`std::iter::once(target_debug.as_os_str())` fails to chain with `split_paths` (yields `PathBuf` not `&OsStr`). Fix: `std::iter::once(target_debug.clone()).chain(split_paths(...))` — both yield `PathBuf`.
+

--- a/.memories/2026-06-04/224504_04b9.md
+++ b/.memories/2026-06-04/224504_04b9.md
@@ -1,0 +1,51 @@
+---
+id: checkpoint_04b9c1f9
+timestamp: 2026-06-04T22:45:04.532Z
+tags:
+  - phase3b
+  - T8
+  - hard-gate
+  - 3-host-race
+  - lock-first
+git:
+  branch: julie-rescue-phase3b
+  commit: 79a45741
+  files:
+    - .codex/config.toml
+summary: T8 HARD GATE v3 — 3-host-race in-process test (PASS)
+briefId: julie-rescue-de-slop-packaging-keep-the-moat
+type: checkpoint
+evidence:
+  - cargo nextest run -p julie-pipeline host_server → 4/4 PASS
+  - cargo nextest run -p julie --features embeddings-sidecar
+    one_sidecar_serves_three_sessions → 1/1 PASS 0.118s
+  - sidecar_launches=1, host_ok=1, host_err=2, embed_elapsed=798µs
+  - commit 79a45741
+---
+
+## T8 HARD GATE v3 — 3-host-race in-process test (PASS)
+
+### WHAT
+Replaced the binary-spawn test (which didn't prove the race) with the correct design: 3 concurrent `run_embedding_host_default` tasks racing for the same lock.
+
+### WHY
+The binary-spawn test's counter==1 was trivially true (only 1 host was spawned; threads 2/3 might have seen the socket live before trying to spawn). The meaningful test requires all 3 hosts to race for the lock simultaneously.
+
+### HOW
+- `tokio::spawn(run_embedding_host_default(&a, &l, c))` × 3, same lock_path, same addr
+- flock(2) semantics: per-open-file-description → genuine 3-way race even in-process
+- Winner: lock held → make_provider → sidecar → socket bound
+- Losers: `try_lock_exclusive` fails → Err immediately, before factory
+- After wait_for_live, 3 connect_or_spawn_host clients (fast path)
+- After embeds and counter check, cancel() → join all 3 → assert 1 Ok / 2 Err
+
+### IMPACT
+Output confirmed: `sidecar_launches=1 | host_ok=1 host_err=2 | embed_elapsed=798µs`
+
+HARD GATE assertions all proven:
+- (a) 3 clients: correct STUB_DIMS=4 vectors
+- (b) counter==1 is now MEANINGFUL — a build without lock-first would show counter==3
+- (c) 1 Ok / 2 Err with "lock"/"singleton" in error messages; socket removed; lock re-acquirable
+
+Commits: 7b46ee01 (Part 1: lock-first refactor), 79a45741 (Part 2: 3-host-race test)
+

--- a/.memories/2026-06-04/232830_d5b6.md
+++ b/.memories/2026-06-04/232830_d5b6.md
@@ -1,0 +1,63 @@
+---
+id: checkpoint_d5b61b0a
+timestamp: 2026-06-04T23:28:30.047Z
+tags:
+  - bug-fix
+  - phase3b
+  - embedding-host
+  - health-gate
+  - ensure_ready
+  - rpc_client
+  - F2
+git:
+  branch: julie-rescue-phase3b
+  commit: 79a45741
+  files:
+    - .codex/config.toml
+    - crates/julie-pipeline/src/embeddings/host_server.rs
+    - crates/julie-pipeline/src/embeddings/host_transport.rs
+    - crates/julie-pipeline/src/embeddings/rpc_client.rs
+    - crates/julie-pipeline/src/tests/host_transport_test.rs
+    - src/daemon/app/helpers.rs
+    - src/embedding_host_launch.rs
+    - src/tests/daemon/embedding_host_optin.rs
+summary: "F2 fix: ensure_ready() gates health before Arc promotion"
+briefId: julie-rescue-de-slop-packaging-keep-the-moat
+evidence:
+  - cargo nextest run --lib embedding_host_optin → 3/3 PASS in 24ms
+symbols:
+  - RpcEmbeddingProvider::ensure_ready
+  - RpcEmbeddingProvider::get_cached
+  - spawn_embedding_init
+---
+
+## F2 fix: ensure_ready() gates health before Arc promotion
+
+### Problem
+`RpcEmbeddingProvider` getters (`device_info`, `accelerated`, `degraded_reason`, `dimensions`) silently swallow `get_cached()` errors by returning defaults. A host that accepts connections but fails the health handshake (or reports `ready=false`) would cause the daemon to publish Ready with fake zero-dims data.
+
+### Fix
+
+**`rpc_client.rs`** — added `pub fn ensure_ready(&self) -> Result<()>`:
+```rust
+pub fn ensure_ready(&self) -> Result<()> {
+    self.get_cached().map(|_| ())
+}
+```
+
+**`helpers.rs`** — in the `Ok(rpc)` arm, call `rpc.ensure_ready()` BEFORE wrapping in Arc:
+```rust
+if let Err(e) = rpc.ensure_ready() {
+    // route to (None, Some(status)) → publish_unavailable
+    return (None, Some(status{degraded_reason: "embedding-host not ready: {e}"}));
+}
+let provider = Arc::new(rpc);
+// OnceLock already populated — accelerated()/degraded_reason() are cache hits
+```
+
+**`embedding_host_optin.rs`** — new test `host_path_publishes_unavailable_when_host_not_ready`: fake host answers health with `ready=false` → assert `Unavailable`.
+
+### Tests — 3/3 green (24ms)
+- `host_path_taken_when_env_set` — PASS
+- `existing_path_taken_when_env_unset` — PASS
+- `host_path_publishes_unavailable_when_host_not_ready` — PASS (new)

--- a/.memories/2026-06-04/232931_cf47.md
+++ b/.memories/2026-06-04/232931_cf47.md
@@ -1,0 +1,46 @@
+---
+id: checkpoint_cf47e153
+timestamp: 2026-06-04T23:29:31.861Z
+tags:
+  - phase3b
+  - F1
+  - F3
+  - F4
+  - codex-findings
+  - timeout
+git:
+  branch: julie-rescue-phase3b
+  commit: 03fde74a
+  files:
+    - .codex/config.toml
+summary: F1+F3+F4 fixes — commit 03fde74a
+briefId: julie-rescue-de-slop-packaging-keep-the-moat
+type: checkpoint
+evidence:
+  - cargo nextest run -p julie-pipeline host_transport host_server → 9/9 PASS
+  - commit 03fde74a
+---
+
+## F1+F3+F4 fixes — commit 03fde74a
+
+### WHAT
+Three codex pre-merge findings fixed in a single commit.
+
+### F1 — host_server.rs: shutdown drop ordering
+- **Before**: `drop(lock_file)` then `drop(listener)` — lock released while socket still bound
+- **After**: `drop(listener)` first (socket removed), then `drop(lock_file)` (lock released)
+- **Why**: new host winning the lock must not find the old socket file still present
+
+### F3 — embedding_host_launch.rs: spawn timeout 10s → 180s
+- New `spawn_timeout()` function reads `JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS` env var
+- Default 180s covers cold sidecar init (model download + venv bootstrap)
+
+### F4 — host_transport.rs: RPC timeouts
+- `connect_with_timeout(addr, rpc_timeout)` — sets SO_RCVTIMEO/SO_SNDTIMEO
+- `connect(addr)` → calls `connect_with_timeout` with 30s default (env: `JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS`)
+- Windows: timeout param accepted but ignored (no SO_RCVTIMEO for named pipes)
+- 2 new tests: normal round-trip with 5s timeout (PASS), stalled server with 50ms timeout (timeout Err)
+
+### IMPACT
+9/9 tests pass. Stalled-server test: 0.420s wall time (50ms timeout + 400ms stall).
+

--- a/.memories/2026-06-05/000853_bbec.md
+++ b/.memories/2026-06-05/000853_bbec.md
@@ -1,0 +1,40 @@
+---
+id: checkpoint_bbec738a
+timestamp: 2026-06-05T00:08:53.565Z
+tags:
+  - julie-rescue
+  - phase3b
+  - pre-merge-review
+  - codex
+  - embedding-host
+git:
+  branch: julie-rescue-phase3b
+  commit: 6d74c0df
+  files:
+    - .codex/config.toml
+summary: Phase 3b pre-merge review complete — all 4 codex findings fixed + verified
+briefId: julie-rescue-de-slop-packaging-keep-the-moat
+type: checkpoint
+evidence:
+  - "pipeline narrow: host_transport+host_server 10-12/12 PASS @ 6d74c0df"
+  - "top-crate: embedding_host_optin 3/3 + parse_spawn_timeout + 3-host-race
+    acceptance one_sidecar_serves_three_sessions PASS"
+  - "branch-gate: cargo xtask test dev 37/37 buckets 1264.9s @ 6d74c0df
+    (xtask-runner now compiles)"
+next: Emit pre-merge summary block, then finishing-a-development-branch → open
+  PR for human merge
+---
+
+## Phase 3b pre-merge review complete — all 4 codex findings fixed + verified
+
+Ran razorback pre-merge-review (reviewer=codex) on the Phase 3b embedding-host branch. Codex returned `needs-attention` with 4 real findings; all verified against code, all fixed, branch-gate GREEN.
+
+**Findings + fixes:**
+- **F1 (HIGH)** shutdown released the fs2 singleton lock BEFORE dropping the listener socket → second host could win lock while old socket still bound. Fixed: `drop(listener); drop(lock_file);` (`03fde74a`).
+- **F2 (HIGH)** `RpcEmbeddingProvider` trait getters swallow health-handshake errors → daemon host path published Ready against a broken/not-ready host. Fixed: added `ensure_ready()` (fallible), gate the host path on it inside spawn_blocking, Err→publish_unavailable; new test `host_unavailable_when_health_not_ready` (`db8ea61b`).
+- **F3 (MED)** 10s spawn-liveness timeout < ~120-180s cold sidecar init. Fixed: 180s default + `JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS` + pure parse test (`6d6d6ad4`).
+- **F4 (MED)** no RPC socket timeout → stalled host hangs round_trip forever. Fixed: `connect_with_timeout(Option<Duration>)`, 120s default (NOT 30s — would abort legit cold CPU batch), `JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS`, timeout-fires test + parse test (`6d6d6ad4`).
+
+**Process incident:** host-server-dev (un-frozen after acceptance) committed `5c9d949e` re-shaping the accepted timeout helpers to match the 2-arg example code in my fix-prompt; it regressed both "0" escape hatches and broke the branch-gate mid-run. Restored the verified `6d6d6ad4` shape as lead revert `6d74c0df`.
+
+**Final HEAD:** `6d74c0df` on `julie-rescue-phase3b`.

--- a/.memories/autonomous-run-2026-06-04-julie-phase3b-embedding-host.md
+++ b/.memories/autonomous-run-2026-06-04-julie-phase3b-embedding-host.md
@@ -1,0 +1,66 @@
+# Autonomous Execution Report - Julie Rescue Phase 3b: Resident Embedding-Host
+
+**Status:** Complete
+**Plan:** docs/plans/2026-06-04-julie-phase3b-embedding-host.md
+**Branch:** julie-rescue-phase3b
+**PR:** (see terminal pointer)
+**Duration:** ~6h elapsed (T1–T8 implementation + codex pre-merge review + 4 fixes), multi-session
+**Phases:** 1/1 complete (Phase 3b of the Julie rescue)
+**Tasks:** 8/8 complete
+
+## What shipped
+
+Phase 3b stands up a resident **embedding-host** process that owns ONE PyTorch sidecar and serves `embed_query` / `embed_batch` / `health` to N Julie processes over a UDS (unix) / named-pipe (windows) front door. It is **additive and opt-in** (`JULIE_EMBEDDING_USE_HOST=1`), runs alongside the existing daemon, and proves "one sidecar serves N processes." It does NOT flip the daemon default or rewire stdio (that is Phase 3c).
+
+- **T1** `DaemonPaths` embedding-host socket/lock/pipe helpers (`crates/julie-core/src/paths.rs`).
+- **T2** Cross-platform IPC transport seam — blocking `HostClientConn` + async `HostListener`/`HostServerConn`; protocol ungated (`host_transport.rs`).
+- **T3** `RpcEmbeddingProvider` — thin blocking RPC-client `EmbeddingProvider` with lazy connect + reconnect-once (`rpc_client.rs`).
+- **T4** Embedding-host server — accept loop, per-connection dispatch, graceful shutdown, lock-first factory (`host_server.rs`).
+- **T5** `julie-embedding-host` binary (`src/bin/julie-embedding-host.rs`).
+- **T6** `connect_or_spawn_host` launch glue — sibling-binary locate, detached spawn, pinned child `JULIE_HOME` (`src/embedding_host_launch.rs`).
+- **T7** Opt-in coexistence wiring in `spawn_embedding_init` — host path routed through the existing init match, Ready gated on a real health handshake (`src/daemon/app/helpers.rs`).
+- **T8 (HARD GATE)** Lock-first factory refactor + hermetic 3-host-race acceptance test proving exactly one sidecar serves three concurrent sessions (`src/tests/daemon/embedding_host_multi_session.rs`).
+
+## Judgment calls (non-blocking decisions made)
+
+- `src/daemon/app/helpers.rs:~426` — F2 failure path sets `resolved_backend: Unresolved` (not `Sidecar`) because the host never resolved to a working sidecar; signals the unresolved state more accurately.
+- `crates/julie-pipeline/src/embeddings/host_transport.rs:100` — F4 default RPC timeout is **120s, not 30s**: 30s could abort a legitimate slow/cold `embed_batch` on a CPU-only machine (a new bug); 120s bounds a true hang while never aborting real work. Operators tune down via `JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS`.
+- `crates/julie-pipeline/src/embeddings/host_transport.rs:110` — `parse_rpc_timeout` keeps `"0" → None` (no-timeout escape hatch) because `set_read_timeout(Some(Duration::ZERO))` errors on unix.
+- `src/embedding_host_launch.rs:76` — `parse_spawn_timeout` keeps `filter(|n| *n > 0)` so `"0" → default 180s`; a 0s liveness poll would fail startup instantly.
+- Restored `6d6d6ad4` timeout-helper shape (commit `6d74c0df`) over the churn commit `5c9d949e`, which regressed both `"0"` escape hatches for no benefit — chose lead-revert over another fix round to end the churn.
+
+## External review (codex, adversarial)
+
+- **Findings:** 4
+- **Verified real, fixed:** 4 (commits: `03fde74a`, `db8ea61b`, `6d6d6ad4`)
+  - **F1 (HIGH)** — shutdown released the fs2 singleton lock BEFORE dropping the listener socket, leaving a window for a second host to win the lock while the old socket was still bound. Fixed: `drop(listener)` before `drop(lock_file)` + invariant comment (`03fde74a`).
+  - **F2 (HIGH)** — `RpcEmbeddingProvider` trait getters (`device_info`/`accelerated`/`degraded_reason`/`dimensions`) swallow a failed health handshake, so the daemon host path could publish Ready against a connectable-but-broken host. Fixed: added fallible `ensure_ready()`, gate the host path on it inside `spawn_blocking`, Err → `publish_unavailable`; new test `host_unavailable_when_health_not_ready` (`db8ea61b`).
+  - **F3 (MED)** — 10s spawn-liveness timeout shorter than a ~120–180s cold sidecar init → spurious first-start failure. Fixed: 180s default + `JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS` + pure parse unit test (`6d6d6ad4`).
+  - **F4 (MED)** — no RPC socket timeout → a stalled host hangs `round_trip` forever. Fixed: `connect_with_timeout(Option<Duration>)` sets read/write timeouts, 120s default, env override, deterministic timeout-fires test + parse unit test (`6d6d6ad4`).
+- **Dismissed:** 0
+- **Flagged for your review:** 0
+
+codex/claude do not surface per-request token counts in their JSON output, so no reviewer token cost is recorded.
+
+## Tests
+
+- **Branch-gate:** `cargo xtask test dev` → **37/37 buckets PASS, 1264.9s** @ `6d74c0df` (incl. `xtask-runner`, `core-pipeline`, `daemon`, `dashboard`). HEAD advanced one commit to `96d30f8e` (`.memories`-only, zero code/test delta), so the gate evidence holds.
+- **Acceptance HARD GATE:** `one_sidecar_serves_three_sessions` (hermetic 3-host race) PASS — exactly one sidecar, two losers fail on the singleton lock.
+- **Narrow re-verify @ HEAD:** pipeline `host_transport` + `host_server` 10/10; `rpc_client` green; `daemon::embedding_host_optin` 3/3 (incl. the new Unavailable test + the unchanged ready=true path); `parse_rpc_timeout`/`parse_spawn_timeout` unit tests green.
+
+## Blockers hit
+
+- None. One process incident (non-blocking, resolved): an un-frozen worker (`host-server-dev`) committed `5c9d949e` after its work was accepted, re-shaping the timeout helpers to match the example code in my fix-prompt; the mid-edit half-states broke the branch-gate mid-run and the reshape regressed both `"0"` escape hatches. Resolved by restoring the verified `6d6d6ad4` shape as lead-revert `6d74c0df`, then re-running the branch-gate green. Lesson recorded to memory (freeze every worker after acceptance; treat fix-prompt example code as load-bearing).
+
+## Files changed
+
+37 files, +3799 / -7. Highlights:
+- New: `host_server.rs` (+323), `rpc_client.rs` (+335), `host_transport.rs` (+298), `src/bin/julie-embedding-host.rs` (+76), `src/embedding_host_launch.rs` (+258), `embedding_host_multi_session.rs` (+423), `embedding_host_optin.rs` (+247), `host_server_test.rs` (+313), `rpc_client_test.rs` (+196), `host_transport_test.rs` (+156), `crates/julie-core/src/tests/paths.rs` (+49).
+- Modified: `src/daemon/app/helpers.rs` (+84/-x), `crates/julie-pipeline/src/embeddings/mod.rs`, `crates/julie-core/src/paths.rs` (+29), `Cargo.toml`/`Cargo.lock`/`.gitignore`, `src/daemon/app.rs`, `src/lib.rs`.
+- Docs/state: plan doc + `.memories/` checkpoint trail.
+
+## Next steps
+
+- Review PR and human-merge-gate it (rescue-plan phases are merged by a human, like #22–#26).
+- After merge: **Phase 3c** — flip the daemon default / rewire stdio onto the resident host (the Phase 3 decomposition's next step after 3b proves "one sidecar serves N").
+- Optional cleanup: branch history includes the `5c9d949e` churn + `6d74c0df` revert; net tree is correct. Squash-merge will collapse it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,6 +1861,7 @@ dependencies = [
  "sqlite-vec",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
  "zerocopy 0.7.35",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ path = "src/bin/julie-adapter.rs"
 name = "julie-daemon"
 path = "src/bin/julie-daemon.rs"
 
+[[bin]]
+name = "julie-embedding-host"
+path = "src/bin/julie-embedding-host.rs"
+
 [features]
 default = ["embeddings-sidecar"]
 embeddings-sidecar = []

--- a/crates/julie-core/src/paths.rs
+++ b/crates/julie-core/src/paths.rs
@@ -394,6 +394,35 @@ impl DaemonPaths {
         self.julie_home.join("daemon.lock")
     }
 
+    /// Unix domain socket for the resident embedding-host (Phase 3b).
+    ///
+    /// One host per `$JULIE_HOME` serves embeddings to every Julie process,
+    /// mirroring the process-global lifetime of the daemon's `EmbeddingService`.
+    #[cfg(unix)]
+    pub fn embedding_host_socket(&self) -> PathBuf {
+        self.julie_home.join("embedding-host.sock")
+    }
+
+    /// Kernel-held singleton lock for the running embedding-host (Phase 3b).
+    ///
+    /// Ensures exactly one host process per `$JULIE_HOME`; a second launch
+    /// fails to acquire the lock and yields to the incumbent.
+    pub fn embedding_host_lock(&self) -> PathBuf {
+        self.julie_home.join("embedding-host.lock")
+    }
+
+    /// Named pipe for the resident embedding-host (Windows, Phase 3b).
+    ///
+    /// Reuses the same FNV-1a `julie_home` hash as [`daemon_shutdown_event`] so
+    /// the name is stable per `$JULIE_HOME`.
+    #[cfg(windows)]
+    pub fn embedding_host_pipe_name(&self) -> String {
+        format!(
+            "\\\\.\\pipe\\julie-embedding-host-{:016x}",
+            self.julie_home_hash()
+        )
+    }
+
     /// Short-lived adapter lock for serializing spawn attempts only.
     pub fn daemon_startup_lock(&self) -> PathBuf {
         self.julie_home.join("daemon-startup.lock")

--- a/crates/julie-core/src/tests/mod.rs
+++ b/crates/julie-core/src/tests/mod.rs
@@ -4,5 +4,6 @@ mod database_lightweight_query;
 mod database_row_mapping;
 mod vector_storage;
 mod memory_vectors;
+mod paths;
 mod bulk_store_types_tests;
 mod bulk_store_types_tdd;

--- a/crates/julie-core/src/tests/paths.rs
+++ b/crates/julie-core/src/tests/paths.rs
@@ -1,0 +1,49 @@
+//! Tests for `DaemonPaths` embedding-host path helpers (Phase 3b).
+
+use crate::paths::DaemonPaths;
+use std::path::PathBuf;
+
+fn fixed_home() -> DaemonPaths {
+    DaemonPaths::with_home(PathBuf::from("/tmp/julie-home-3b"))
+}
+
+#[cfg(unix)]
+#[test]
+fn embedding_host_socket_composes_under_home() {
+    let paths = fixed_home();
+    assert_eq!(
+        paths.embedding_host_socket(),
+        PathBuf::from("/tmp/julie-home-3b/embedding-host.sock")
+    );
+}
+
+#[test]
+fn embedding_host_lock_composes_under_home() {
+    let paths = fixed_home();
+    assert_eq!(
+        paths.embedding_host_lock(),
+        PathBuf::from("/tmp/julie-home-3b/embedding-host.lock")
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn embedding_host_pipe_name_is_deterministic_and_prefixed() {
+    let paths = fixed_home();
+    let a = paths.embedding_host_pipe_name();
+    let b = paths.embedding_host_pipe_name();
+    // Deterministic for a fixed JULIE_HOME.
+    assert_eq!(a, b);
+    // Local named-pipe namespace prefix.
+    assert!(
+        a.starts_with(r"\\.\pipe\julie-embedding-host-"),
+        "unexpected pipe name: {a}"
+    );
+    // Shares the same FNV-1a hash suffix as the daemon shutdown event.
+    let shutdown = paths.daemon_shutdown_event();
+    let hash_suffix = shutdown.rsplit('-').next().unwrap();
+    assert!(
+        a.ends_with(hash_suffix),
+        "pipe name {a} should reuse the daemon hash suffix {hash_suffix}"
+    );
+}

--- a/crates/julie-pipeline/Cargo.toml
+++ b/crates/julie-pipeline/Cargo.toml
@@ -18,6 +18,7 @@ julie-extractors = { git = "https://github.com/anortham/julie-extractors", tag =
 
 # Async runtime
 tokio = { version = "1.47.1", features = ["full"] }
+tokio-util = "0.7" # CancellationToken for the embedding-host accept loop
 
 # Async futures
 futures = "0.3"

--- a/crates/julie-pipeline/src/embeddings/host_server.rs
+++ b/crates/julie-pipeline/src/embeddings/host_server.rs
@@ -1,21 +1,292 @@
-//! Resident embedding-host server (Phase 3b).
+//! Resident embedding-host server (Phase 3b, Task 4).
 //!
-//! IMPLEMENTED IN TASK 4. The lead owns module wiring in `embeddings/mod.rs`;
-//! fill this file only. Make `run_embedding_host` / `run_embedding_host_default`
-//! (and any config struct) `pub`.
-//!
-//! Contract (from the plan's Fixed Contract):
-//! - `pub async fn run_embedding_host(addr: &super::host_transport::HostAddress,
-//!   lock_path: &Path, cancel: CancellationToken, provider: Arc<dyn EmbeddingProvider>)`
-//!   plus `run_embedding_host_default(...)` which resolves the provider via
-//!   `super::init::create_embedding_provider`.
-//! - Acquire an `fs2` singleton lock on `lock_path` (yield/exit if held).
-//! - Bind via `super::host_transport::HostListener::bind`; accept loop spawns a
-//!   task per connection. Each connection: read a line → parse
-//!   `RequestEnvelope<serde_json::Value>` → dispatch `health` / `embed_query` /
-//!   `embed_batch` / `shutdown` to the provider via `tokio::task::spawn_blocking`
-//!   (the provider is sync + `Mutex`-guarded) → write `ResponseEnvelope`.
-//!   Application errors → `ResponseEnvelope.error`; never panic the accept loop.
-//! - Graceful shutdown on `cancel.cancelled()` (model on
-//!   `src/daemon/http_transport.rs`), then `provider.shutdown()` +
-//!   `spawn_blocking(provider.wait_for_exit(Duration::from_secs(3)))`.
+//! Listens on the IPC front door established by [`super::host_transport`],
+//! dispatches `health` / `embed_query` / `embed_batch` / `shutdown` requests
+//! to an [`EmbeddingProvider`], and shuts down cleanly on cancellation.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use fs2::FileExt as _;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use julie_core::embeddings_contract::EmbeddingProvider;
+
+use super::host_transport::{HostAddress, HostListener, HostServerConn};
+use super::sidecar_protocol::{
+    EmbedBatchRequest, EmbedBatchResult, EmbedQueryRequest, EmbedQueryResult, HealthResult,
+    ProtocolError, RequestEnvelope, ResponseEnvelope, SIDECAR_PROTOCOL_SCHEMA,
+    SIDECAR_PROTOCOL_VERSION,
+};
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+/// Acquire the singleton lock, bind the IPC front door, and serve embedding
+/// requests until `cancel` fires.
+///
+/// Returns `Ok(())` after a clean cancel-driven shutdown.
+/// Returns `Err` if the singleton lock is already held (another host is
+/// running) or if the listener cannot be bound.
+pub async fn run_embedding_host(
+    addr: &HostAddress,
+    lock_path: &Path,
+    cancel: CancellationToken,
+    provider: Arc<dyn EmbeddingProvider>,
+) -> Result<()> {
+    // 1. Singleton lock — refuse to start a second instance.
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)
+            .context("failed to create embedding-host lock directory")?;
+    }
+    let lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(lock_path)
+        .context("failed to open/create embedding-host lock file")?;
+    lock_file
+        .try_lock_exclusive()
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "embedding-host singleton lock already held — \
+                 another host instance is running ({})",
+                lock_path.display()
+            )
+        })?;
+
+    // 2. Bind the front door.
+    let listener = HostListener::bind(addr)
+        .await
+        .context("failed to bind embedding-host listener")?;
+
+    info!("embedding-host listening");
+
+    // 3. Accept loop.
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("embedding-host: cancel received, stopping accept loop");
+                break;
+            }
+            accept_result = listener.accept() => {
+                match accept_result {
+                    Ok(conn) => {
+                        let p = Arc::clone(&provider);
+                        tokio::spawn(serve_connection(conn, p));
+                    }
+                    Err(e) => {
+                        warn!("embedding-host: accept error: {e}");
+                    }
+                }
+            }
+        }
+    }
+
+    // 4. Graceful shutdown: ask the provider to stop its child process.
+    provider.shutdown();
+    let p = Arc::clone(&provider);
+    let _ =
+        tokio::task::spawn_blocking(move || p.wait_for_exit(Duration::from_secs(3))).await;
+
+    // `lock_file` drops here → fs2 lock released.
+    // `listener` drops here → socket file removed (unix Drop impl).
+    drop(lock_file);
+    drop(listener);
+
+    info!("embedding-host shut down cleanly");
+    Ok(())
+}
+
+/// Resolve the provider via [`super::init::create_embedding_provider`] and
+/// run the host.  Returns an error if no provider is available.
+pub async fn run_embedding_host_default(
+    addr: &HostAddress,
+    lock_path: &Path,
+    cancel: CancellationToken,
+) -> Result<()> {
+    let (provider, _status) = super::init::create_embedding_provider();
+    let provider = provider.ok_or_else(|| {
+        anyhow::anyhow!(
+            "no embedding provider available — cannot start the resident embedding-host"
+        )
+    })?;
+    run_embedding_host(addr, lock_path, cancel, provider).await
+}
+
+// ---------------------------------------------------------------------------
+// Per-connection handler
+// ---------------------------------------------------------------------------
+
+async fn serve_connection(mut conn: HostServerConn, provider: Arc<dyn EmbeddingProvider>) {
+    loop {
+        let line = match conn.read_line().await {
+            Ok(Some(l)) => l,
+            Ok(None) => break, // clean EOF — client disconnected
+            Err(e) => {
+                warn!("embedding-host: read error: {e}");
+                break;
+            }
+        };
+
+        // Parse the outer envelope; method and params are always present.
+        let envelope: RequestEnvelope<serde_json::Value> = match serde_json::from_str(&line) {
+            Ok(e) => e,
+            Err(e) => {
+                // No request_id to echo; use empty string so the client gets
+                // valid JSON it can at least log.
+                let resp = error_line("", "parse_error", &format!("bad envelope: {e}"));
+                let _ = conn.write_line(&resp).await;
+                continue;
+            }
+        };
+
+        let request_id = envelope.request_id.clone();
+
+        let response_line: String = match envelope.method.as_str() {
+            "health" => {
+                let p = Arc::clone(&provider);
+                match tokio::task::spawn_blocking(move || {
+                    let info = p.device_info();
+                    let dims = p.dimensions();
+                    HealthResult {
+                        ready: true,
+                        dims: Some(dims),
+                        device: Some(info.device),
+                        runtime: Some(info.runtime),
+                        model_id: Some(info.model_name),
+                        resolved_backend: None,
+                        accelerated: p.accelerated(),
+                        degraded_reason: p.degraded_reason(),
+                        capabilities: None,
+                        load_policy: None,
+                    }
+                })
+                .await
+                {
+                    Ok(result) => ok_line(&request_id, result),
+                    Err(e) => error_line(
+                        &request_id,
+                        "internal_error",
+                        &format!("health dispatch failed: {e}"),
+                    ),
+                }
+            }
+
+            "embed_query" => match serde_json::from_value::<EmbedQueryRequest>(envelope.params) {
+                Ok(req) => {
+                    let p = Arc::clone(&provider);
+                    match tokio::task::spawn_blocking(move || -> anyhow::Result<EmbedQueryResult> {
+                        let vector = p.embed_query(&req.text)?;
+                        let dims = p.dimensions();
+                        Ok(EmbedQueryResult { dims, vector })
+                    })
+                    .await
+                    {
+                        Ok(Ok(result)) => ok_line(&request_id, result),
+                        Ok(Err(e)) => {
+                            error_line(&request_id, "embed_error", &e.to_string())
+                        }
+                        Err(e) => error_line(
+                            &request_id,
+                            "internal_error",
+                            &format!("embed_query dispatch failed: {e}"),
+                        ),
+                    }
+                }
+                Err(e) => error_line(
+                    &request_id,
+                    "invalid_params",
+                    &format!("embed_query params: {e}"),
+                ),
+            },
+
+            "embed_batch" => match serde_json::from_value::<EmbedBatchRequest>(envelope.params) {
+                Ok(req) => {
+                    let p = Arc::clone(&provider);
+                    match tokio::task::spawn_blocking(move || -> anyhow::Result<EmbedBatchResult> {
+                        let vectors = p.embed_batch(&req.texts)?;
+                        let dims = p.dimensions();
+                        Ok(EmbedBatchResult { dims, vectors })
+                    })
+                    .await
+                    {
+                        Ok(Ok(result)) => ok_line(&request_id, result),
+                        Ok(Err(e)) => {
+                            error_line(&request_id, "embed_error", &e.to_string())
+                        }
+                        Err(e) => error_line(
+                            &request_id,
+                            "internal_error",
+                            &format!("embed_batch dispatch failed: {e}"),
+                        ),
+                    }
+                }
+                Err(e) => error_line(
+                    &request_id,
+                    "invalid_params",
+                    &format!("embed_batch params: {e}"),
+                ),
+            },
+
+            "shutdown" => {
+                // Acknowledge and close this connection (not the whole server).
+                let line = ok_line::<serde_json::Value>(&request_id, serde_json::Value::Null);
+                let _ = conn.write_line(&line).await;
+                break;
+            }
+
+            unknown => error_line(
+                &request_id,
+                "unknown_method",
+                &format!("unknown method: '{unknown}'"),
+            ),
+        };
+
+        if let Err(e) = conn.write_line(&response_line).await {
+            warn!("embedding-host: write error: {e}");
+            break;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response serialization helpers
+// ---------------------------------------------------------------------------
+
+/// Serialize a successful `ResponseEnvelope<T>` to a single JSON line.
+///
+/// If serialization of `result` fails (should never happen for our types),
+/// falls back to an error envelope so the client always receives valid JSON.
+fn ok_line<T: serde::Serialize>(request_id: &str, result: T) -> String {
+    let env = ResponseEnvelope {
+        schema: SIDECAR_PROTOCOL_SCHEMA.to_string(),
+        version: SIDECAR_PROTOCOL_VERSION,
+        request_id: request_id.to_string(),
+        result: Some(result),
+        error: None::<ProtocolError>,
+    };
+    serde_json::to_string(&env)
+        .unwrap_or_else(|e| error_line(request_id, "serialize_error", &e.to_string()))
+}
+
+/// Serialize an error `ResponseEnvelope` to a single JSON line.
+///
+/// Uses `unwrap_or_default` — if this fails the caller receives `""` which
+/// is better than a panic inside a connection task.
+fn error_line(request_id: &str, code: &str, message: &str) -> String {
+    let env = ResponseEnvelope::<serde_json::Value> {
+        schema: SIDECAR_PROTOCOL_SCHEMA.to_string(),
+        version: SIDECAR_PROTOCOL_VERSION,
+        request_id: request_id.to_string(),
+        result: None,
+        error: Some(ProtocolError {
+            code: code.to_string(),
+            message: message.to_string(),
+        }),
+    };
+    serde_json::to_string(&env).unwrap_or_default()
+}

--- a/crates/julie-pipeline/src/embeddings/host_server.rs
+++ b/crates/julie-pipeline/src/embeddings/host_server.rs
@@ -1,0 +1,21 @@
+//! Resident embedding-host server (Phase 3b).
+//!
+//! IMPLEMENTED IN TASK 4. The lead owns module wiring in `embeddings/mod.rs`;
+//! fill this file only. Make `run_embedding_host` / `run_embedding_host_default`
+//! (and any config struct) `pub`.
+//!
+//! Contract (from the plan's Fixed Contract):
+//! - `pub async fn run_embedding_host(addr: &super::host_transport::HostAddress,
+//!   lock_path: &Path, cancel: CancellationToken, provider: Arc<dyn EmbeddingProvider>)`
+//!   plus `run_embedding_host_default(...)` which resolves the provider via
+//!   `super::init::create_embedding_provider`.
+//! - Acquire an `fs2` singleton lock on `lock_path` (yield/exit if held).
+//! - Bind via `super::host_transport::HostListener::bind`; accept loop spawns a
+//!   task per connection. Each connection: read a line → parse
+//!   `RequestEnvelope<serde_json::Value>` → dispatch `health` / `embed_query` /
+//!   `embed_batch` / `shutdown` to the provider via `tokio::task::spawn_blocking`
+//!   (the provider is sync + `Mutex`-guarded) → write `ResponseEnvelope`.
+//!   Application errors → `ResponseEnvelope.error`; never panic the accept loop.
+//! - Graceful shutdown on `cancel.cancelled()` (model on
+//!   `src/daemon/http_transport.rs`), then `provider.shutdown()` +
+//!   `spawn_blocking(provider.wait_for_exit(Duration::from_secs(3)))`.

--- a/crates/julie-pipeline/src/embeddings/host_server.rs
+++ b/crates/julie-pipeline/src/embeddings/host_server.rs
@@ -26,17 +26,22 @@ use super::sidecar_protocol::{
 // Public entry points
 // ---------------------------------------------------------------------------
 
-/// Acquire the singleton lock, bind the IPC front door, and serve embedding
-/// requests until `cancel` fires.
+/// Core loop: acquire the singleton lock, call `make_provider` to build the
+/// [`EmbeddingProvider`] (sidecar spawns only **after** we hold the lock), bind
+/// the listener, and serve connections until `cancel` fires.
 ///
-/// Returns `Ok(())` after a clean cancel-driven shutdown.
-/// Returns `Err` if the singleton lock is already held (another host is
-/// running) or if the listener cannot be bound.
-pub async fn run_embedding_host(
+/// By calling the factory after lock acquisition, competing host processes fail
+/// fast on the lock and exit without ever spawning a sidecar — guaranteeing
+/// exactly one sidecar per `$JULIE_HOME` under concurrent `connect_or_spawn_host`
+/// calls.
+///
+/// If `make_provider` returns an error, `lock_file` drops (releasing the lock)
+/// before the error propagates.
+pub async fn run_embedding_host_with_factory(
     addr: &HostAddress,
     lock_path: &Path,
     cancel: CancellationToken,
-    provider: Arc<dyn EmbeddingProvider>,
+    make_provider: impl FnOnce() -> anyhow::Result<Arc<dyn EmbeddingProvider>>,
 ) -> Result<()> {
     // 1. Singleton lock — refuse to start a second instance.
     if let Some(parent) = lock_path.parent() {
@@ -58,14 +63,18 @@ pub async fn run_embedding_host(
             )
         })?;
 
-    // 2. Bind the front door.
+    // 2. Build provider — only the lock winner reaches this point.
+    //    If make_provider fails, lock_file goes out of scope here → lock released.
+    let provider = make_provider()?;
+
+    // 3. Bind the front door.
     let listener = HostListener::bind(addr)
         .await
         .context("failed to bind embedding-host listener")?;
 
     info!("embedding-host listening");
 
-    // 3. Accept loop.
+    // 4. Accept loop.
     loop {
         tokio::select! {
             _ = cancel.cancelled() => {
@@ -86,7 +95,7 @@ pub async fn run_embedding_host(
         }
     }
 
-    // 4. Graceful shutdown: ask the provider to stop its child process.
+    // 5. Graceful shutdown: ask the provider to stop its child process.
     provider.shutdown();
     let p = Arc::clone(&provider);
     let _ =
@@ -101,20 +110,40 @@ pub async fn run_embedding_host(
     Ok(())
 }
 
-/// Resolve the provider via [`super::init::create_embedding_provider`] and
-/// run the host.  Returns an error if no provider is available.
+/// Thin wrapper for tests that inject a pre-built provider (e.g. `FakeProvider`).
+///
+/// The lock is still acquired first; `make_provider` just wraps the already-built
+/// `Arc<dyn EmbeddingProvider>` in `Ok(...)`.
+pub async fn run_embedding_host(
+    addr: &HostAddress,
+    lock_path: &Path,
+    cancel: CancellationToken,
+    provider: Arc<dyn EmbeddingProvider>,
+) -> Result<()> {
+    run_embedding_host_with_factory(addr, lock_path, cancel, || Ok(provider)).await
+}
+
+/// Resolve the provider via [`super::init::create_embedding_provider`] and run
+/// the host.
+///
+/// The singleton lock is acquired **before** `create_embedding_provider` is
+/// called, so competing host processes fail the lock before ever spawning a
+/// sidecar.  Returns an error if no provider is available or the lock is already
+/// held.
 pub async fn run_embedding_host_default(
     addr: &HostAddress,
     lock_path: &Path,
     cancel: CancellationToken,
 ) -> Result<()> {
-    let (provider, _status) = super::init::create_embedding_provider();
-    let provider = provider.ok_or_else(|| {
-        anyhow::anyhow!(
-            "no embedding provider available — cannot start the resident embedding-host"
-        )
-    })?;
-    run_embedding_host(addr, lock_path, cancel, provider).await
+    run_embedding_host_with_factory(addr, lock_path, cancel, || {
+        let (p, _status) = super::init::create_embedding_provider();
+        p.ok_or_else(|| {
+            anyhow::anyhow!(
+                "no embedding provider available — cannot start the resident embedding-host"
+            )
+        })
+    })
+    .await
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/julie-pipeline/src/embeddings/host_server.rs
+++ b/crates/julie-pipeline/src/embeddings/host_server.rs
@@ -101,10 +101,12 @@ pub async fn run_embedding_host_with_factory(
     let _ =
         tokio::task::spawn_blocking(move || p.wait_for_exit(Duration::from_secs(3))).await;
 
-    // `lock_file` drops here → fs2 lock released.
-    // `listener` drops here → socket file removed (unix Drop impl).
-    drop(lock_file);
+    // Drop listener FIRST (removes socket file) then lock_file (releases lock).
+    // Order matters: once the lock is free a new host process may win it and
+    // call HostListener::bind — at that point the old socket must already be
+    // gone so the new host can cleanly re-bind without hitting AddrInUse.
     drop(listener);
+    drop(lock_file);
 
     info!("embedding-host shut down cleanly");
     Ok(())

--- a/crates/julie-pipeline/src/embeddings/host_transport.rs
+++ b/crates/julie-pipeline/src/embeddings/host_transport.rs
@@ -20,6 +20,7 @@
 //! box** (matches the Phase 3 design's "Unix proof is the must-have" stance).
 
 use std::io::{self, BufRead, BufReader, Write};
+use std::time::Duration;
 
 #[cfg(unix)]
 use std::path::PathBuf;
@@ -93,12 +94,42 @@ pub struct HostClientConn {
 }
 
 impl HostClientConn {
-    /// Open a blocking connection to the host. Errors if the host is not
-    /// listening (socket/pipe absent or refused).
+    /// Default read/write timeout applied to every `round_trip`.
+    ///
+    /// Prevents a stalled host from hanging a session indefinitely.
+    /// Override per-call with [`connect_with_timeout`], or globally via
+    /// `JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS`.
+    const DEFAULT_RPC_TIMEOUT_SECS: u64 = 30;
+
+    /// Read the default RPC timeout from the environment, falling back to
+    /// [`DEFAULT_RPC_TIMEOUT_SECS`].
+    fn default_rpc_timeout() -> Duration {
+        std::env::var("JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(Duration::from_secs)
+            .unwrap_or(Duration::from_secs(Self::DEFAULT_RPC_TIMEOUT_SECS))
+    }
+
+    /// Open a blocking connection to the host using the default RPC timeout.
+    ///
+    /// Errors if the host is not listening (socket/pipe absent or refused).
     pub fn connect(addr: &HostAddress) -> io::Result<Self> {
+        Self::connect_with_timeout(addr, Self::default_rpc_timeout())
+    }
+
+    /// Open a blocking connection and set `rpc_timeout` as both the read and
+    /// write timeout on the underlying socket.
+    ///
+    /// A `round_trip` that takes longer than `rpc_timeout` (because the host
+    /// is stalled or unresponsive) returns an error instead of blocking forever.
+    /// Use a short timeout in tests for deterministic failure paths.
+    pub fn connect_with_timeout(addr: &HostAddress, rpc_timeout: Duration) -> io::Result<Self> {
         #[cfg(unix)]
         {
             let writer = StdUnixStream::connect(&addr.socket)?;
+            writer.set_read_timeout(Some(rpc_timeout))?;
+            writer.set_write_timeout(Some(rpc_timeout))?;
             let reader = BufReader::new(writer.try_clone()?);
             Ok(Self { writer, reader })
         }
@@ -106,6 +137,9 @@ impl HostClientConn {
         {
             // A Windows named pipe is opened like a file. Byte-mode framing
             // (newline-delimited) matches the server side below.
+            // Windows pipe handles do not support SO_RCVTIMEO; callers on
+            // Windows should rely on async cancellation instead.
+            let _ = rpc_timeout;
             let writer = std::fs::OpenOptions::new()
                 .read(true)
                 .write(true)

--- a/crates/julie-pipeline/src/embeddings/host_transport.rs
+++ b/crates/julie-pipeline/src/embeddings/host_transport.rs
@@ -1,0 +1,249 @@
+//! Cross-platform IPC transport seam for the resident embedding-host (Phase 3b).
+//!
+//! This module is **protocol-agnostic**: it moves newline-delimited *lines* of
+//! bytes between a session process and the embedding-host. It knows nothing
+//! about the embedding envelope — callers ([`super::rpc_client`] /
+//! [`super::host_server`]) marshal `RequestEnvelope`/`ResponseEnvelope` JSON.
+//!
+//! Two halves:
+//! - **Blocking client** ([`HostClientConn`]): used inside the synchronous
+//!   `EmbeddingProvider` trait methods, which already run under
+//!   `tokio::task::spawn_blocking` at every call site. Mirrors the blocking
+//!   stdin/stdout framing of `SidecarProcess::send_request_with_timeout`
+//!   (`sidecar_provider.rs`): write one JSON line + `\n` + flush, read one line.
+//! - **Async server** ([`HostListener`] / [`HostServerConn`]): the host's tokio
+//!   accept loop, modeled on `HttpTransportServer`'s listener structure.
+//!
+//! Platform support: **Unix domain sockets** are the proven path (implemented +
+//! tested). **Windows named pipes** are `cfg`-gated, written to the documented
+//! `tokio::net::windows::named_pipe` API, and are **not exercised on the CI/dev
+//! box** (matches the Phase 3 design's "Unix proof is the must-have" stance).
+
+use std::io::{self, BufRead, BufReader, Write};
+
+#[cfg(unix)]
+use std::path::PathBuf;
+
+use julie_core::paths::DaemonPaths;
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader as TokioBufReader};
+
+#[cfg(unix)]
+use std::os::unix::net::UnixStream as StdUnixStream;
+#[cfg(unix)]
+use tokio::net::UnixListener;
+
+#[cfg(windows)]
+use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+
+/// Platform-specific address of the embedding-host front door.
+///
+/// Construct once from [`DaemonPaths`]; pass by reference to the client and
+/// server. The inner representation differs per platform (socket path vs pipe
+/// name) but callers never need to branch on it.
+#[derive(Clone, Debug)]
+pub struct HostAddress {
+    #[cfg(unix)]
+    socket: PathBuf,
+    #[cfg(windows)]
+    pipe: String,
+}
+
+impl HostAddress {
+    /// Derive the address for the global per-`$JULIE_HOME` embedding-host.
+    pub fn from_paths(paths: &DaemonPaths) -> Self {
+        #[cfg(unix)]
+        {
+            Self {
+                socket: paths.embedding_host_socket(),
+            }
+        }
+        #[cfg(windows)]
+        {
+            Self {
+                pipe: paths.embedding_host_pipe_name(),
+            }
+        }
+    }
+
+    /// The unix socket path, for stale-file cleanup by the host.
+    #[cfg(unix)]
+    pub fn socket_path(&self) -> &std::path::Path {
+        &self.socket
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Blocking client
+// ---------------------------------------------------------------------------
+
+/// A blocking connection to the embedding-host.
+///
+/// One request is in flight at a time (strictly request/response), matching the
+/// synchronous `EmbeddingProvider` trait. Hold one per logical client behind a
+/// `Mutex` for interior mutability.
+pub struct HostClientConn {
+    #[cfg(unix)]
+    writer: StdUnixStream,
+    #[cfg(unix)]
+    reader: BufReader<StdUnixStream>,
+    #[cfg(windows)]
+    writer: std::fs::File,
+    #[cfg(windows)]
+    reader: BufReader<std::fs::File>,
+}
+
+impl HostClientConn {
+    /// Open a blocking connection to the host. Errors if the host is not
+    /// listening (socket/pipe absent or refused).
+    pub fn connect(addr: &HostAddress) -> io::Result<Self> {
+        #[cfg(unix)]
+        {
+            let writer = StdUnixStream::connect(&addr.socket)?;
+            let reader = BufReader::new(writer.try_clone()?);
+            Ok(Self { writer, reader })
+        }
+        #[cfg(windows)]
+        {
+            // A Windows named pipe is opened like a file. Byte-mode framing
+            // (newline-delimited) matches the server side below.
+            let writer = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&addr.pipe)?;
+            let reader = BufReader::new(writer.try_clone()?);
+            Ok(Self { writer, reader })
+        }
+    }
+
+    /// Send one request line and read exactly one response line.
+    ///
+    /// `request_line` MUST be a single line (no embedded `\n`) — JSON produced
+    /// by `serde_json::to_string` satisfies this. The returned string has its
+    /// trailing newline stripped.
+    pub fn round_trip(&mut self, request_line: &str) -> io::Result<String> {
+        self.writer.write_all(request_line.as_bytes())?;
+        self.writer.write_all(b"\n")?;
+        self.writer.flush()?;
+
+        let mut line = String::new();
+        let n = self.reader.read_line(&mut line)?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "embedding-host closed the connection before responding",
+            ));
+        }
+        Ok(line.trim_end_matches(['\n', '\r']).to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Async server
+// ---------------------------------------------------------------------------
+
+/// The host's listening socket/pipe. On unix the bound socket file is removed
+/// on drop so a restart can re-bind cleanly.
+pub struct HostListener {
+    #[cfg(unix)]
+    inner: UnixListener,
+    #[cfg(unix)]
+    socket_path: PathBuf,
+    #[cfg(windows)]
+    pipe: String,
+    // The next idle pipe instance awaiting a client (Windows accept loop).
+    #[cfg(windows)]
+    pending: tokio::sync::Mutex<Option<NamedPipeServer>>,
+}
+
+impl HostListener {
+    /// Bind the front door. On unix this removes any stale socket file first.
+    pub async fn bind(addr: &HostAddress) -> io::Result<Self> {
+        #[cfg(unix)]
+        {
+            // `UnixListener::bind` fails with AddrInUse if the path exists, even
+            // when no process is listening (a leaked socket file). Clear it.
+            let _ = std::fs::remove_file(&addr.socket);
+            let inner = UnixListener::bind(&addr.socket)?;
+            Ok(Self {
+                inner,
+                socket_path: addr.socket.clone(),
+            })
+        }
+        #[cfg(windows)]
+        {
+            let first = ServerOptions::new()
+                .first_pipe_instance(true)
+                .create(&addr.pipe)?;
+            Ok(Self {
+                pipe: addr.pipe.clone(),
+                pending: tokio::sync::Mutex::new(Some(first)),
+            })
+        }
+    }
+
+    /// Accept the next client connection.
+    pub async fn accept(&self) -> io::Result<HostServerConn> {
+        #[cfg(unix)]
+        {
+            let (stream, _peer) = self.inner.accept().await?;
+            let (read_half, write_half) = stream.into_split();
+            Ok(HostServerConn {
+                reader: TokioBufReader::new(Box::new(read_half)),
+                writer: Box::new(write_half),
+            })
+        }
+        #[cfg(windows)]
+        {
+            // Named-pipe accept loop: wait for a client on the current idle
+            // instance, then immediately create the next instance so the
+            // following accept() has something to wait on.
+            let mut guard = self.pending.lock().await;
+            let server = guard
+                .take()
+                .expect("HostListener invariant: a pending pipe instance always exists");
+            server.connect().await?;
+            let next = ServerOptions::new().create(&self.pipe)?;
+            *guard = Some(next);
+            drop(guard);
+            let (read_half, write_half) = tokio::io::split(server);
+            Ok(HostServerConn {
+                reader: TokioBufReader::new(Box::new(read_half)),
+                writer: Box::new(write_half),
+            })
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for HostListener {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+/// A single accepted connection on the host side. Async, one request/response
+/// at a time (the client is strictly sequential).
+pub struct HostServerConn {
+    reader: TokioBufReader<Box<dyn AsyncRead + Send + Unpin>>,
+    writer: Box<dyn AsyncWrite + Send + Unpin>,
+}
+
+impl HostServerConn {
+    /// Read one request line. Returns `Ok(None)` on clean EOF (client hung up).
+    pub async fn read_line(&mut self) -> io::Result<Option<String>> {
+        let mut line = String::new();
+        let n = self.reader.read_line(&mut line).await?;
+        if n == 0 {
+            return Ok(None);
+        }
+        Ok(Some(line.trim_end_matches(['\n', '\r']).to_string()))
+    }
+
+    /// Write one response line (a `\n` terminator is appended and flushed).
+    pub async fn write_line(&mut self, line: &str) -> io::Result<()> {
+        self.writer.write_all(line.as_bytes()).await?;
+        self.writer.write_all(b"\n").await?;
+        self.writer.flush().await?;
+        Ok(())
+    }
+}

--- a/crates/julie-pipeline/src/embeddings/host_transport.rs
+++ b/crates/julie-pipeline/src/embeddings/host_transport.rs
@@ -93,53 +93,68 @@ pub struct HostClientConn {
     reader: BufReader<std::fs::File>,
 }
 
-impl HostClientConn {
-    /// Default read/write timeout applied to every `round_trip`.
-    ///
-    /// Prevents a stalled host from hanging a session indefinitely.
-    /// Override per-call with [`connect_with_timeout`], or globally via
-    /// `JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS`.
-    const DEFAULT_RPC_TIMEOUT_SECS: u64 = 30;
+/// Default per-request socket timeout.
+///
+/// Generous: a legitimate cold batch embed can take a while, but an infinite
+/// hang is never acceptable.  Override via `JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS`.
+const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(120);
 
-    /// Read the default RPC timeout from the environment, falling back to
-    /// [`DEFAULT_RPC_TIMEOUT_SECS`].
-    fn default_rpc_timeout() -> Duration {
-        std::env::var("JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .map(Duration::from_secs)
-            .unwrap_or(Duration::from_secs(Self::DEFAULT_RPC_TIMEOUT_SECS))
+/// Parse a raw env-var string into an RPC timeout.
+///
+/// - `Some("0")` → `None` (no timeout — escape hatch for unusual deployments).
+/// - `Some("<positive integer>")` → `Some(Duration::from_secs(n))`.
+/// - `Some("<invalid>")` | `None` → `Some(DEFAULT_RPC_TIMEOUT)`.
+///
+/// Exposed as `pub(crate)` so `host_transport_test.rs` can unit-test this
+/// function directly without touching the environment.
+pub(crate) fn parse_rpc_timeout(raw: Option<String>) -> Option<Duration> {
+    match raw.map(|s| s.trim().to_string()) {
+        Some(s) if s == "0" => None,
+        Some(s) => Some(
+            s.parse::<u64>()
+                .ok()
+                .map(Duration::from_secs)
+                .unwrap_or(DEFAULT_RPC_TIMEOUT),
+        ),
+        None => Some(DEFAULT_RPC_TIMEOUT),
     }
+}
 
-    /// Open a blocking connection to the host using the default RPC timeout.
+fn resolve_rpc_timeout() -> Option<Duration> {
+    parse_rpc_timeout(std::env::var("JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS").ok())
+}
+
+impl HostClientConn {
+    /// Open a blocking connection to the host using the default RPC timeout
+    /// (read from `JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS`, default 120 s).
     ///
     /// Errors if the host is not listening (socket/pipe absent or refused).
     pub fn connect(addr: &HostAddress) -> io::Result<Self> {
-        Self::connect_with_timeout(addr, Self::default_rpc_timeout())
+        Self::connect_with_timeout(addr, resolve_rpc_timeout())
     }
 
-    /// Open a blocking connection and set `rpc_timeout` as both the read and
+    /// Open a blocking connection and apply `timeout` as both the read and
     /// write timeout on the underlying socket.
     ///
-    /// A `round_trip` that takes longer than `rpc_timeout` (because the host
-    /// is stalled or unresponsive) returns an error instead of blocking forever.
-    /// Use a short timeout in tests for deterministic failure paths.
-    pub fn connect_with_timeout(addr: &HostAddress, rpc_timeout: Duration) -> io::Result<Self> {
+    /// `timeout = None` means no timeout (block indefinitely) — legacy
+    /// behaviour or escape hatch; prefer the env-configurable default.
+    /// Use a short `Some(...)` in tests for deterministic failure paths.
+    pub fn connect_with_timeout(addr: &HostAddress, timeout: Option<Duration>) -> io::Result<Self> {
         #[cfg(unix)]
         {
             let writer = StdUnixStream::connect(&addr.socket)?;
-            writer.set_read_timeout(Some(rpc_timeout))?;
-            writer.set_write_timeout(Some(rpc_timeout))?;
-            let reader = BufReader::new(writer.try_clone()?);
+            writer.set_write_timeout(timeout)?;
+            let reader_stream = writer.try_clone()?;
+            reader_stream.set_read_timeout(timeout)?;
+            let reader = BufReader::new(reader_stream);
             Ok(Self { writer, reader })
         }
         #[cfg(windows)]
         {
-            // A Windows named pipe is opened like a file. Byte-mode framing
-            // (newline-delimited) matches the server side below.
-            // Windows pipe handles do not support SO_RCVTIMEO; callers on
-            // Windows should rely on async cancellation instead.
-            let _ = rpc_timeout;
+            // Named-pipe File has no set_read/write_timeout; the Windows path
+            // is cfg-gated and not exercised on CI/dev (see module docs).
+            // `timeout` is a documented no-op on Windows.
+            let _ = timeout;
             let writer = std::fs::OpenOptions::new()
                 .read(true)
                 .write(true)

--- a/crates/julie-pipeline/src/embeddings/host_transport.rs
+++ b/crates/julie-pipeline/src/embeddings/host_transport.rs
@@ -93,33 +93,35 @@ pub struct HostClientConn {
     reader: BufReader<std::fs::File>,
 }
 
-/// Default per-request socket timeout (seconds).
+/// Default per-request socket timeout.
 ///
-/// 120 s is generous: on a CPU-only machine (no GPU/MPS), or on the first
-/// batch right after model load, a single `round_trip` can legitimately
-/// exceed 30 s.  A shorter default would abort real embedding work and
-/// introduce a new failure mode.  Operators who want fail-fast behaviour
-/// can lower it via `JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS`.
-const DEFAULT_RPC_TIMEOUT_SECS: u64 = 120;
+/// Generous: a legitimate cold batch embed can take a while, but an infinite
+/// hang is never acceptable.  Override via `JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS`.
+const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(120);
 
-/// Parse a raw env-var string into an RPC timeout duration.
+/// Parse a raw env-var string into an RPC timeout.
 ///
-/// - `Some("<positive integer>")` → `Duration::from_secs(n)`.
-/// - `Some("<invalid>")` | `None` → `Duration::from_secs(default_secs)`.
+/// - `Some("0")` → `None` (no timeout — escape hatch for unusual deployments).
+/// - `Some("<positive integer>")` → `Some(Duration::from_secs(n))`.
+/// - `Some("<invalid>")` | `None` → `Some(DEFAULT_RPC_TIMEOUT)`.
 ///
 /// Exposed as `pub(crate)` so `host_transport_test.rs` can unit-test this
 /// function directly without touching the environment.
-pub(crate) fn parse_rpc_timeout(raw: Option<String>, default_secs: u64) -> Duration {
-    raw.and_then(|v| v.trim().parse::<u64>().ok())
-        .map(Duration::from_secs)
-        .unwrap_or(Duration::from_secs(default_secs))
+pub(crate) fn parse_rpc_timeout(raw: Option<String>) -> Option<Duration> {
+    match raw.map(|s| s.trim().to_string()) {
+        Some(s) if s == "0" => None,
+        Some(s) => Some(
+            s.parse::<u64>()
+                .ok()
+                .map(Duration::from_secs)
+                .unwrap_or(DEFAULT_RPC_TIMEOUT),
+        ),
+        None => Some(DEFAULT_RPC_TIMEOUT),
+    }
 }
 
-fn default_rpc_timeout() -> Duration {
-    parse_rpc_timeout(
-        std::env::var("JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS").ok(),
-        DEFAULT_RPC_TIMEOUT_SECS,
-    )
+fn resolve_rpc_timeout() -> Option<Duration> {
+    parse_rpc_timeout(std::env::var("JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS").ok())
 }
 
 impl HostClientConn {
@@ -128,22 +130,22 @@ impl HostClientConn {
     ///
     /// Errors if the host is not listening (socket/pipe absent or refused).
     pub fn connect(addr: &HostAddress) -> io::Result<Self> {
-        Self::connect_with_timeout(addr, default_rpc_timeout())
+        Self::connect_with_timeout(addr, resolve_rpc_timeout())
     }
 
     /// Open a blocking connection and apply `timeout` as both the read and
     /// write timeout on the underlying socket.
     ///
-    /// Use a short `Duration` in tests for deterministic failure paths.
-    /// The env-configurable default is `JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS`
-    /// (default: 120 s — generous enough for a cold CPU-only `embed_batch`).
-    pub fn connect_with_timeout(addr: &HostAddress, timeout: Duration) -> io::Result<Self> {
+    /// `timeout = None` means no timeout (block indefinitely) — legacy
+    /// behaviour or escape hatch; prefer the env-configurable default.
+    /// Use a short `Some(...)` in tests for deterministic failure paths.
+    pub fn connect_with_timeout(addr: &HostAddress, timeout: Option<Duration>) -> io::Result<Self> {
         #[cfg(unix)]
         {
             let writer = StdUnixStream::connect(&addr.socket)?;
-            writer.set_write_timeout(Some(timeout))?;
+            writer.set_write_timeout(timeout)?;
             let reader_stream = writer.try_clone()?;
-            reader_stream.set_read_timeout(Some(timeout))?;
+            reader_stream.set_read_timeout(timeout)?;
             let reader = BufReader::new(reader_stream);
             Ok(Self { writer, reader })
         }

--- a/crates/julie-pipeline/src/embeddings/host_transport.rs
+++ b/crates/julie-pipeline/src/embeddings/host_transport.rs
@@ -93,35 +93,33 @@ pub struct HostClientConn {
     reader: BufReader<std::fs::File>,
 }
 
-/// Default per-request socket timeout.
+/// Default per-request socket timeout (seconds).
 ///
-/// Generous: a legitimate cold batch embed can take a while, but an infinite
-/// hang is never acceptable.  Override via `JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS`.
-const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(120);
+/// 120 s is generous: on a CPU-only machine (no GPU/MPS), or on the first
+/// batch right after model load, a single `round_trip` can legitimately
+/// exceed 30 s.  A shorter default would abort real embedding work and
+/// introduce a new failure mode.  Operators who want fail-fast behaviour
+/// can lower it via `JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS`.
+const DEFAULT_RPC_TIMEOUT_SECS: u64 = 120;
 
-/// Parse a raw env-var string into an RPC timeout.
+/// Parse a raw env-var string into an RPC timeout duration.
 ///
-/// - `Some("0")` → `None` (no timeout — escape hatch for unusual deployments).
-/// - `Some("<positive integer>")` → `Some(Duration::from_secs(n))`.
-/// - `Some("<invalid>")` | `None` → `Some(DEFAULT_RPC_TIMEOUT)`.
+/// - `Some("<positive integer>")` → `Duration::from_secs(n)`.
+/// - `Some("<invalid>")` | `None` → `Duration::from_secs(default_secs)`.
 ///
 /// Exposed as `pub(crate)` so `host_transport_test.rs` can unit-test this
 /// function directly without touching the environment.
-pub(crate) fn parse_rpc_timeout(raw: Option<String>) -> Option<Duration> {
-    match raw.map(|s| s.trim().to_string()) {
-        Some(s) if s == "0" => None,
-        Some(s) => Some(
-            s.parse::<u64>()
-                .ok()
-                .map(Duration::from_secs)
-                .unwrap_or(DEFAULT_RPC_TIMEOUT),
-        ),
-        None => Some(DEFAULT_RPC_TIMEOUT),
-    }
+pub(crate) fn parse_rpc_timeout(raw: Option<String>, default_secs: u64) -> Duration {
+    raw.and_then(|v| v.trim().parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(Duration::from_secs(default_secs))
 }
 
-fn resolve_rpc_timeout() -> Option<Duration> {
-    parse_rpc_timeout(std::env::var("JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS").ok())
+fn default_rpc_timeout() -> Duration {
+    parse_rpc_timeout(
+        std::env::var("JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS").ok(),
+        DEFAULT_RPC_TIMEOUT_SECS,
+    )
 }
 
 impl HostClientConn {
@@ -130,22 +128,22 @@ impl HostClientConn {
     ///
     /// Errors if the host is not listening (socket/pipe absent or refused).
     pub fn connect(addr: &HostAddress) -> io::Result<Self> {
-        Self::connect_with_timeout(addr, resolve_rpc_timeout())
+        Self::connect_with_timeout(addr, default_rpc_timeout())
     }
 
     /// Open a blocking connection and apply `timeout` as both the read and
     /// write timeout on the underlying socket.
     ///
-    /// `timeout = None` means no timeout (block indefinitely) — legacy
-    /// behaviour or escape hatch; prefer the env-configurable default.
-    /// Use a short `Some(...)` in tests for deterministic failure paths.
-    pub fn connect_with_timeout(addr: &HostAddress, timeout: Option<Duration>) -> io::Result<Self> {
+    /// Use a short `Duration` in tests for deterministic failure paths.
+    /// The env-configurable default is `JULIE_EMBEDDING_HOST_RPC_TIMEOUT_SECS`
+    /// (default: 120 s — generous enough for a cold CPU-only `embed_batch`).
+    pub fn connect_with_timeout(addr: &HostAddress, timeout: Duration) -> io::Result<Self> {
         #[cfg(unix)]
         {
             let writer = StdUnixStream::connect(&addr.socket)?;
-            writer.set_write_timeout(timeout)?;
+            writer.set_write_timeout(Some(timeout))?;
             let reader_stream = writer.try_clone()?;
-            reader_stream.set_read_timeout(timeout)?;
+            reader_stream.set_read_timeout(Some(timeout))?;
             let reader = BufReader::new(reader_stream);
             Ok(Self { writer, reader })
         }

--- a/crates/julie-pipeline/src/embeddings/mod.rs
+++ b/crates/julie-pipeline/src/embeddings/mod.rs
@@ -11,16 +11,21 @@
 //! - Vector storage lives in `database::vectors` (sqlite-vec)
 
 pub mod factory;
+pub mod host_server;
+pub mod host_transport;
 pub mod init;
 pub mod log_fields;
 pub mod metadata;
 pub mod pipeline;
+pub mod rpc_client;
+// Pure-serde envelope contracts — always compiled (no torch/Python deps) so the
+// thin RPC client works in binaries built WITHOUT the `embeddings-sidecar`
+// feature (a session process that only talks to the resident host, Phase 3b).
+pub mod sidecar_protocol;
 #[cfg(feature = "embeddings-sidecar")]
 pub mod sidecar_bootstrap;
 #[cfg(feature = "embeddings-sidecar")]
 pub mod sidecar_embedded;
-#[cfg(feature = "embeddings-sidecar")]
-pub mod sidecar_protocol;
 #[cfg(feature = "embeddings-sidecar")]
 pub mod sidecar_provider;
 #[cfg(feature = "embeddings-sidecar")]
@@ -40,8 +45,8 @@ pub use factory::{
     parse_provider_preference, resolve_backend_preference, should_disable_for_strict_acceleration,
     strict_acceleration_enabled_from_env_value,
 };
+pub use host_transport::{HostAddress, HostClientConn, HostListener, HostServerConn};
 pub use init::create_embedding_provider;
-#[cfg(feature = "embeddings-sidecar")]
 pub use sidecar_protocol::{
     DeviceBackendCapabilities, DeviceBackendCapability, DeviceLoadPolicy, EmbedBatchRequest,
     EmbedBatchResult, EmbedQueryRequest, EmbedQueryResult, HealthResult, ProtocolError,

--- a/crates/julie-pipeline/src/embeddings/rpc_client.rs
+++ b/crates/julie-pipeline/src/embeddings/rpc_client.rs
@@ -1,16 +1,321 @@
 //! Thin RPC-client `EmbeddingProvider` for the resident embedding-host (Phase 3b).
 //!
-//! IMPLEMENTED IN TASK 3. The lead owns module wiring in `embeddings/mod.rs`;
-//! fill this file only. Make `RpcEmbeddingProvider` (and any helper) `pub`.
-//!
-//! Contract (from the plan's Fixed Contract):
-//! - Implement `julie_core::embeddings_contract::EmbeddingProvider` over
-//!   `super::host_transport::HostClientConn`.
-//! - Hold `Mutex<Option<HostClientConn>>` (lazy connect + reconnect-once on
-//!   broken pipe), a per-connection `request_id` counter, and cached
-//!   `dimensions`/`DeviceInfo` from a `health` round-trip at first connect.
-//! - Marshal via `super::sidecar_protocol::{RequestEnvelope, ResponseEnvelope,
-//!   EmbedQueryRequest, EmbedQueryResult, EmbedBatchRequest, EmbedBatchResult,
-//!   HealthResult, SIDECAR_PROTOCOL_SCHEMA, SIDECAR_PROTOCOL_VERSION}` and reuse
-//!   `validate_query_response` / `validate_batch_response`.
-//! - `shutdown()` drops the connection; `wait_for_exit()` returns `true`.
+//! Implements [`EmbeddingProvider`] over [`HostClientConn`]: lazy-connects on
+//! first use, runs a health handshake to populate the cached dimensions and
+//! device info, then forwards `embed_query` / `embed_batch` calls over the
+//! blocking newline-delimited transport. On a broken-pipe I/O error the cached
+//! connection is dropped and the call is retried exactly once (one reconnect
+//! + re-handshake).
+
+use std::io;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Result};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use julie_core::embeddings_contract::{DeviceInfo, EmbeddingProvider};
+
+use super::host_transport::{HostAddress, HostClientConn};
+use super::sidecar_protocol::{
+    EmbedBatchRequest, EmbedBatchResult, EmbedQueryRequest, EmbedQueryResult, HealthResult,
+    RequestEnvelope, ResponseEnvelope, SIDECAR_PROTOCOL_SCHEMA, SIDECAR_PROTOCOL_VERSION,
+    validate_batch_response, validate_health_response, validate_query_response,
+    validate_response_envelope,
+};
+
+// ---------------------------------------------------------------------------
+// Internal state types
+// ---------------------------------------------------------------------------
+
+/// Active connection + per-connection sequential request-id counter.
+struct ConnInner {
+    conn: HostClientConn,
+    request_seq: u64,
+}
+
+impl ConnInner {
+    fn next_request_id(&mut self) -> String {
+        self.request_seq = self.request_seq.wrapping_add(1);
+        format!("rpc-{}", self.request_seq)
+    }
+}
+
+/// Dimensions, device info, and acceleration state cached from the first
+/// health round-trip. Written once via [`OnceLock`]; never mutated.
+#[derive(Clone)]
+struct CachedHealth {
+    dimensions: usize,
+    device_info: DeviceInfo,
+    accelerated: Option<bool>,
+    degraded_reason: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Public provider
+// ---------------------------------------------------------------------------
+
+/// Thin RPC client that implements [`EmbeddingProvider`] by forwarding over
+/// the blocking [`HostClientConn`] transport to the resident embedding-host.
+///
+/// Interior mutability via `Mutex<Option<ConnInner>>` satisfies the `&self`
+/// requirement of the trait while allowing lazy connect and reconnect-once.
+pub struct RpcEmbeddingProvider {
+    addr: HostAddress,
+    /// `None` while disconnected; `Some` while a live connection is held.
+    conn: Mutex<Option<ConnInner>>,
+    /// Populated once from the health handshake at first connect.
+    cached: OnceLock<CachedHealth>,
+}
+
+impl RpcEmbeddingProvider {
+    /// Create a new provider. Does **not** connect until first use.
+    pub fn new(addr: HostAddress) -> Self {
+        Self {
+            addr,
+            conn: Mutex::new(None),
+            cached: OnceLock::new(),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Connection management
+    // -----------------------------------------------------------------------
+
+    /// Ensure the guard holds a live connection. If `guard` is `None`:
+    /// connects, runs a health handshake, populates the cache (once).
+    ///
+    /// Returns `io::Error` so callers can distinguish transport errors from
+    /// deserialization / protocol errors.
+    fn ensure_connected(
+        guard: &mut Option<ConnInner>,
+        addr: &HostAddress,
+        cached: &OnceLock<CachedHealth>,
+    ) -> io::Result<()> {
+        if guard.is_some() {
+            return Ok(());
+        }
+        let new_conn = HostClientConn::connect(addr)?;
+        let mut inner = ConnInner { conn: new_conn, request_seq: 0 };
+        let health = Self::do_health_handshake(&mut inner)?;
+        // Only set the cache on the first successful connect; later reconnects
+        // are expected to return the same model/dims, so we keep the first value.
+        cached.get_or_init(|| {
+            let dims = health.dims.unwrap_or(0);
+            CachedHealth {
+                dimensions: dims,
+                device_info: DeviceInfo {
+                    runtime: health.runtime.unwrap_or_else(|| "rpc".to_string()),
+                    device: health.device.unwrap_or_else(|| "unknown".to_string()),
+                    model_name: health.model_id.unwrap_or_else(|| "unknown".to_string()),
+                    dimensions: dims,
+                },
+                accelerated: health.accelerated,
+                degraded_reason: health.degraded_reason,
+            }
+        });
+        *guard = Some(inner);
+        Ok(())
+    }
+
+    /// Send a `health` request on a freshly opened connection and return the
+    /// validated [`HealthResult`].
+    fn do_health_handshake(inner: &mut ConnInner) -> io::Result<HealthResult> {
+        let request_id = inner.next_request_id();
+        let envelope = RequestEnvelope {
+            schema: SIDECAR_PROTOCOL_SCHEMA.to_string(),
+            version: SIDECAR_PROTOCOL_VERSION,
+            request_id: request_id.clone(),
+            method: "health".to_string(),
+            params: serde_json::json!({}),
+        };
+        let line = serde_json::to_string(&envelope)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        let resp_line = inner.conn.round_trip(&line)?;
+        let resp: ResponseEnvelope<HealthResult> = serde_json::from_str(resp_line.trim())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        validate_response_envelope(&resp, &request_id)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        if let Some(err) = &resp.error {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("health error from host: [{}] {}", err.code, err.message),
+            ));
+        }
+        let health = resp.result.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "health response missing result")
+        })?;
+        validate_health_response(&health)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        if !health.ready {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "embedding host reported not ready",
+            ));
+        }
+        Ok(health)
+    }
+
+    // -----------------------------------------------------------------------
+    // Request dispatch
+    // -----------------------------------------------------------------------
+
+    /// Perform one request/response round-trip on the connection held in
+    /// `guard` (which must be `Some` on entry). Returns `(response_line,
+    /// request_id)`.
+    fn attempt_once(
+        guard: &mut Option<ConnInner>,
+        method: &str,
+        params: &serde_json::Value,
+    ) -> io::Result<(String, String)> {
+        let inner = guard.as_mut().expect("ConnInner must be Some");
+        let request_id = inner.next_request_id();
+        let envelope = RequestEnvelope {
+            schema: SIDECAR_PROTOCOL_SCHEMA.to_string(),
+            version: SIDECAR_PROTOCOL_VERSION,
+            request_id: request_id.clone(),
+            method: method.to_string(),
+            params: params.clone(),
+        };
+        let line = serde_json::to_string(&envelope)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        let resp_line = inner.conn.round_trip(&line)?;
+        Ok((resp_line, request_id))
+    }
+
+    /// Serialize `params`, send to `method`, and deserialize the response.
+    ///
+    /// On a broken-pipe / EOF I/O error the cached connection is dropped and
+    /// the call is retried exactly once (reconnect + re-handshake + retry).
+    fn send_request<P: Serialize, R: DeserializeOwned>(&self, method: &str, params: P) -> Result<R> {
+        let params_val = serde_json::to_value(params)
+            .map_err(|e| anyhow!("failed to serialize {method} params: {e}"))?;
+        let mut guard = self
+            .conn
+            .lock()
+            .map_err(|_| anyhow!("RpcEmbeddingProvider: mutex poisoned"))?;
+
+        Self::ensure_connected(&mut guard, &self.addr, &self.cached)
+            .map_err(|e| anyhow!("embedding host connect: {e}"))?;
+
+        let (resp_line, request_id) = match Self::attempt_once(&mut guard, method, &params_val) {
+            Ok(pair) => pair,
+            Err(e) if is_connection_dropped(&e) => {
+                // Drop the dead connection and reconnect exactly once.
+                *guard = None;
+                Self::ensure_connected(&mut guard, &self.addr, &self.cached)
+                    .map_err(|e| anyhow!("embedding host reconnect: {e}"))?;
+                Self::attempt_once(&mut guard, method, &params_val)
+                    .map_err(|e| anyhow!("{method} failed after reconnect: {e}"))?
+            }
+            Err(e) => return Err(anyhow!("{method} io error: {e}")),
+        };
+
+        Self::parse_response::<R>(&resp_line, method, &request_id)
+    }
+
+    /// Deserialize and validate one raw response line.
+    fn parse_response<R: DeserializeOwned>(
+        line: &str,
+        method: &str,
+        request_id: &str,
+    ) -> Result<R> {
+        let env: ResponseEnvelope<R> = serde_json::from_str(line.trim())
+            .map_err(|e| anyhow!("failed to decode {method} response: {e}"))?;
+        validate_response_envelope(&env, request_id)?;
+        if let Some(err) = env.error {
+            bail!("{method} host error: [{}] {}", err.code, err.message);
+        }
+        env.result
+            .ok_or_else(|| anyhow!("{method} response missing result"))
+    }
+
+    // -----------------------------------------------------------------------
+    // Cache access
+    // -----------------------------------------------------------------------
+
+    /// Return the cached health info, connecting lazily if not yet populated.
+    fn get_cached(&self) -> Result<&CachedHealth> {
+        if let Some(c) = self.cached.get() {
+            return Ok(c);
+        }
+        // Not yet connected — trigger connection + health handshake.
+        let mut guard = self
+            .conn
+            .lock()
+            .map_err(|_| anyhow!("RpcEmbeddingProvider: mutex poisoned"))?;
+        Self::ensure_connected(&mut guard, &self.addr, &self.cached)
+            .map_err(|e| anyhow!("embedding host connect: {e}"))?;
+        self.cached
+            .get()
+            .ok_or_else(|| anyhow!("health cache not populated after connect"))
+    }
+}
+
+/// Returns `true` if the I/O error kind indicates the peer closed or reset
+/// the connection.
+fn is_connection_dropped(e: &io::Error) -> bool {
+    matches!(
+        e.kind(),
+        io::ErrorKind::BrokenPipe
+            | io::ErrorKind::UnexpectedEof
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::ConnectionAborted
+    )
+}
+
+// ---------------------------------------------------------------------------
+// EmbeddingProvider impl
+// ---------------------------------------------------------------------------
+
+impl EmbeddingProvider for RpcEmbeddingProvider {
+    fn embed_query(&self, text: &str) -> Result<Vec<f32>> {
+        let result: EmbedQueryResult =
+            self.send_request("embed_query", EmbedQueryRequest { text: text.to_string() })?;
+        validate_query_response(&result, self.dimensions())?;
+        Ok(result.vector)
+    }
+
+    fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        let count = texts.len();
+        let result: EmbedBatchResult =
+            self.send_request("embed_batch", EmbedBatchRequest { texts: texts.to_vec() })?;
+        validate_batch_response(&result, count, self.dimensions())?;
+        Ok(result.vectors)
+    }
+
+    fn dimensions(&self) -> usize {
+        self.get_cached().map(|c| c.dimensions).unwrap_or(0)
+    }
+
+    fn device_info(&self) -> DeviceInfo {
+        self.get_cached()
+            .map(|c| c.device_info.clone())
+            .unwrap_or_else(|_| DeviceInfo {
+                runtime: "rpc".to_string(),
+                device: "unknown".to_string(),
+                model_name: "unknown".to_string(),
+                dimensions: 0,
+            })
+    }
+
+    fn accelerated(&self) -> Option<bool> {
+        self.get_cached().ok()?.accelerated
+    }
+
+    fn degraded_reason(&self) -> Option<String> {
+        self.get_cached().ok()?.degraded_reason.clone()
+    }
+
+    fn shutdown(&self) {
+        if let Ok(mut guard) = self.conn.lock() {
+            *guard = None;
+        }
+    }
+
+    fn wait_for_exit(&self, _timeout: Duration) -> bool {
+        // The RPC client does not own the host process; caller is responsible.
+        true
+    }
+}

--- a/crates/julie-pipeline/src/embeddings/rpc_client.rs
+++ b/crates/julie-pipeline/src/embeddings/rpc_client.rs
@@ -1,0 +1,16 @@
+//! Thin RPC-client `EmbeddingProvider` for the resident embedding-host (Phase 3b).
+//!
+//! IMPLEMENTED IN TASK 3. The lead owns module wiring in `embeddings/mod.rs`;
+//! fill this file only. Make `RpcEmbeddingProvider` (and any helper) `pub`.
+//!
+//! Contract (from the plan's Fixed Contract):
+//! - Implement `julie_core::embeddings_contract::EmbeddingProvider` over
+//!   `super::host_transport::HostClientConn`.
+//! - Hold `Mutex<Option<HostClientConn>>` (lazy connect + reconnect-once on
+//!   broken pipe), a per-connection `request_id` counter, and cached
+//!   `dimensions`/`DeviceInfo` from a `health` round-trip at first connect.
+//! - Marshal via `super::sidecar_protocol::{RequestEnvelope, ResponseEnvelope,
+//!   EmbedQueryRequest, EmbedQueryResult, EmbedBatchRequest, EmbedBatchResult,
+//!   HealthResult, SIDECAR_PROTOCOL_SCHEMA, SIDECAR_PROTOCOL_VERSION}` and reuse
+//!   `validate_query_response` / `validate_batch_response`.
+//! - `shutdown()` drops the connection; `wait_for_exit()` returns `true`.

--- a/crates/julie-pipeline/src/embeddings/rpc_client.rs
+++ b/crates/julie-pipeline/src/embeddings/rpc_client.rs
@@ -251,6 +251,20 @@ impl RpcEmbeddingProvider {
             .get()
             .ok_or_else(|| anyhow!("health cache not populated after connect"))
     }
+
+    /// Force the health handshake and return an error if it fails or if the
+    /// host reports `ready=false`.
+    ///
+    /// The `dyn EmbeddingProvider` getters (`device_info`, `accelerated`,
+    /// `degraded_reason`, `dimensions`) silently swallow errors by returning
+    /// defaults when the health handshake fails. Callers that need a hard gate
+    /// — such as the daemon's host-path init — should call `ensure_ready()`
+    /// before promoting the provider to `Arc<dyn EmbeddingProvider>`, so that
+    /// a host that accepts connections but can't answer health (or reports
+    /// `ready=false`) is routed to `publish_unavailable` rather than `Ready`.
+    pub fn ensure_ready(&self) -> Result<()> {
+        self.get_cached().map(|_| ())
+    }
 }
 
 /// Returns `true` if the I/O error kind indicates the peer closed or reset

--- a/crates/julie-pipeline/src/tests/host_server_test.rs
+++ b/crates/julie-pipeline/src/tests/host_server_test.rs
@@ -1,6 +1,313 @@
 //! Tests for the embedding-host server (Phase 3b, Task 4).
 //!
-//! IMPLEMENTED IN TASK 4. Run `run_embedding_host` with an injected fake
-//! provider; assert health/embed_query/embed_batch round-trip, two concurrent
-//! client connections both succeed, and cancellation stops the accept loop and
-//! releases the singleton lock.
+//! Uses an injected `FakeProvider` (deterministic, no Python/torch) to verify:
+//! - `health` / `embed_query` / `embed_batch` round-trip correctly.
+//! - Two concurrent client connections both complete successfully.
+//! - `cancel.cancel()` makes `run_embedding_host` return and releases the
+//!   socket file and the singleton lock.
+
+#[cfg(all(test, unix))]
+mod unix {
+    use std::sync::Arc;
+
+    use julie_core::{
+        embeddings_contract::{DeviceInfo, EmbeddingProvider},
+        paths::DaemonPaths,
+    };
+    use tokio_util::sync::CancellationToken;
+
+    use crate::embeddings::{
+        host_server::run_embedding_host,
+        host_transport::{HostAddress, HostClientConn, HostListener},
+        sidecar_protocol::{
+            EmbedBatchRequest, EmbedBatchResult, EmbedQueryRequest, EmbedQueryResult,
+            HealthResult, RequestEnvelope, ResponseEnvelope, SIDECAR_PROTOCOL_SCHEMA,
+            SIDECAR_PROTOCOL_VERSION,
+        },
+    };
+
+    // -----------------------------------------------------------------------
+    // Fake provider — deterministic vectors, no real ML
+    // -----------------------------------------------------------------------
+
+    const FAKE_DIMS: usize = 4;
+
+    struct FakeProvider;
+
+    impl EmbeddingProvider for FakeProvider {
+        fn embed_query(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+            Ok(vec![text.len() as f32; FAKE_DIMS])
+        }
+
+        fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+            Ok(texts
+                .iter()
+                .map(|t| vec![t.len() as f32; FAKE_DIMS])
+                .collect())
+        }
+
+        fn dimensions(&self) -> usize {
+            FAKE_DIMS
+        }
+
+        fn device_info(&self) -> DeviceInfo {
+            DeviceInfo {
+                runtime: "fake".to_string(),
+                device: "cpu".to_string(),
+                model_name: "fake-model".to_string(),
+                dimensions: FAKE_DIMS,
+            }
+        }
+        // shutdown / wait_for_exit use default no-op implementations.
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    /// Serialize a `RequestEnvelope` to a single JSON line ready for round-trip.
+    fn request_line<T: serde::Serialize>(method: &str, id: &str, params: T) -> String {
+        let env = RequestEnvelope {
+            schema: SIDECAR_PROTOCOL_SCHEMA.to_string(),
+            version: SIDECAR_PROTOCOL_VERSION,
+            request_id: id.to_string(),
+            method: method.to_string(),
+            params,
+        };
+        serde_json::to_string(&env).expect("serialize request")
+    }
+
+    /// Spawn the host server and wait briefly for the listener to bind.
+    ///
+    /// Returns `(cancel_token, join_handle, Arc<HostAddress>)`.  The `Arc`
+    /// lets multiple blocking-client tasks share the address without cloning
+    /// the raw `HostAddress` (which is not `Clone`).
+    async fn spawn_host(
+        tmp_root: std::path::PathBuf,
+        lock_path: std::path::PathBuf,
+    ) -> (
+        CancellationToken,
+        tokio::task::JoinHandle<anyhow::Result<()>>,
+        Arc<HostAddress>,
+    ) {
+        let provider: Arc<dyn EmbeddingProvider> = Arc::new(FakeProvider);
+        let cancel = CancellationToken::new();
+
+        // Build the address from the tmp root — we need to do it here so we
+        // can return an Arc, and again inside the spawn because HostAddress is
+        // not Clone.
+        let paths = DaemonPaths::with_home(tmp_root.clone());
+        let addr = Arc::new(HostAddress::from_paths(&paths));
+
+        let addr_inner = Arc::clone(&addr);
+        let cancel_inner = cancel.clone();
+        let handle = tokio::spawn(async move {
+            run_embedding_host(&addr_inner, &lock_path, cancel_inner, provider).await
+        });
+
+        // Give the listener a moment to bind before clients try to connect.
+        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+
+        (cancel, handle, addr)
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    /// health / embed_query / embed_batch all return the correct results over
+    /// the real IPC transport with an injected FakeProvider.
+    #[tokio::test]
+    async fn health_embed_query_embed_batch_round_trip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock_path = dir.path().join("embedding-host.lock");
+        let (cancel, handle, addr) =
+            spawn_host(dir.path().to_path_buf(), lock_path).await;
+
+        let addr_c = Arc::clone(&addr);
+        let (health_line, query_line, batch_line) =
+            tokio::task::spawn_blocking(move || {
+                let mut conn = HostClientConn::connect(&addr_c).expect("connect");
+
+                let h = conn
+                    .round_trip(&request_line("health", "h1", serde_json::json!({})))
+                    .expect("health round_trip");
+
+                let q = conn
+                    .round_trip(&request_line(
+                        "embed_query",
+                        "q1",
+                        EmbedQueryRequest { text: "hello".to_string() }, // len=5
+                    ))
+                    .expect("embed_query round_trip");
+
+                let b = conn
+                    .round_trip(&request_line(
+                        "embed_batch",
+                        "b1",
+                        EmbedBatchRequest {
+                            texts: vec!["hi".to_string(), "there".to_string()], // len 2,5
+                        },
+                    ))
+                    .expect("embed_batch round_trip");
+
+                (h, q, b)
+            })
+            .await
+            .expect("spawn_blocking");
+
+        // --- health ---
+        let hr: ResponseEnvelope<HealthResult> =
+            serde_json::from_str(&health_line).expect("parse health");
+        assert!(hr.error.is_none(), "health must not carry an error");
+        let hr = hr.result.expect("health result present");
+        assert!(hr.ready, "health.ready");
+        assert_eq!(hr.dims, Some(FAKE_DIMS), "health.dims");
+        assert_eq!(hr.device.as_deref(), Some("cpu"), "health.device");
+        assert_eq!(hr.runtime.as_deref(), Some("fake"), "health.runtime");
+        assert_eq!(hr.model_id.as_deref(), Some("fake-model"), "health.model_id");
+
+        // --- embed_query: "hello" len=5 → [5.0; 4] ---
+        let qr: ResponseEnvelope<EmbedQueryResult> =
+            serde_json::from_str(&query_line).expect("parse query");
+        assert!(qr.error.is_none(), "embed_query must not carry an error");
+        let qr = qr.result.expect("query result present");
+        assert_eq!(qr.dims, FAKE_DIMS, "query dims");
+        assert_eq!(qr.vector, vec![5.0f32; FAKE_DIMS], "query vector");
+
+        // --- embed_batch: ["hi"(2), "there"(5)] ---
+        let br: ResponseEnvelope<EmbedBatchResult> =
+            serde_json::from_str(&batch_line).expect("parse batch");
+        assert!(br.error.is_none(), "embed_batch must not carry an error");
+        let br = br.result.expect("batch result present");
+        assert_eq!(br.dims, FAKE_DIMS, "batch dims");
+        assert_eq!(br.vectors.len(), 2, "batch count");
+        assert_eq!(br.vectors[0], vec![2.0f32; FAKE_DIMS], "batch[0] hi");
+        assert_eq!(br.vectors[1], vec![5.0f32; FAKE_DIMS], "batch[1] there");
+
+        cancel.cancel();
+        handle.await.expect("server join").expect("server ok");
+    }
+
+    /// Two concurrent blocking connections both receive correct embed_query
+    /// results from the single shared FakeProvider.
+    #[tokio::test]
+    async fn two_concurrent_connections_both_succeed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock_path = dir.path().join("embedding-host.lock");
+        let (cancel, handle, addr) =
+            spawn_host(dir.path().to_path_buf(), lock_path).await;
+
+        let addr1 = Arc::clone(&addr);
+        let addr2 = Arc::clone(&addr);
+
+        // Each task connects independently and sends a different text.
+        let t1 = tokio::task::spawn_blocking(move || {
+            let mut conn = HostClientConn::connect(&addr1).expect("connect c1");
+            conn.round_trip(&request_line(
+                "embed_query",
+                "c1",
+                EmbedQueryRequest { text: "abcde".to_string() }, // len=5
+            ))
+            .expect("c1 round_trip")
+        });
+        let t2 = tokio::task::spawn_blocking(move || {
+            let mut conn = HostClientConn::connect(&addr2).expect("connect c2");
+            conn.round_trip(&request_line(
+                "embed_query",
+                "c2",
+                EmbedQueryRequest { text: "ab".to_string() }, // len=2
+            ))
+            .expect("c2 round_trip")
+        });
+
+        let (r1, r2) = tokio::join!(t1, t2);
+        let r1: ResponseEnvelope<EmbedQueryResult> =
+            serde_json::from_str(&r1.expect("t1")).expect("parse c1");
+        let r2: ResponseEnvelope<EmbedQueryResult> =
+            serde_json::from_str(&r2.expect("t2")).expect("parse c2");
+
+        assert_eq!(r1.result.expect("c1 result").vector, vec![5.0f32; FAKE_DIMS]);
+        assert_eq!(r2.result.expect("c2 result").vector, vec![2.0f32; FAKE_DIMS]);
+
+        cancel.cancel();
+        handle.await.expect("join").expect("server ok");
+    }
+
+    /// After cancellation the server returns `Ok(())`, the socket file is
+    /// removed, and the singleton lock is released (can be re-acquired).
+    #[tokio::test]
+    async fn cancel_releases_socket_and_singleton_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock_path = dir.path().join("embedding-host.lock");
+        let tmp_root = dir.path().to_path_buf();
+
+        let paths = DaemonPaths::with_home(tmp_root.clone());
+        let addr_ref = HostAddress::from_paths(&paths);
+        let socket_path = addr_ref.socket_path().to_path_buf();
+
+        let (cancel, handle, _addr) =
+            spawn_host(tmp_root.clone(), lock_path.clone()).await;
+
+        assert!(socket_path.exists(), "socket should exist while server is running");
+
+        cancel.cancel();
+        handle.await.expect("server join").expect("server ok after cancel");
+
+        // Socket file removed by HostListener's Drop impl.
+        assert!(
+            !socket_path.exists(),
+            "socket file should be removed after shutdown"
+        );
+
+        // Singleton lock is released — we can acquire it from this process.
+        let lf = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(&lock_path)
+            .expect("open lock file after shutdown");
+        use fs2::FileExt as _;
+        assert!(
+            lf.try_lock_exclusive().is_ok(),
+            "singleton lock must be acquirable after shutdown"
+        );
+
+        // Listener can be re-bound on the same address.
+        let paths2 = DaemonPaths::with_home(tmp_root);
+        let addr2 = HostAddress::from_paths(&paths2);
+        HostListener::bind(&addr2)
+            .await
+            .expect("re-bind after shutdown must succeed");
+    }
+
+    /// An unrecognised method returns an error envelope with code = "unknown_method".
+    #[tokio::test]
+    async fn unknown_method_returns_error_envelope() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock_path = dir.path().join("embedding-host.lock");
+        let (cancel, handle, addr) =
+            spawn_host(dir.path().to_path_buf(), lock_path).await;
+
+        let addr_c = Arc::clone(&addr);
+        let reply = tokio::task::spawn_blocking(move || {
+            let mut conn = HostClientConn::connect(&addr_c).expect("connect");
+            conn.round_trip(&request_line(
+                "not_a_real_method",
+                "e1",
+                serde_json::json!({}),
+            ))
+            .expect("round_trip")
+        })
+        .await
+        .expect("spawn_blocking");
+
+        let env: ResponseEnvelope<serde_json::Value> =
+            serde_json::from_str(&reply).expect("parse error envelope");
+        assert!(env.result.is_none(), "result must be None for unknown method");
+        let err = env.error.expect("error field must be set");
+        assert_eq!(err.code, "unknown_method");
+
+        cancel.cancel();
+        handle.await.expect("join").expect("ok");
+    }
+}

--- a/crates/julie-pipeline/src/tests/host_server_test.rs
+++ b/crates/julie-pipeline/src/tests/host_server_test.rs
@@ -1,0 +1,6 @@
+//! Tests for the embedding-host server (Phase 3b, Task 4).
+//!
+//! IMPLEMENTED IN TASK 4. Run `run_embedding_host` with an injected fake
+//! provider; assert health/embed_query/embed_batch round-trip, two concurrent
+//! client connections both succeed, and cancellation stops the accept loop and
+//! releases the singleton lock.

--- a/crates/julie-pipeline/src/tests/host_transport_test.rs
+++ b/crates/julie-pipeline/src/tests/host_transport_test.rs
@@ -87,7 +87,7 @@ mod unix {
         // Generous 5 s timeout — server responds immediately.
         let reply = tokio::task::spawn_blocking(move || {
             let mut client =
-                HostClientConn::connect_with_timeout(&addr, Duration::from_secs(5))
+                HostClientConn::connect_with_timeout(&addr, Some(Duration::from_secs(5)))
                     .expect("connect");
             client.round_trip("ping")
         })
@@ -99,27 +99,25 @@ mod unix {
         server.await.expect("server task");
     }
 
-    /// `round_trip` returns an error when the server accepts but stalls longer
-    /// than the configured read timeout.
+    /// `round_trip` returns an error when the server accepts the connection but
+    /// never writes a response, stalling past the client's read timeout.
     #[tokio::test]
     async fn connect_with_timeout_read_times_out_on_stalled_server() {
         let (_dir, addr) = temp_address();
 
         let listener = HostListener::bind(&addr).await.expect("bind");
         let server = tokio::spawn(async move {
-            let mut conn = listener.accept().await.expect("accept");
-            // Consume the request but stall the response beyond the client timeout.
-            let _req = conn.read_line().await.expect("read");
-            tokio::time::sleep(Duration::from_millis(400)).await;
-            let _ = conn.write_line("too late").await;
+            let _conn = listener.accept().await.expect("accept");
+            // Accept only; never read or write — client must time out.
+            tokio::time::sleep(Duration::from_millis(500)).await;
         });
 
-        // 50 ms read timeout — the server stalls 400 ms, so round_trip must error.
+        // 200 ms read timeout — server never responds, so round_trip must error.
         let result = tokio::task::spawn_blocking(move || {
             let mut client =
-                HostClientConn::connect_with_timeout(&addr, Duration::from_millis(50))
+                HostClientConn::connect_with_timeout(&addr, Some(Duration::from_millis(200)))
                     .expect("connect");
-            client.round_trip("hello")
+            client.round_trip("{}")
         })
         .await
         .expect("join");
@@ -130,5 +128,29 @@ mod unix {
         );
 
         server.await.expect("server task");
+    }
+
+    /// Pure unit tests for `parse_rpc_timeout` — no environment mutation.
+    #[test]
+    fn parse_rpc_timeout_values() {
+        use crate::embeddings::host_transport::parse_rpc_timeout;
+
+        // "0" → None (infinite — escape hatch).
+        assert_eq!(parse_rpc_timeout(Some("0".into())), None);
+        // None (env var absent) → Some(default = 120 s).
+        assert_eq!(
+            parse_rpc_timeout(None),
+            Some(Duration::from_secs(120))
+        );
+        // Valid positive integer → Some(that many seconds).
+        assert_eq!(
+            parse_rpc_timeout(Some("3".into())),
+            Some(Duration::from_secs(3))
+        );
+        // Invalid string → Some(default).
+        assert_eq!(
+            parse_rpc_timeout(Some("bad".into())),
+            Some(Duration::from_secs(120))
+        );
     }
 }

--- a/crates/julie-pipeline/src/tests/host_transport_test.rs
+++ b/crates/julie-pipeline/src/tests/host_transport_test.rs
@@ -9,6 +9,7 @@ mod unix {
     use crate::embeddings::host_transport::{HostAddress, HostClientConn, HostListener};
     use julie_core::paths::DaemonPaths;
     use std::path::PathBuf;
+    use std::time::Duration;
 
     fn temp_address() -> (tempfile::TempDir, HostAddress) {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -67,5 +68,67 @@ mod unix {
             !socket_path.exists(),
             "socket file should be removed on listener drop"
         );
+    }
+
+    /// `connect_with_timeout` completes normally when the server responds within
+    /// the deadline.
+    #[tokio::test]
+    async fn connect_with_timeout_succeeds_when_server_responds_promptly() {
+        let (_dir, addr) = temp_address();
+
+        let listener = HostListener::bind(&addr).await.expect("bind");
+        let server = tokio::spawn(async move {
+            let mut conn = listener.accept().await.expect("accept");
+            let line = conn.read_line().await.expect("read").expect("not eof");
+            conn.write_line(&line.to_uppercase()).await.expect("write");
+            let _ = conn.read_line().await;
+        });
+
+        // Generous 5 s timeout — server responds immediately.
+        let reply = tokio::task::spawn_blocking(move || {
+            let mut client =
+                HostClientConn::connect_with_timeout(&addr, Duration::from_secs(5))
+                    .expect("connect");
+            client.round_trip("ping")
+        })
+        .await
+        .expect("join")
+        .expect("round_trip");
+
+        assert_eq!(reply, "PING");
+        server.await.expect("server task");
+    }
+
+    /// `round_trip` returns an error when the server accepts but stalls longer
+    /// than the configured read timeout.
+    #[tokio::test]
+    async fn connect_with_timeout_read_times_out_on_stalled_server() {
+        let (_dir, addr) = temp_address();
+
+        let listener = HostListener::bind(&addr).await.expect("bind");
+        let server = tokio::spawn(async move {
+            let mut conn = listener.accept().await.expect("accept");
+            // Consume the request but stall the response beyond the client timeout.
+            let _req = conn.read_line().await.expect("read");
+            tokio::time::sleep(Duration::from_millis(400)).await;
+            let _ = conn.write_line("too late").await;
+        });
+
+        // 50 ms read timeout — the server stalls 400 ms, so round_trip must error.
+        let result = tokio::task::spawn_blocking(move || {
+            let mut client =
+                HostClientConn::connect_with_timeout(&addr, Duration::from_millis(50))
+                    .expect("connect");
+            client.round_trip("hello")
+        })
+        .await
+        .expect("join");
+
+        assert!(
+            result.is_err(),
+            "expected a timeout error from the stalled server, got Ok"
+        );
+
+        server.await.expect("server task");
     }
 }

--- a/crates/julie-pipeline/src/tests/host_transport_test.rs
+++ b/crates/julie-pipeline/src/tests/host_transport_test.rs
@@ -87,7 +87,7 @@ mod unix {
         // Generous 5 s timeout — server responds immediately.
         let reply = tokio::task::spawn_blocking(move || {
             let mut client =
-                HostClientConn::connect_with_timeout(&addr, Some(Duration::from_secs(5)))
+                HostClientConn::connect_with_timeout(&addr, Duration::from_secs(5))
                     .expect("connect");
             client.round_trip("ping")
         })
@@ -115,7 +115,7 @@ mod unix {
         // 200 ms read timeout — server never responds, so round_trip must error.
         let result = tokio::task::spawn_blocking(move || {
             let mut client =
-                HostClientConn::connect_with_timeout(&addr, Some(Duration::from_millis(200)))
+                HostClientConn::connect_with_timeout(&addr, Duration::from_millis(200))
                     .expect("connect");
             client.round_trip("{}")
         })
@@ -135,22 +135,20 @@ mod unix {
     fn parse_rpc_timeout_values() {
         use crate::embeddings::host_transport::parse_rpc_timeout;
 
-        // "0" → None (infinite — escape hatch).
-        assert_eq!(parse_rpc_timeout(Some("0".into())), None);
-        // None (env var absent) → Some(default = 120 s).
+        // None (env var absent) → default (120 s).
         assert_eq!(
-            parse_rpc_timeout(None),
-            Some(Duration::from_secs(120))
+            parse_rpc_timeout(None, 120),
+            Duration::from_secs(120)
         );
-        // Valid positive integer → Some(that many seconds).
+        // Valid positive integer → that many seconds.
         assert_eq!(
-            parse_rpc_timeout(Some("3".into())),
-            Some(Duration::from_secs(3))
+            parse_rpc_timeout(Some("5".into()), 120),
+            Duration::from_secs(5)
         );
-        // Invalid string → Some(default).
+        // Invalid string → default.
         assert_eq!(
-            parse_rpc_timeout(Some("bad".into())),
-            Some(Duration::from_secs(120))
+            parse_rpc_timeout(Some("garbage".into()), 120),
+            Duration::from_secs(120)
         );
     }
 }

--- a/crates/julie-pipeline/src/tests/host_transport_test.rs
+++ b/crates/julie-pipeline/src/tests/host_transport_test.rs
@@ -87,7 +87,7 @@ mod unix {
         // Generous 5 s timeout — server responds immediately.
         let reply = tokio::task::spawn_blocking(move || {
             let mut client =
-                HostClientConn::connect_with_timeout(&addr, Duration::from_secs(5))
+                HostClientConn::connect_with_timeout(&addr, Some(Duration::from_secs(5)))
                     .expect("connect");
             client.round_trip("ping")
         })
@@ -115,7 +115,7 @@ mod unix {
         // 200 ms read timeout — server never responds, so round_trip must error.
         let result = tokio::task::spawn_blocking(move || {
             let mut client =
-                HostClientConn::connect_with_timeout(&addr, Duration::from_millis(200))
+                HostClientConn::connect_with_timeout(&addr, Some(Duration::from_millis(200)))
                     .expect("connect");
             client.round_trip("{}")
         })
@@ -135,20 +135,22 @@ mod unix {
     fn parse_rpc_timeout_values() {
         use crate::embeddings::host_transport::parse_rpc_timeout;
 
-        // None (env var absent) → default (120 s).
+        // "0" → None (infinite — escape hatch).
+        assert_eq!(parse_rpc_timeout(Some("0".into())), None);
+        // None (env var absent) → Some(default = 120 s).
         assert_eq!(
-            parse_rpc_timeout(None, 120),
-            Duration::from_secs(120)
+            parse_rpc_timeout(None),
+            Some(Duration::from_secs(120))
         );
-        // Valid positive integer → that many seconds.
+        // Valid positive integer → Some(that many seconds).
         assert_eq!(
-            parse_rpc_timeout(Some("5".into()), 120),
-            Duration::from_secs(5)
+            parse_rpc_timeout(Some("3".into())),
+            Some(Duration::from_secs(3))
         );
-        // Invalid string → default.
+        // Invalid string → Some(default).
         assert_eq!(
-            parse_rpc_timeout(Some("garbage".into()), 120),
-            Duration::from_secs(120)
+            parse_rpc_timeout(Some("bad".into())),
+            Some(Duration::from_secs(120))
         );
     }
 }

--- a/crates/julie-pipeline/src/tests/host_transport_test.rs
+++ b/crates/julie-pipeline/src/tests/host_transport_test.rs
@@ -1,0 +1,71 @@
+//! Tests for the cross-platform IPC transport seam (Phase 3b, Task 2).
+//!
+//! Unix domain sockets are the proven path. A throwaway tokio echo server
+//! exercises the blocking client against the async server end-to-end. The
+//! Windows named-pipe arms are compile-guarded and not exercised here.
+
+#[cfg(all(test, unix))]
+mod unix {
+    use crate::embeddings::host_transport::{HostAddress, HostClientConn, HostListener};
+    use julie_core::paths::DaemonPaths;
+    use std::path::PathBuf;
+
+    fn temp_address() -> (tempfile::TempDir, HostAddress) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = DaemonPaths::with_home(dir.path().to_path_buf());
+        let addr = HostAddress::from_paths(&paths);
+        (dir, addr)
+    }
+
+    #[tokio::test]
+    async fn client_round_trips_one_line_through_async_server() {
+        let (_dir, addr) = temp_address();
+
+        // Async echo server: read a line, echo it back uppercased.
+        let listener = HostListener::bind(&addr).await.expect("bind");
+        let server = tokio::spawn(async move {
+            let mut conn = listener.accept().await.expect("accept");
+            let line = conn.read_line().await.expect("read").expect("not eof");
+            conn.write_line(&line.to_uppercase()).await.expect("write");
+            // Read EOF so the client's response is fully flushed before drop.
+            let _ = conn.read_line().await;
+        });
+
+        // Blocking client runs on a blocking thread (mirrors real call sites).
+        let reply = tokio::task::spawn_blocking(move || {
+            let mut client = HostClientConn::connect(&addr).expect("connect");
+            client.round_trip("hello host")
+        })
+        .await
+        .expect("join")
+        .expect("round_trip");
+
+        assert_eq!(reply, "HELLO HOST");
+        server.await.expect("server task");
+    }
+
+    #[tokio::test]
+    async fn connect_fails_when_no_host_is_listening() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = DaemonPaths::with_home(dir.path().to_path_buf());
+        let addr = HostAddress::from_paths(&paths);
+        let err = tokio::task::spawn_blocking(move || HostClientConn::connect(&addr))
+            .await
+            .expect("join");
+        assert!(err.is_err(), "connecting to an absent host must error");
+    }
+
+    #[tokio::test]
+    async fn unix_socket_file_is_removed_when_listener_drops() {
+        let (_dir, addr) = temp_address();
+        let socket_path: PathBuf = addr.socket_path().to_path_buf();
+        {
+            let _listener = HostListener::bind(&addr).await.expect("bind");
+            assert!(socket_path.exists(), "socket should exist while bound");
+        }
+        assert!(
+            !socket_path.exists(),
+            "socket file should be removed on listener drop"
+        );
+    }
+}

--- a/crates/julie-pipeline/src/tests/mod.rs
+++ b/crates/julie-pipeline/src/tests/mod.rs
@@ -5,3 +5,6 @@ pub mod embedding_metadata_enrichment;
 pub mod sidecar_embedding_tests;
 pub mod sidecar_supervisor_tests;
 pub mod embedding_sidecar_protocol;
+pub mod host_transport_test;
+pub mod host_server_test;
+pub mod rpc_client_test;

--- a/crates/julie-pipeline/src/tests/rpc_client_test.rs
+++ b/crates/julie-pipeline/src/tests/rpc_client_test.rs
@@ -1,0 +1,6 @@
+//! Tests for `RpcEmbeddingProvider` (Phase 3b, Task 3).
+//!
+//! IMPLEMENTED IN TASK 3. Drive the client against an in-test tokio fake host
+//! that speaks the envelope protocol; assert embed_query/embed_batch return
+//! correct vectors, cached dimensions/device_info reflect the health response,
+//! and a simulated broken pipe triggers exactly one reconnect.

--- a/crates/julie-pipeline/src/tests/rpc_client_test.rs
+++ b/crates/julie-pipeline/src/tests/rpc_client_test.rs
@@ -1,6 +1,196 @@
 //! Tests for `RpcEmbeddingProvider` (Phase 3b, Task 3).
 //!
-//! IMPLEMENTED IN TASK 3. Drive the client against an in-test tokio fake host
-//! that speaks the envelope protocol; assert embed_query/embed_batch return
-//! correct vectors, cached dimensions/device_info reflect the health response,
-//! and a simulated broken pipe triggers exactly one reconnect.
+//! Drive the client against an in-test tokio fake host that speaks the
+//! envelope protocol. The fake host reads `RequestEnvelope` lines and replies
+//! with deterministic `EmbedQueryResult` / `EmbedBatchResult` / `HealthResult`
+//! responses serialised as `ResponseEnvelope` JSON.
+//!
+//! Invariant proven: `RpcEmbeddingProvider`, talking only over the transport,
+//! returns correct embedding vectors from a host and recovers from a dropped
+//! connection with exactly one reconnect.
+
+#[cfg(all(test, unix))]
+mod unix {
+    use julie_core::paths::DaemonPaths;
+
+    use crate::embeddings::host_transport::{HostAddress, HostListener, HostServerConn};
+    use crate::embeddings::rpc_client::RpcEmbeddingProvider;
+    use crate::embeddings::{
+        EmbedBatchResult, EmbedQueryResult, EmbeddingProvider, HealthResult, ResponseEnvelope,
+        SIDECAR_PROTOCOL_SCHEMA, SIDECAR_PROTOCOL_VERSION,
+    };
+
+    // -----------------------------------------------------------------------
+    // Shared constants
+    // -----------------------------------------------------------------------
+
+    const DIMS: usize = 3;
+    const VEC: [f32; 3] = [0.1, 0.2, 0.3];
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    fn temp_address() -> (tempfile::TempDir, HostAddress) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = DaemonPaths::with_home(dir.path().to_path_buf());
+        (dir, HostAddress::from_paths(&paths))
+    }
+
+    /// A deterministic health response the fake host returns.
+    fn fake_health() -> HealthResult {
+        HealthResult {
+            ready: true,
+            dims: Some(DIMS),
+            device: Some("cpu".to_string()),
+            runtime: Some("fake-host".to_string()),
+            model_id: Some("test-model".to_string()),
+            resolved_backend: None,
+            accelerated: Some(false),
+            degraded_reason: None,
+            capabilities: None,
+            load_policy: None,
+        }
+    }
+
+    /// Read exactly one request from `conn`, dispatch by `method`, and write
+    /// the appropriate response back. Returns the method name, or `None` if
+    /// the client closed the connection before sending a request.
+    async fn handle_one(conn: &mut HostServerConn) -> Option<String> {
+        let line = conn.read_line().await.expect("server read")?;
+        let req: serde_json::Value = serde_json::from_str(&line).expect("parse request");
+        let method = req["method"].as_str().expect("method field").to_string();
+        let request_id = req["request_id"].as_str().unwrap_or("1").to_string();
+
+        let resp = match method.as_str() {
+            "health" => serde_json::to_string(&ResponseEnvelope {
+                schema: SIDECAR_PROTOCOL_SCHEMA.to_string(),
+                version: SIDECAR_PROTOCOL_VERSION,
+                request_id,
+                result: Some(fake_health()),
+                error: None,
+            })
+            .expect("serialize health"),
+
+            "embed_query" => serde_json::to_string(&ResponseEnvelope {
+                schema: SIDECAR_PROTOCOL_SCHEMA.to_string(),
+                version: SIDECAR_PROTOCOL_VERSION,
+                request_id,
+                result: Some(EmbedQueryResult { dims: DIMS, vector: VEC.to_vec() }),
+                error: None,
+            })
+            .expect("serialize embed_query"),
+
+            "embed_batch" => {
+                let count =
+                    req["params"]["texts"].as_array().map_or(0, |a| a.len());
+                serde_json::to_string(&ResponseEnvelope {
+                    schema: SIDECAR_PROTOCOL_SCHEMA.to_string(),
+                    version: SIDECAR_PROTOCOL_VERSION,
+                    request_id,
+                    result: Some(EmbedBatchResult {
+                        dims: DIMS,
+                        vectors: vec![VEC.to_vec(); count],
+                    }),
+                    error: None,
+                })
+                .expect("serialize embed_batch")
+            }
+
+            other => panic!("unexpected method from client: {other}"),
+        };
+
+        conn.write_line(&resp).await.expect("server write");
+        Some(method)
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 1: happy path — embed_query, embed_batch, dimensions, device_info
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn embed_query_batch_and_cached_info_reflect_health() {
+        let (_dir, addr) = temp_address();
+        let listener = HostListener::bind(&addr).await.expect("bind");
+
+        let server = tokio::spawn(async move {
+            let mut conn = listener.accept().await.expect("accept");
+            // health — triggered by the lazy connect inside embed_query
+            assert_eq!(handle_one(&mut conn).await.as_deref(), Some("health"));
+            // embed_query request
+            assert_eq!(handle_one(&mut conn).await.as_deref(), Some("embed_query"));
+            // embed_batch request (same connection, no reconnect)
+            assert_eq!(handle_one(&mut conn).await.as_deref(), Some("embed_batch"));
+        });
+
+        let (query_vec, batch_vecs, dims, dev) = tokio::task::spawn_blocking(move || {
+            let p = RpcEmbeddingProvider::new(addr);
+            let query_vec = p.embed_query("hello")?;
+            let batch_vecs = p.embed_batch(&["a".to_string(), "b".to_string()])?;
+            let dims = p.dimensions();
+            let dev = p.device_info();
+            Ok::<_, anyhow::Error>((query_vec, batch_vecs, dims, dev))
+        })
+        .await
+        .expect("blocking join")
+        .expect("provider calls");
+
+        assert_eq!(query_vec, VEC.to_vec(), "embed_query vector");
+        assert_eq!(
+            batch_vecs,
+            vec![VEC.to_vec(), VEC.to_vec()],
+            "embed_batch vectors"
+        );
+        assert_eq!(dims, DIMS, "dimensions from health cache");
+        assert_eq!(dev.runtime, "fake-host", "device_info.runtime");
+        assert_eq!(dev.device, "cpu", "device_info.device");
+        assert_eq!(dev.model_name, "test-model", "device_info.model_name");
+        assert_eq!(dev.dimensions, DIMS, "device_info.dimensions");
+
+        server.await.expect("server task");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 2: broken pipe → exactly one reconnect → success
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn broken_pipe_triggers_exactly_one_reconnect_and_succeeds() {
+        let (_dir, addr) = temp_address();
+        let listener = HostListener::bind(&addr).await.expect("bind");
+
+        let server = tokio::spawn(async move {
+            // Connection 1: serve health, then drop conn.
+            // The server-side FIN causes the client's embed_query round_trip to
+            // return UnexpectedEof, which is classified as a connection drop.
+            {
+                let mut conn = listener.accept().await.expect("accept conn1");
+                assert_eq!(handle_one(&mut conn).await.as_deref(), Some("health"));
+                // conn drops here → FIN sent → client sees EOF on next read
+            }
+
+            // Connection 2: the client reconnects; serve health + embed_query.
+            {
+                let mut conn = listener.accept().await.expect("accept conn2");
+                assert_eq!(handle_one(&mut conn).await.as_deref(), Some("health"));
+                assert_eq!(
+                    handle_one(&mut conn).await.as_deref(),
+                    Some("embed_query")
+                );
+            }
+        });
+
+        let vector = tokio::task::spawn_blocking(move || {
+            let p = RpcEmbeddingProvider::new(addr);
+            // This call must survive the broken connection with one reconnect.
+            p.embed_query("reconnect-test")
+        })
+        .await
+        .expect("blocking join")
+        .expect("embed_query after reconnect");
+
+        assert_eq!(vector, VEC.to_vec(), "vector after reconnect");
+
+        server.await.expect("server task");
+    }
+}

--- a/docs/plans/2026-06-04-julie-phase3b-embedding-host.md
+++ b/docs/plans/2026-06-04-julie-phase3b-embedding-host.md
@@ -1,0 +1,266 @@
+# Julie Rescue Phase 3b — Resident Embedding-Host Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `@razorback:subagent-driven-development` (subagent delegation is available — visible team, inline lead review). Fall back to `@razorback:executing-plans` only if delegation becomes unavailable. Follow `@razorback:test-driven-development` for every task.
+
+**Goal:** Stand up a resident "embedding-host" process that owns the single PyTorch sidecar and serves `embed_query`/`embed_batch`/`health` to N independent Julie processes over a UDS (unix) / named-pipe (windows) front door, plus a thin RPC-client `EmbeddingProvider` — proving "one sidecar serves N processes" *additively*, before any daemon teardown.
+
+**Architecture:** Reuse the existing `SidecarEmbeddingProvider` + `RequestEnvelope`/`ResponseEnvelope` newline-delimited-JSON protocol **as-is**. The host process holds one `Arc<dyn EmbeddingProvider>` (the real sidecar) behind an async `tokio` accept loop; each accepted connection dispatches requests to the provider via `spawn_blocking` (the provider's `Mutex<SidecarProcess>` serializes naturally — one model, one GPU). Session/tool processes get a **blocking** `RpcEmbeddingProvider` that implements the same `julie_core::EmbeddingProvider` trait and forwards over the socket. Because every consumer already depends only on `Arc<dyn EmbeddingProvider>` (via `ToolContext::embedding_provider`/`ensure_embedding_provider`), the RPC client drops in at one seam with zero call-site changes. 3b is opt-in (env-gated) and does **not** remove the daemon's existing shared sidecar — the cutover is 3c.
+
+**Tech Stack:** Rust, tokio 1.47.1 (`full`, already a dep — provides `tokio::net::UnixListener` + `tokio::net::windows::named_pipe` with no new crates), `serde_json` (existing envelope types), `fs2` (existing, for the host singleton lock), `tokio_util::sync::CancellationToken` (graceful shutdown, mirrors `HttpTransportServer`). Python sidecar provisioning (`uv`) and the `embeddings-sidecar` cargo feature are unchanged.
+
+**Architecture Quality:** Approved shape — (1) the **wire contract** and the **client struct shape** are *lead-fixed* in §Fixed Contract below; workers fill implementations inside it and may not redesign the protocol or trait surface. (2) New code placement obeys the crate DAG: `RpcEmbeddingProvider` + transport + host-server live in **julie-pipeline** (which already owns the sidecar + protocol and is depended on by tools/runtime/julie); the host **binary** + process-launch glue live in the top **julie** crate; only **two** path-helper methods are added to **julie-core**. No code in `julie-context` (core+index only). **Main architecture risk:** cross-platform IPC — Unix UDS is the must-prove path (fully implemented + tested); Windows named-pipe is compile-guarded and documented-untested (matches the design doc's Unix-proof-is-the-must-have stance). Secondary risk: the sync `EmbeddingProvider` trait vs an async host — resolved by making the **client blocking** (no tokio) so it is safe inside the existing `spawn_blocking` embed call sites, while the **host is async**.
+
+---
+
+## Fixed Contract (lead-owned — do NOT redesign; implement against these exact shapes)
+
+### The substitution seam (verified at `crates/julie-core/src/embeddings_contract.rs:75`)
+```rust
+pub trait EmbeddingProvider: Send + Sync {
+    fn embed_query(&self, text: &str) -> anyhow::Result<Vec<f32>>;
+    fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>>;
+    fn dimensions(&self) -> usize;
+    fn device_info(&self) -> DeviceInfo;            // { runtime, device, model_name, dimensions }
+    fn accelerated(&self) -> Option<bool> { None }
+    fn degraded_reason(&self) -> Option<String> { None }
+    fn shutdown(&self) {}
+    fn wait_for_exit(&self, _timeout: Duration) -> bool { true }
+}
+```
+The `RpcEmbeddingProvider` implements this trait. `shutdown()` closes its socket; `wait_for_exit()` returns `true` immediately (it does **not** own the host). `dimensions()`/`device_info()`/`accelerated()`/`degraded_reason()` are served from a `health` response cached at first connect.
+
+### The wire protocol (REUSED AS-IS — verified at `crates/julie-pipeline/src/embeddings/sidecar_protocol.rs:10`, all types already `pub`)
+- Framing: **newline-delimited JSON**, one object per line, **no length prefix** — identical to `SidecarProcess::send_request_with_timeout` (`sidecar_provider.rs:365`). Write `serde_json::to_writer(stream, &envelope)`, then `b"\n"`, then flush; read one line, `trim()`, `serde_json::from_str`.
+- `RequestEnvelope<T> { schema: String, version: u32, request_id: String, method: String, params: T }`
+- `ResponseEnvelope<T> { schema, version, request_id, result: Option<T>, error: Option<ProtocolError> }` (exactly one of result/error set)
+- Constants: `SIDECAR_PROTOCOL_SCHEMA = "julie.embedding.sidecar"`, `SIDECAR_PROTOCOL_VERSION = 1`
+- Methods: `health` (params `{}` → `HealthResult`), `embed_query` (`EmbedQueryRequest{text}` → `EmbedQueryResult{dims,vector}`), `embed_batch` (`EmbedBatchRequest{texts}` → `EmbedBatchResult{dims,vectors}`), `shutdown` (params `{}`).
+- Reuse the existing validators: `validate_response_envelope`, `validate_query_response`, `validate_batch_response`, `validate_health_response` (all `pub` from `julie-pipeline/src/embeddings/mod.rs`).
+
+### Concurrency / connection model (lead-decided)
+- **One persistent connection per client; one in-flight request per connection** (matches the sync trait). The client holds connection state behind a `Mutex` for interior mutability.
+- **Host serializes all embeds** through the single `Arc<dyn EmbeddingProvider>` (its inner `Mutex<SidecarProcess>` already enforces one-request-at-a-time against the Python child — correct, since there is one model on one device). Multiple connections are accepted concurrently; their `embed_*` dispatches queue on that mutex inside `spawn_blocking`.
+- `request_id`: per-connection sequential (`req-1`, `req-2`, …) — sufficient because each connection is strictly sequential. No correlation-ID multiplexing.
+
+### Socket / lifecycle conventions (lead-decided)
+- **Global per `$JULIE_HOME`** (not per-workspace): one host serves all workspaces, mirroring today's process-global `EmbeddingService`. Unix socket `$JULIE_HOME/embedding-host.sock`; Windows pipe name derived from the `$JULIE_HOME` hash (mirror `DaemonPaths::daemon_shutdown_event` naming); singleton lock `$JULIE_HOME/embedding-host.lock` (`fs2` exclusive).
+- **Client = blocking std I/O** (`std::os::unix::net::UnixStream` / Windows named-pipe file handle). NOT tokio. This keeps the sync trait methods safe inside the existing `spawn_blocking` embed sites.
+- **Host = async tokio** (`UnixListener` accept loop), graceful shutdown via `CancellationToken` (model on `src/daemon/http_transport.rs:125-335`).
+- **Opt-in for 3b:** env var `JULIE_EMBEDDING_USE_HOST` (truthy → use the host path). Absent → existing behavior, fully unchanged. 3b does not flip the daemon's default wiring; that is 3c.
+- Client connection failure: reconnect-once-per-call on broken pipe/connection-reset; if the host is unreachable after the retry, return an `anyhow::Err` (the host's own `FATAL_THRESHOLD=3` circuit breaker already governs the Python child — the client adds connection resilience, not a second model-level breaker).
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `crates/julie-core/src/paths.rs` (DaemonPaths, ~`:243`→end) | Add `embedding_host_socket()`, `embedding_host_pipe_name()`, `embedding_host_lock()` |
+| Create | `crates/julie-pipeline/src/embeddings/host_transport.rs` | Cross-platform IPC seam: async server listener + blocking client connection; cfg(unix)/cfg(windows) |
+| Create | `crates/julie-pipeline/src/embeddings/rpc_client.rs` | `RpcEmbeddingProvider` — blocking `EmbeddingProvider` over `host_transport` client |
+| Create | `crates/julie-pipeline/src/embeddings/host_server.rs` | `run_embedding_host(...)` — owns one provider, accept loop, dispatch, graceful shutdown, singleton lock |
+| Modify | `crates/julie-pipeline/src/embeddings/mod.rs` (~`:45`) | Export the three new modules' public items |
+| Create | `src/bin/julie-embedding-host.rs` | Thin binary: env/args → tracing → DaemonPaths → `run_embedding_host` → SIGTERM handling |
+| Modify | `Cargo.toml` (root, `[[bin]]` block near julie-adapter/julie-daemon) | Register `julie-embedding-host` bin (gate features to include `embeddings-sidecar`) |
+| Create | `src/embedding_host_launch.rs` (top crate) + wire into `src/lib.rs`/`mod` | `connect_or_spawn_host(paths) -> Result<RpcEmbeddingProvider>` — launch glue (knows the bin) |
+| Modify | `src/daemon/app/helpers.rs` (`spawn_embedding_init`, `:403`) | Opt-in branch: when `JULIE_EMBEDDING_USE_HOST`, build provider via `connect_or_spawn_host` instead of `create_embedding_provider`, then `publish_ready` |
+| Create | `crates/julie-pipeline/src/tests/embeddings/host_roundtrip.rs` (+ register) | Unit/integration: transport round-trip, client↔fake-host, protocol mapping |
+| Create | `src/tests/daemon/embedding_host_multi_session.rs` (+ register in tests mod) | **Acceptance:** one host + 3 concurrent clients → one sidecar, all embed OK |
+
+---
+
+## Verification Strategy
+
+**Project source of truth:** `CLAUDE.md` / `AGENTS.md` (xtask tiers + TDD), `docs/TESTING_GUIDE.md`, `RAZORBACK.md` (routing + gate ownership). Crate-split rules from the rescue: dep-direction tripwires + a `cargo nextest --no-run` build gate.
+
+**Worker red/green scope:** the narrowest behavior proof — `cargo nextest run --lib <exact_test_name> 2>&1 | tail -10`. Sidecar/host tests that touch the real provider require `--features embeddings-sidecar` (e.g. `cargo nextest run -p julie-pipeline --features embeddings-sidecar <name>`). Workers run **at most twice** per change (RED then GREEN).
+
+**Worker ceiling:** the single named test (or the one new test file) for their task. Workers do **not** run `cargo xtask test changed/dev` or any tier — the lead owns those.
+
+**Worker gate invariant (per task):** stated in each task's acceptance criteria — e.g. Task 8's gate proves "exactly one sidecar child is spawned while 3 concurrent clients all embed successfully."
+
+**Lead affected-change scope:** `cargo xtask test changed` after each coherent batch; if it falls back to `dev`, accept it (shared infra moved).
+
+**Branch gate (lead, before PR):** `cargo xtask test dev` GREEN + the dep-direction tripwire scan + `cargo nextest run --no-run` (cfg(test) build) GREEN + the acceptance test (Task 8) GREEN under `--features embeddings-sidecar`. Per the rescue rule, `--no-run` does NOT execute integration tripwires — so the lead also runs the full relevant `-p` dev tier, not just `--no-run`.
+
+**Replay/metric evidence:** Task 8 is the acceptance gate. **Hard gate:** (a) all 3 concurrent clients return vectors of the correct `dims`; (b) exactly **one** sidecar child spawned (single "Embedding provider initialized" log / single spawn-counter increment). **Report-only:** per-call latency.
+
+**Escalation triggers (→ lead/Opus):** any change to the wire protocol or trait surface; cross-process lifecycle/shutdown ordering; a worker's transport test hangs or flakes; two worker attempts fail review; Windows-path uncertainty.
+
+**Assigned verification failure:** workers stop and report; they do not "fix" the gate or present a failing run as evidence.
+
+**Verification ledger:** use `docs/plans/verification-ledger-template.md`. Record invariant, command, scope label, commit SHA, result, timestamp. Include a **relink-evidence** row proving an edit to a `julie-pipeline` test does not relink the top `julie` crate's test monolith (the rescue's whole point).
+
+---
+
+## Model Routing
+
+**Project source of truth:** `RAZORBACK.md`. This is **shared-invariant work** (transport, process lifecycle, concurrency) per RAZORBACK.md §"shared-invariant areas", so the bar is raised below.
+
+**Strategy / lead (Opus):** the Fixed Contract, IPC abstraction signatures, all review, Task 8 acceptance interpretation, branch + specialist gates. Harness mapping: `opus`.
+
+**Coupled-implementation tier (workers, within the lead-fixed contract):** Tasks 3–8 bounded edits. Harness mapping: `sonnet`. (RAZORBACK: "Coupled implementation → Sonnet high or Opus.")
+
+**Mechanical tier:** none — every task owns executable behavior or a gate. Do not assign a mechanical worker any task here.
+
+**Gate-interpretation reviewer:** the lead (Opus) reads the plan + failing/passing test + diff for Task 8 and the protocol tasks.
+
+**Escalation tier (Opus):** concurrency/shutdown correctness, protocol changes, repeated worker failure, Windows path.
+
+**Worker eligibility:** Tasks 3–8 are worker-eligible **only because** Tasks 1–2 fix the contract (paths + transport seam) first. Workers get a frozen wire format, frozen struct shapes, and disjoint files.
+
+**Lead-owned lanes (not delegated):** Task 1 (julie-core path contract) and Task 2 (the `host_transport` cross-platform seam) — these define the invariant everything else builds on, and Task 2 carries the Windows uncertainty. The lead implements/finalizes these and assigns 3–8 against them.
+
+**Unsupported harness behavior:** Claude Code selects per-agent model via the Agent `model` param (`opus`/`sonnet`/`haiku`) — fully supported; no `inherit` needed.
+
+---
+
+## Tasks
+
+> TDD applies to every task (RED → GREEN → refactor). Commit after each green task. Use Julie's code-intelligence tools (`get_symbols`, `deep_dive`, `fast_refs`) — not blind Read/Grep — to read the real code before editing.
+
+### Task 1 — DaemonPaths socket/lock helpers (LEAD-OWNED)
+
+**Files:**
+- Modify: `crates/julie-core/src/paths.rs` (DaemonPaths impl, after the existing daemon_* helpers ~`:243`–end)
+- Test: inline `#[cfg(test)]` in `paths.rs` (matches existing path-test convention there) **or** the existing paths test module
+
+**What to build:** Three `DaemonPaths` methods: `embedding_host_socket() -> PathBuf` (unix → `julie_home.join("embedding-host.sock")`), `embedding_host_lock() -> PathBuf` (`julie_home.join("embedding-host.lock")`), and `embedding_host_pipe_name() -> String` (windows-oriented: `format!(r"\\.\pipe\julie-embedding-host-{}", <julie_home hash>)`, reusing the exact hashing already used by `daemon_shutdown_event()` so the name is stable per `$JULIE_HOME`).
+
+**Approach:** Mirror the existing `daemon_*` helpers verbatim for style. For the pipe-name hash, `deep_dive` `daemon_shutdown_event` first and reuse its hash helper — do not invent a new hash.
+
+**Acceptance criteria:**
+- [ ] `embedding_host_socket`/`_lock` compose under `julie_home`; test asserts exact suffixes.
+- [ ] `embedding_host_pipe_name` is deterministic for a fixed `$JULIE_HOME` and uses the same hash as `daemon_shutdown_event` (test asserts stability + `\\.\pipe\` prefix).
+- [ ] `cargo nextest run -p julie-core <test_name>` green.
+
+### Task 2 — Cross-platform IPC transport seam (LEAD-OWNED)
+
+**Files:**
+- Create: `crates/julie-pipeline/src/embeddings/host_transport.rs`
+- Modify: `crates/julie-pipeline/src/embeddings/mod.rs` (add `mod host_transport;` + `pub use`)
+- Test: `crates/julie-pipeline/src/tests/embeddings/host_roundtrip.rs` (transport-only round trip)
+
+**What to build:** The minimal seam both client and server build on, isolating all OS-specific code here.
+- **Blocking client:** `pub struct HostClientConn` with `pub fn connect(paths-derived address) -> io::Result<Self>` and `pub fn round_trip(&mut self, request_line: &str) -> io::Result<String>` (write line + `\n` + flush, read one line). `#[cfg(unix)]` wraps `std::os::unix::net::UnixStream`; `#[cfg(windows)]` opens the named pipe as a blocking file handle.
+- **Async server:** `pub async fn bind_host_listener(address) -> io::Result<HostListener>` and `HostListener::accept() -> io::Result<HostServerConn>` where `HostServerConn` exposes async `read_line`/`write_line`. `#[cfg(unix)]` → `tokio::net::{UnixListener, UnixStream}`; `#[cfg(windows)]` → `tokio::net::windows::named_pipe`.
+
+**Approach:** Unix is the must-prove path — implement and test it fully. Windows is `cfg`-gated, written to compile, and documented as **untested on this platform** (cannot be exercised on the macOS dev box; matches the design doc's Unix-proof stance). Keep the address type a thin enum/struct carrying either a socket `PathBuf` (unix) or a pipe name `String` (windows). No protocol knowledge here — this module moves bytes/lines only.
+
+**Acceptance criteria:**
+- [ ] Unix round-trip test: a throwaway tokio server echoes a line; `HostClientConn::connect` + `round_trip` gets it back. `cargo nextest run -p julie-pipeline <test_name>` green.
+- [ ] Windows arms compile under `cfg(windows)` (reviewed by lead; documented untested).
+- [ ] No new crate dependencies (tokio `full` + std only).
+
+### Task 3 — `RpcEmbeddingProvider` (thin client)
+
+**Files:**
+- Create: `crates/julie-pipeline/src/embeddings/rpc_client.rs`
+- Modify: `crates/julie-pipeline/src/embeddings/mod.rs` (export `RpcEmbeddingProvider`)
+- Test: extend `crates/julie-pipeline/src/tests/embeddings/host_roundtrip.rs`
+
+**What to build:** A struct implementing the Fixed-Contract `EmbeddingProvider` trait by forwarding over `host_transport::HostClientConn`. Holds: the address, `Mutex<Option<HostClientConn>>` (lazy connect + reconnect), a per-connection `request_id` counter, and cached `dimensions`/`DeviceInfo` populated from a `health` round-trip on first connect.
+
+**Approach:**
+- `embed_query`/`embed_batch`: build `RequestEnvelope` (schema/version constants), serialize, `round_trip`, deserialize `ResponseEnvelope`, run the matching existing validator, return `result.vector`/`result.vectors` or map `ProtocolError`→`anyhow::Err`. On `io::Error` (broken pipe), drop the connection and retry **once** (reconnect), else error.
+- `dimensions()`/`device_info()`/`accelerated()`/`degraded_reason()`: serve from cached `HealthResult` (connect lazily if not yet cached). `shutdown()` drops the connection; `wait_for_exit()` returns `true`.
+- Mirror `SidecarProcess::send_request_with_timeout` (`sidecar_provider.rs:365`) for the exact serialize/flush/read sequence — `deep_dive` it first.
+
+**Acceptance criteria:**
+- [ ] Against a fake host (a small in-test tokio server speaking the envelope protocol), `embed_query`/`embed_batch` return correct vectors; `dimensions()`/`device_info()` reflect the health response.
+- [ ] A simulated broken pipe triggers exactly one reconnect, then succeeds.
+- [ ] `RpcEmbeddingProvider` satisfies `Arc<dyn EmbeddingProvider>` (compile assertion).
+- [ ] `cargo nextest run -p julie-pipeline <test_name>` green.
+
+### Task 4 — Embedding-host server
+
+**Files:**
+- Create: `crates/julie-pipeline/src/embeddings/host_server.rs`
+- Modify: `crates/julie-pipeline/src/embeddings/mod.rs` (export `run_embedding_host` + a config struct)
+- Test: extend `host_roundtrip.rs` (host with an injected fake provider)
+
+**What to build:** `pub async fn run_embedding_host(address, lock_path, cancellation: CancellationToken, provider: Arc<dyn EmbeddingProvider>)` (a sibling `run_embedding_host_default` resolves the provider via `create_embedding_provider` for the bin path). It: acquires the `fs2` singleton lock (yield/exit if held), binds via `host_transport::bind_host_listener`, runs an accept loop spawning a task per connection. Each connection task loops: read a line → parse `RequestEnvelope<serde_json::Value>` → match `method` → call the provider's matching method inside `tokio::task::spawn_blocking` (the provider is sync + `Mutex`-guarded) → write `ResponseEnvelope`. `shutdown` method drains + closes. Graceful shutdown on `cancellation.cancelled()` (mirror `HttpTransportServer`), then `provider.shutdown()` + `spawn_blocking(provider.wait_for_exit(3s))`.
+
+**Approach:** `deep_dive` `HttpTransportServer::bind_with_listener` + the accept/`CancellationToken`/`with_graceful_shutdown` structure and copy the shape. Inject the provider so tests use a fake (no Python). Errors → `ResponseEnvelope.error = Some(ProtocolError{code,message})`, never a panic that kills the accept loop.
+
+**Acceptance criteria:**
+- [ ] With an injected fake provider, a `HostClientConn` round-trips `health`/`embed_query`/`embed_batch` correctly.
+- [ ] Two concurrent client connections both succeed (serialized through the provider mutex).
+- [ ] `cancellation.cancel()` stops the accept loop and the function returns; the lock is released.
+- [ ] `cargo nextest run -p julie-pipeline <test_name>` green.
+
+### Task 5 — `julie-embedding-host` binary
+
+**Files:**
+- Create: `src/bin/julie-embedding-host.rs`
+- Modify: root `Cargo.toml` (`[[bin]]` entry near `julie-adapter`/`julie-daemon`; ensure it builds with `embeddings-sidecar`)
+
+**What to build:** A thin entrypoint: init tracing (reuse the daemon's tracing/log-file setup helper — `deep_dive` how `julie-daemon` bin or `run_daemon` initializes tracing and reuse it), resolve `DaemonPaths` from `$JULIE_HOME`, compute the address (socket on unix / pipe on windows), create a `CancellationToken`, spawn a SIGTERM/Ctrl-C handler that cancels it (reuse `shutdown_signal()` from the daemon if reachable), then `run_embedding_host_default(...)`.
+
+**Approach:** Keep this < 80 lines — all logic is in `host_server`. Mirror `src/bin/julie-daemon.rs` for the tokio `#[tokio::main]` + tracing + signal scaffolding.
+
+**Acceptance criteria:**
+- [ ] `cargo build --bin julie-embedding-host --features embeddings-sidecar` succeeds.
+- [ ] Manual/CLI smoke (lead, recorded in ledger): launching the bin creates the socket and answers a `health` round-trip. (Automated coverage comes via Task 8 using `current_exe`.)
+
+### Task 6 — `connect_or_spawn_host` launch glue
+
+**Files:**
+- Create: `src/embedding_host_launch.rs` (top crate) + declare the module
+- Test: `src/tests/daemon/embedding_host_multi_session.rs` exercises it (see Task 8) — no separate test file
+
+**What to build:** `pub fn connect_or_spawn_host(paths: &DaemonPaths) -> anyhow::Result<RpcEmbeddingProvider>`: if the socket/pipe is live → construct + return the client. Else spawn `julie-embedding-host` (resolve the sibling binary via `std::env::current_exe()` parent — mirror how the adapter auto-starts the daemon; `deep_dive` `src/adapter/launcher.rs`), pass through the relevant `JULIE_EMBEDDING_*` env vars, poll for the socket up to a bounded timeout, then connect.
+
+**Approach:** This lives in the **top crate** because only it knows the host bin and can launch sibling processes (julie-pipeline must not depend on the bin). Reuse the adapter's current_exe + readiness-poll pattern rather than inventing one.
+
+**Acceptance criteria:**
+- [ ] When no host is running, the function spawns one, waits for readiness, and returns a working client (covered by Task 8).
+- [ ] When a host is already running, it connects without spawning a second (the host's singleton lock also guarantees this).
+
+### Task 7 — Opt-in coexistence wiring (additive)
+
+**Files:**
+- Modify: `src/daemon/app/helpers.rs` — `spawn_embedding_init` (`:403`)
+- Test: a daemon-mode test (in `embedding_host_multi_session.rs` or `src/tests/daemon/embedding_service.rs`)
+
+**What to build:** Inside `spawn_embedding_init`'s `spawn_blocking`, branch on `std::env::var("JULIE_EMBEDDING_USE_HOST")`: when truthy, build the provider via `connect_or_spawn_host(&paths)` (wrap as `Arc<dyn EmbeddingProvider>`) and a synthesized `EmbeddingRuntimeStatus`, then `publish_ready` exactly as today; on error `publish_unavailable`. When unset/false, the **existing `create_embedding_provider()` path is unchanged**. `watcher_pool.update_all_provider(...)` continues to receive whatever provider was published — no change.
+
+**Approach:** Purely additive — one `if` at the provider-construction point. Do not touch the session-side guard in `embedding_init.rs:66` (it already prevents stdio double-spawn and works identically for an RPC-client provider). Leave the stdio-mode lazy-init path for a follow-up note (3c) unless trivially gated the same way — do **not** expand scope here.
+
+**Acceptance criteria:**
+- [ ] With `JULIE_EMBEDDING_USE_HOST=1`, a daemon-mode test shows the published provider is an `RpcEmbeddingProvider` and N `JulieServerHandler`s share the one `Arc<EmbeddingService>`.
+- [ ] With the env unset, behavior is byte-for-byte the existing path (a test asserts `create_embedding_provider` is still the source — or that no host socket is created).
+- [ ] `cargo nextest run --lib <test_name>` green.
+
+### Task 8 — Acceptance: one sidecar serves 3 concurrent sessions (HARD GATE)
+
+**Files:**
+- Create: `src/tests/daemon/embedding_host_multi_session.rs` + register in the daemon tests mod
+- Test seam (if needed): add a `#[cfg(any(test, feature="test-support"))]` spawn-counter (e.g. `AtomicU32`) incremented in `SidecarEmbeddingProvider::spawn_process` (`sidecar_provider.rs:62`) so the test can assert "exactly one sidecar"
+
+**What to build:** An integration test that launches **one** real `julie-embedding-host` (via `current_exe()` sibling, `--features embeddings-sidecar`) configured with a **fake CPU sidecar** through the existing `JULIE_EMBEDDING_SIDECAR_RAW_PROGRAM` hook (an inline echo/stub script that speaks the envelope protocol — copy the technique from the circuit-breaker test in `sidecar_provider.rs` tests), then opens **3 concurrent** `RpcEmbeddingProvider` clients and fires concurrent `embed_query` + `embed_batch` from all three.
+
+**Approach:** `deep_dive` the existing `JULIE_EMBEDDING_SIDECAR_RAW_PROGRAM` test usage first and reuse its stub-sidecar pattern so this needs **no GPU and no real model**. Prove the single-sidecar invariant either via the spawn-counter seam (one increment) or by asserting the host emitted exactly one "Embedding provider initialized" log. Keep total wall-clock low (stub sidecar, short timeouts).
+
+**Acceptance criteria (HARD GATE):**
+- [ ] All 3 concurrent clients return vectors of the correct `dims` for both `embed_query` and `embed_batch`. **(hard)**
+- [ ] Exactly **one** sidecar child is spawned across all 3 clients. **(hard)**
+- [ ] Host shuts down cleanly (cancellation → socket + lock released). **(hard)**
+- [ ] Per-call latency recorded. **(report-only)**
+- [ ] `cargo nextest run -p julie-pipeline --features embeddings-sidecar <test_name> 2>&1 | tail -20` green (lead runs; this is the 3b proof).
+
+---
+
+## Out of scope for 3b (explicit — do NOT build here)
+
+- Removing the daemon's existing shared sidecar / flipping the default onto the host (that is the 3c cutover).
+- The per-workspace **leader-election lock** and WAL/mmap reader model (3c).
+- Conditioning `watcher_pool.update_all_provider` on write-leadership (3c — sessions aren't leaders yet).
+- Deleting `adapter/**`, HTTP transport, or any daemon subsystem (3d).
+- Moving `daemon.db` → `registry.db` or the dashboard re-home (3c/3d).
+- Stdio-mode default rewiring onto the host beyond the env-gated opt-in (3c).
+
+## Notes carried to 3c (record, don't act)
+
+- `EmbeddingService` itself need not move out of `src/daemon/` for 3b to work — its only non-std deps are `tokio::sync::watch` + the core trait. Physically relocating it (design §2 "MOVE") can ride 3c's in-process server work; 3b proves the host mechanism without the move. (If the team prefers, relocating the file is a clean mechanical add — but it is not required by any 3b acceptance criterion and must not block the gate.)
+- The sync-vs-async sidecar I/O (`std::sync::mpsc` stdout reader) stays as-is; the host wraps it via `spawn_blocking`.

--- a/src/bin/julie-embedding-host.rs
+++ b/src/bin/julie-embedding-host.rs
@@ -1,0 +1,76 @@
+//! `julie-embedding-host` — resident embedding host process.
+//!
+//! Acquires the singleton lock, binds the IPC front door, and serves
+//! `health` / `embed_query` / `embed_batch` requests until SIGTERM / SIGINT.
+//! All logic lives in `julie_pipeline::embeddings::host_server`.
+
+use anyhow::Context as _;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Resolve $JULIE_HOME (or the platform default) into structured paths.
+    let paths = julie::paths::DaemonPaths::try_new()
+        .map_err(|e| anyhow::anyhow!("JULIE_HOME misconfiguration: {e}"))?;
+
+    // File tracing → $JULIE_HOME/embedding-host.<date>.log
+    if let Err(e) = julie::logging::install_file_tracing(
+        &paths.julie_home(),
+        "embedding-host",
+        "julie=info",
+    ) {
+        eprintln!("julie-embedding-host: failed to install file tracing: {e}");
+    }
+
+    info!("julie-embedding-host starting");
+
+    let addr = julie_pipeline::embeddings::host_transport::HostAddress::from_paths(&paths);
+    let lock_path = paths.embedding_host_lock();
+
+    let cancel = CancellationToken::new();
+
+    // Spawn a task that cancels the token when a shutdown signal arrives.
+    let cancel_signal = cancel.clone();
+    tokio::spawn(async move {
+        match await_shutdown_signal().await {
+            Ok(()) => info!("shutdown signal received"),
+            Err(e) => error!("signal handler error: {e}"),
+        }
+        cancel_signal.cancel();
+    });
+
+    julie_pipeline::embeddings::host_server::run_embedding_host_default(
+        &addr,
+        &lock_path,
+        cancel,
+    )
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// Signal handling (mirrors daemon's shutdown_signal, inlined because
+// that function is pub(crate) and bins are separate compilation units)
+// ---------------------------------------------------------------------------
+
+async fn await_shutdown_signal() -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut sigterm =
+            signal(SignalKind::terminate()).context("failed to register SIGTERM handler")?;
+        let mut sigint =
+            signal(SignalKind::interrupt()).context("failed to register SIGINT handler")?;
+        tokio::select! {
+            _ = sigterm.recv() => {}
+            _ = sigint.recv() => {}
+        }
+    }
+    #[cfg(windows)]
+    {
+        tokio::signal::ctrl_c()
+            .await
+            .context("failed to listen for Ctrl-C")?;
+    }
+    Ok(())
+}

--- a/src/daemon/app.rs
+++ b/src/daemon/app.rs
@@ -445,6 +445,7 @@ impl DaemonApp {
             Arc::clone(&self.embedding_service),
             self.daemon_db.clone(),
             Arc::clone(&watcher_pool_for_handlers),
+            self.paths.clone(),
         );
 
         // ---- Build the handle (owns lock, pools, background tasks) ----
@@ -497,9 +498,9 @@ impl Drop for DaemonApp {
 mod helpers;
 pub(crate) use helpers::{
     acquire_or_yield_to_existing_daemon, bind_mcp_listener_with_fallback,
-    publish_starting_discovery, shutdown_signal, spawn_restart_bridge,
+    publish_starting_discovery, shutdown_signal, spawn_embedding_init, spawn_restart_bridge,
 };
 use helpers::{
     bind_dashboard_listener_and_publish, open_and_migrate_daemon_db, session_reaper_interval,
-    setup_stop_notify, spawn_cleanup_sweep, spawn_embedding_init, spawn_session_idle_reaper,
+    setup_stop_notify, spawn_cleanup_sweep, spawn_session_idle_reaper,
 };

--- a/src/daemon/app.rs
+++ b/src/daemon/app.rs
@@ -445,7 +445,6 @@ impl DaemonApp {
             Arc::clone(&self.embedding_service),
             self.daemon_db.clone(),
             Arc::clone(&watcher_pool_for_handlers),
-            self.paths.clone(),
         );
 
         // ---- Build the handle (owns lock, pools, background tasks) ----
@@ -498,9 +497,11 @@ impl Drop for DaemonApp {
 mod helpers;
 pub(crate) use helpers::{
     acquire_or_yield_to_existing_daemon, bind_mcp_listener_with_fallback,
-    publish_starting_discovery, shutdown_signal, spawn_embedding_init, spawn_restart_bridge,
+    publish_starting_discovery, shutdown_signal, spawn_restart_bridge,
 };
+#[cfg(test)]
+pub(crate) use helpers::use_embedding_host;
 use helpers::{
     bind_dashboard_listener_and_publish, open_and_migrate_daemon_db, session_reaper_interval,
-    setup_stop_notify, spawn_cleanup_sweep, spawn_session_idle_reaper,
+    setup_stop_notify, spawn_cleanup_sweep, spawn_embedding_init, spawn_session_idle_reaper,
 };

--- a/src/daemon/app.rs
+++ b/src/daemon/app.rs
@@ -445,6 +445,7 @@ impl DaemonApp {
             Arc::clone(&self.embedding_service),
             self.daemon_db.clone(),
             Arc::clone(&watcher_pool_for_handlers),
+            self.paths.clone(),
         );
 
         // ---- Build the handle (owns lock, pools, background tasks) ----
@@ -497,11 +498,9 @@ impl Drop for DaemonApp {
 mod helpers;
 pub(crate) use helpers::{
     acquire_or_yield_to_existing_daemon, bind_mcp_listener_with_fallback,
-    publish_starting_discovery, shutdown_signal, spawn_restart_bridge,
+    publish_starting_discovery, shutdown_signal, spawn_embedding_init, spawn_restart_bridge,
 };
-#[cfg(test)]
-pub(crate) use helpers::use_embedding_host;
 use helpers::{
     bind_dashboard_listener_and_publish, open_and_migrate_daemon_db, session_reaper_interval,
-    setup_stop_notify, spawn_cleanup_sweep, spawn_embedding_init, spawn_session_idle_reaper,
+    setup_stop_notify, spawn_cleanup_sweep, spawn_session_idle_reaper,
 };

--- a/src/daemon/app/helpers.rs
+++ b/src/daemon/app/helpers.rs
@@ -404,48 +404,47 @@ pub(crate) fn spawn_embedding_init(
     embedding_service: Arc<EmbeddingService>,
     daemon_db: Option<Arc<DaemonDatabase>>,
     watcher_pool: Arc<WatcherPool>,
-    paths: DaemonPaths,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         info!("Background embedding init task started");
 
-        // --- Opt-in host path (JULIE_EMBEDDING_USE_HOST) ---
-        if is_use_host_enabled() {
-            let host_result = tokio::task::spawn_blocking(move || {
-                crate::embedding_host_launch::connect_or_spawn_host(&paths)
+        // Single init_result computed from whichever path is active; both
+        // branches produce the same type so the match below is unchanged.
+        let init_result = if use_embedding_host() {
+            tokio::task::spawn_blocking(|| {
+                // Resolve the home dir inside the closure — no new param needed.
+                match DaemonPaths::try_new()
+                    .map_err(anyhow::Error::from)
+                    .and_then(|paths| crate::embedding_host_launch::connect_or_spawn_host(&paths))
+                {
+                    Ok(rpc) => {
+                        let provider: Arc<dyn crate::embeddings::EmbeddingProvider> =
+                            Arc::new(rpc);
+                        let status = crate::embeddings::EmbeddingRuntimeStatus {
+                            requested_backend: crate::embeddings::EmbeddingBackend::Sidecar,
+                            resolved_backend: crate::embeddings::EmbeddingBackend::Sidecar,
+                            accelerated: provider.accelerated().unwrap_or(false),
+                            degraded_reason: provider.degraded_reason(),
+                        };
+                        (Some(provider), Some(status))
+                    }
+                    Err(e) => {
+                        let status = crate::embeddings::EmbeddingRuntimeStatus {
+                            requested_backend: crate::embeddings::EmbeddingBackend::Sidecar,
+                            resolved_backend: crate::embeddings::EmbeddingBackend::Unresolved,
+                            accelerated: false,
+                            degraded_reason: Some(format!(
+                                "embedding-host connect/spawn failed: {e}"
+                            )),
+                        };
+                        (None, Some(status))
+                    }
+                }
             })
-            .await;
-            match host_result {
-                Ok(Ok(provider)) => {
-                    let provider: Arc<dyn crate::embeddings::EmbeddingProvider> =
-                        Arc::new(provider);
-                    let status = crate::embeddings::EmbeddingRuntimeStatus {
-                        requested_backend: crate::embeddings::EmbeddingBackend::Sidecar,
-                        resolved_backend: crate::embeddings::EmbeddingBackend::Sidecar,
-                        accelerated: false,
-                        degraded_reason: None,
-                    };
-                    embedding_service.publish_ready(Arc::clone(&provider), status);
-                    watcher_pool.update_all_provider(Some(provider)).await;
-                }
-                Ok(Err(e)) => {
-                    embedding_service.publish_unavailable(
-                        format!("embedding-host connect/spawn failed: {e}"),
-                        None,
-                    );
-                }
-                Err(join_err) => {
-                    embedding_service.publish_unavailable(
-                        format!("embedding-host init task panicked: {join_err}"),
-                        None,
-                    );
-                }
-            }
-            return;
-        }
-        // --- End host path ---
-        let init_result =
-            tokio::task::spawn_blocking(|| crate::embeddings::create_embedding_provider()).await;
+            .await
+        } else {
+            tokio::task::spawn_blocking(|| crate::embeddings::create_embedding_provider()).await
+        };
 
         match init_result {
             Ok((Some(provider), Some(status))) => {
@@ -540,13 +539,16 @@ pub(crate) fn spawn_embedding_init(
 }
 
 /// Returns `true` when `JULIE_EMBEDDING_USE_HOST` is set to a truthy value
-/// (`1`, `true`, `yes`, or `on`, case-insensitive). Any other value, or the
-/// variable being absent, returns `false`.
-fn is_use_host_enabled() -> bool {
+/// (`1`, `true`, or `on`, case-insensitive). Any other value, or the variable
+/// being absent, returns `false`.
+///
+/// `pub(crate)` so the test suite can drive it directly without spinning a
+/// real host process.
+pub(crate) fn use_embedding_host() -> bool {
     std::env::var("JULIE_EMBEDDING_USE_HOST")
         .map(|v| {
-            let lower = v.to_ascii_lowercase();
-            matches!(lower.trim(), "1" | "true" | "yes" | "on")
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true" || v == "on"
         })
         .unwrap_or(false)
 }

--- a/src/daemon/app/helpers.rs
+++ b/src/daemon/app/helpers.rs
@@ -411,15 +411,14 @@ pub(crate) fn spawn_embedding_init(
 
         // Single init_result computed from whichever path is active; both
         // branches produce the same type so the existing match below is
-        // byte-for-byte unchanged — the (Some,Some) arm's device_info() call
-        // gates Ready on a real health round-trip, and the daemon_db model-sync
-        // runs for both paths.
+        // byte-for-byte unchanged — ensure_ready() gates Ready on a real
+        // health handshake, and the daemon_db model-sync runs for both paths.
         let init_result = if use_embedding_host() {
             tokio::task::spawn_blocking(move || {
                 // All blocking work — including the health round-trip triggered
-                // by accelerated()/degraded_reason() — must stay inside this
-                // closure. Calling them outside (e.g. in a .map()) would block
-                // the tokio runtime and deadlock with the async server task.
+                // by ensure_ready() — must stay inside this closure. Calling
+                // blocking I/O outside (e.g. in a .map()) would block the
+                // tokio runtime and deadlock with the async server task.
                 match crate::embedding_host_launch::connect_or_spawn_host(&paths) {
                     Ok(rpc) => {
                         // Hard-gate: ensure_ready() runs the health handshake
@@ -427,26 +426,36 @@ pub(crate) fn spawn_embedding_init(
                         // dyn-trait getters (accelerated/degraded_reason/
                         // dimensions/device_info) would otherwise swallow by
                         // returning silent defaults.
-                        if let Err(e) = rpc.ensure_ready() {
-                            let status = crate::embeddings::EmbeddingRuntimeStatus {
-                                requested_backend: crate::embeddings::EmbeddingBackend::Sidecar,
-                                resolved_backend: crate::embeddings::EmbeddingBackend::Unresolved,
-                                accelerated: false,
-                                degraded_reason: Some(format!("embedding-host not ready: {e}")),
-                            };
-                            return (None, Some(status));
+                        match rpc.ensure_ready() {
+                            Ok(()) => {
+                                let provider: Arc<dyn crate::embeddings::EmbeddingProvider> =
+                                    Arc::new(rpc);
+                                // OnceLock already populated by ensure_ready()
+                                // — cache hits below, no extra I/O.
+                                let status = crate::embeddings::EmbeddingRuntimeStatus {
+                                    requested_backend:
+                                        crate::embeddings::EmbeddingBackend::Sidecar,
+                                    resolved_backend:
+                                        crate::embeddings::EmbeddingBackend::Sidecar,
+                                    accelerated: provider.accelerated().unwrap_or(false),
+                                    degraded_reason: provider.degraded_reason(),
+                                };
+                                (Some(provider), Some(status))
+                            }
+                            Err(e) => {
+                                let status = crate::embeddings::EmbeddingRuntimeStatus {
+                                    requested_backend:
+                                        crate::embeddings::EmbeddingBackend::Sidecar,
+                                    resolved_backend:
+                                        crate::embeddings::EmbeddingBackend::Unresolved,
+                                    accelerated: false,
+                                    degraded_reason: Some(format!(
+                                        "embedding-host health handshake failed: {e}"
+                                    )),
+                                };
+                                (None, Some(status))
+                            }
                         }
-                        let provider: Arc<dyn crate::embeddings::EmbeddingProvider> =
-                            Arc::new(rpc);
-                        // OnceLock already populated by ensure_ready() — cache
-                        // hits below, no extra I/O.
-                        let status = crate::embeddings::EmbeddingRuntimeStatus {
-                            requested_backend: crate::embeddings::EmbeddingBackend::Sidecar,
-                            resolved_backend: crate::embeddings::EmbeddingBackend::Sidecar,
-                            accelerated: provider.accelerated().unwrap_or(false),
-                            degraded_reason: provider.degraded_reason(),
-                        };
-                        (Some(provider), Some(status))
                     }
                     Err(e) => {
                         let status = crate::embeddings::EmbeddingRuntimeStatus {

--- a/src/daemon/app/helpers.rs
+++ b/src/daemon/app/helpers.rs
@@ -404,9 +404,46 @@ pub(crate) fn spawn_embedding_init(
     embedding_service: Arc<EmbeddingService>,
     daemon_db: Option<Arc<DaemonDatabase>>,
     watcher_pool: Arc<WatcherPool>,
+    paths: DaemonPaths,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         info!("Background embedding init task started");
+
+        // --- Opt-in host path (JULIE_EMBEDDING_USE_HOST) ---
+        if is_use_host_enabled() {
+            let host_result = tokio::task::spawn_blocking(move || {
+                crate::embedding_host_launch::connect_or_spawn_host(&paths)
+            })
+            .await;
+            match host_result {
+                Ok(Ok(provider)) => {
+                    let provider: Arc<dyn crate::embeddings::EmbeddingProvider> =
+                        Arc::new(provider);
+                    let status = crate::embeddings::EmbeddingRuntimeStatus {
+                        requested_backend: crate::embeddings::EmbeddingBackend::Sidecar,
+                        resolved_backend: crate::embeddings::EmbeddingBackend::Sidecar,
+                        accelerated: false,
+                        degraded_reason: None,
+                    };
+                    embedding_service.publish_ready(Arc::clone(&provider), status);
+                    watcher_pool.update_all_provider(Some(provider)).await;
+                }
+                Ok(Err(e)) => {
+                    embedding_service.publish_unavailable(
+                        format!("embedding-host connect/spawn failed: {e}"),
+                        None,
+                    );
+                }
+                Err(join_err) => {
+                    embedding_service.publish_unavailable(
+                        format!("embedding-host init task panicked: {join_err}"),
+                        None,
+                    );
+                }
+            }
+            return;
+        }
+        // --- End host path ---
         let init_result =
             tokio::task::spawn_blocking(|| crate::embeddings::create_embedding_provider()).await;
 
@@ -500,4 +537,16 @@ pub(crate) fn spawn_embedding_init(
             }
         }
     })
+}
+
+/// Returns `true` when `JULIE_EMBEDDING_USE_HOST` is set to a truthy value
+/// (`1`, `true`, `yes`, or `on`, case-insensitive). Any other value, or the
+/// variable being absent, returns `false`.
+fn is_use_host_enabled() -> bool {
+    std::env::var("JULIE_EMBEDDING_USE_HOST")
+        .map(|v| {
+            let lower = v.to_ascii_lowercase();
+            matches!(lower.trim(), "1" | "true" | "yes" | "on")
+        })
+        .unwrap_or(false)
 }

--- a/src/daemon/app/helpers.rs
+++ b/src/daemon/app/helpers.rs
@@ -422,10 +422,24 @@ pub(crate) fn spawn_embedding_init(
                 // the tokio runtime and deadlock with the async server task.
                 match crate::embedding_host_launch::connect_or_spawn_host(&paths) {
                     Ok(rpc) => {
+                        // Hard-gate: ensure_ready() runs the health handshake
+                        // and surfaces errors + ready=false that the
+                        // dyn-trait getters (accelerated/degraded_reason/
+                        // dimensions/device_info) would otherwise swallow by
+                        // returning silent defaults.
+                        if let Err(e) = rpc.ensure_ready() {
+                            let status = crate::embeddings::EmbeddingRuntimeStatus {
+                                requested_backend: crate::embeddings::EmbeddingBackend::Sidecar,
+                                resolved_backend: crate::embeddings::EmbeddingBackend::Unresolved,
+                                accelerated: false,
+                                degraded_reason: Some(format!("embedding-host not ready: {e}")),
+                            };
+                            return (None, Some(status));
+                        }
                         let provider: Arc<dyn crate::embeddings::EmbeddingProvider> =
                             Arc::new(rpc);
-                        // accelerated() / degraded_reason() → get_cached() →
-                        // ensure_connected() → health handshake (blocking I/O).
+                        // OnceLock already populated by ensure_ready() — cache
+                        // hits below, no extra I/O.
                         let status = crate::embeddings::EmbeddingRuntimeStatus {
                             requested_backend: crate::embeddings::EmbeddingBackend::Sidecar,
                             resolved_backend: crate::embeddings::EmbeddingBackend::Sidecar,

--- a/src/daemon/app/helpers.rs
+++ b/src/daemon/app/helpers.rs
@@ -404,22 +404,28 @@ pub(crate) fn spawn_embedding_init(
     embedding_service: Arc<EmbeddingService>,
     daemon_db: Option<Arc<DaemonDatabase>>,
     watcher_pool: Arc<WatcherPool>,
+    paths: DaemonPaths,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         info!("Background embedding init task started");
 
         // Single init_result computed from whichever path is active; both
-        // branches produce the same type so the match below is unchanged.
+        // branches produce the same type so the existing match below is
+        // byte-for-byte unchanged — the (Some,Some) arm's device_info() call
+        // gates Ready on a real health round-trip, and the daemon_db model-sync
+        // runs for both paths.
         let init_result = if use_embedding_host() {
-            tokio::task::spawn_blocking(|| {
-                // Resolve the home dir inside the closure — no new param needed.
-                match DaemonPaths::try_new()
-                    .map_err(anyhow::Error::from)
-                    .and_then(|paths| crate::embedding_host_launch::connect_or_spawn_host(&paths))
-                {
+            tokio::task::spawn_blocking(move || {
+                // All blocking work — including the health round-trip triggered
+                // by accelerated()/degraded_reason() — must stay inside this
+                // closure. Calling them outside (e.g. in a .map()) would block
+                // the tokio runtime and deadlock with the async server task.
+                match crate::embedding_host_launch::connect_or_spawn_host(&paths) {
                     Ok(rpc) => {
                         let provider: Arc<dyn crate::embeddings::EmbeddingProvider> =
                             Arc::new(rpc);
+                        // accelerated() / degraded_reason() → get_cached() →
+                        // ensure_connected() → health handshake (blocking I/O).
                         let status = crate::embeddings::EmbeddingRuntimeStatus {
                             requested_backend: crate::embeddings::EmbeddingBackend::Sidecar,
                             resolved_backend: crate::embeddings::EmbeddingBackend::Sidecar,
@@ -431,7 +437,7 @@ pub(crate) fn spawn_embedding_init(
                     Err(e) => {
                         let status = crate::embeddings::EmbeddingRuntimeStatus {
                             requested_backend: crate::embeddings::EmbeddingBackend::Sidecar,
-                            resolved_backend: crate::embeddings::EmbeddingBackend::Unresolved,
+                            resolved_backend: crate::embeddings::EmbeddingBackend::Sidecar,
                             accelerated: false,
                             degraded_reason: Some(format!(
                                 "embedding-host connect/spawn failed: {e}"

--- a/src/embedding_host_launch.rs
+++ b/src/embedding_host_launch.rs
@@ -59,31 +59,29 @@ pub fn connect_or_spawn_host(paths: &DaemonPaths) -> Result<RpcEmbeddingProvider
 // Spawn timeout
 // ---------------------------------------------------------------------------
 
-/// Default wait for the host process to become live after spawning (seconds).
+/// Default wait for the host process to become live after spawning.
 ///
 /// 180 s covers a cold sidecar init: model download + venv bootstrap can
-/// take up to ~3 minutes on a slow machine.  Override via
-/// `JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS`.
-const DEFAULT_HOST_SPAWN_TIMEOUT_SECS: u64 = 180;
+/// take up to ~3 minutes on a slow machine.
+const DEFAULT_HOST_SPAWN_TIMEOUT: Duration = Duration::from_secs(180);
 
 /// Parse a raw env-var string into a spawn timeout duration.
 ///
+/// - `Some("0")` → `DEFAULT_HOST_SPAWN_TIMEOUT` (0 means "use the default").
 /// - `Some("<positive integer>")` → `Duration::from_secs(n)`.
-/// - `Some("<invalid>")` | `None` → `Duration::from_secs(default_secs)`.
+/// - `Some("<invalid>")` | `None` → `DEFAULT_HOST_SPAWN_TIMEOUT`.
 ///
-/// Module-private so the inline `#[cfg(test)]` block can unit-test it
-/// directly without touching the process environment.
-fn parse_spawn_timeout(raw: Option<String>, default_secs: u64) -> Duration {
+/// Exposed as module-private so the inline `#[cfg(test)]` block can unit-test
+/// it without touching the process environment.
+fn parse_spawn_timeout(raw: Option<String>) -> Duration {
     raw.and_then(|s| s.trim().parse::<u64>().ok())
+        .filter(|n| *n > 0)
         .map(Duration::from_secs)
-        .unwrap_or(Duration::from_secs(default_secs))
+        .unwrap_or(DEFAULT_HOST_SPAWN_TIMEOUT)
 }
 
 fn host_spawn_timeout() -> Duration {
-    parse_spawn_timeout(
-        std::env::var("JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS").ok(),
-        DEFAULT_HOST_SPAWN_TIMEOUT_SECS,
-    )
+    parse_spawn_timeout(std::env::var("JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS").ok())
 }
 
 // ---------------------------------------------------------------------------
@@ -250,16 +248,11 @@ mod tests {
     #[test]
     fn parse_spawn_timeout_values() {
         assert_eq!(
-            parse_spawn_timeout(Some("5".into()), 180),
+            parse_spawn_timeout(Some("5".into())),
             Duration::from_secs(5)
         );
-        assert_eq!(
-            parse_spawn_timeout(None, 180),
-            Duration::from_secs(180)
-        );
-        assert_eq!(
-            parse_spawn_timeout(Some("garbage".into()), 180),
-            Duration::from_secs(180)
-        );
+        assert_eq!(parse_spawn_timeout(None), DEFAULT_HOST_SPAWN_TIMEOUT);
+        // "0" is treated as "use the default" (not a valid timeout).
+        assert_eq!(parse_spawn_timeout(Some("0".into())), DEFAULT_HOST_SPAWN_TIMEOUT);
     }
 }

--- a/src/embedding_host_launch.rs
+++ b/src/embedding_host_launch.rs
@@ -59,29 +59,31 @@ pub fn connect_or_spawn_host(paths: &DaemonPaths) -> Result<RpcEmbeddingProvider
 // Spawn timeout
 // ---------------------------------------------------------------------------
 
-/// Default wait for the host process to become live after spawning.
+/// Default wait for the host process to become live after spawning (seconds).
 ///
 /// 180 s covers a cold sidecar init: model download + venv bootstrap can
-/// take up to ~3 minutes on a slow machine.
-const DEFAULT_HOST_SPAWN_TIMEOUT: Duration = Duration::from_secs(180);
+/// take up to ~3 minutes on a slow machine.  Override via
+/// `JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS`.
+const DEFAULT_HOST_SPAWN_TIMEOUT_SECS: u64 = 180;
 
 /// Parse a raw env-var string into a spawn timeout duration.
 ///
-/// - `Some("0")` → `DEFAULT_HOST_SPAWN_TIMEOUT` (0 means "use the default").
 /// - `Some("<positive integer>")` → `Duration::from_secs(n)`.
-/// - `Some("<invalid>")` | `None` → `DEFAULT_HOST_SPAWN_TIMEOUT`.
+/// - `Some("<invalid>")` | `None` → `Duration::from_secs(default_secs)`.
 ///
-/// Exposed as module-private so the inline `#[cfg(test)]` block can unit-test
-/// it without touching the process environment.
-fn parse_spawn_timeout(raw: Option<String>) -> Duration {
+/// Module-private so the inline `#[cfg(test)]` block can unit-test it
+/// directly without touching the process environment.
+fn parse_spawn_timeout(raw: Option<String>, default_secs: u64) -> Duration {
     raw.and_then(|s| s.trim().parse::<u64>().ok())
-        .filter(|n| *n > 0)
         .map(Duration::from_secs)
-        .unwrap_or(DEFAULT_HOST_SPAWN_TIMEOUT)
+        .unwrap_or(Duration::from_secs(default_secs))
 }
 
 fn host_spawn_timeout() -> Duration {
-    parse_spawn_timeout(std::env::var("JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS").ok())
+    parse_spawn_timeout(
+        std::env::var("JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS").ok(),
+        DEFAULT_HOST_SPAWN_TIMEOUT_SECS,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -248,11 +250,16 @@ mod tests {
     #[test]
     fn parse_spawn_timeout_values() {
         assert_eq!(
-            parse_spawn_timeout(Some("5".into())),
+            parse_spawn_timeout(Some("5".into()), 180),
             Duration::from_secs(5)
         );
-        assert_eq!(parse_spawn_timeout(None), DEFAULT_HOST_SPAWN_TIMEOUT);
-        // "0" is treated as "use the default" (not a valid timeout).
-        assert_eq!(parse_spawn_timeout(Some("0".into())), DEFAULT_HOST_SPAWN_TIMEOUT);
+        assert_eq!(
+            parse_spawn_timeout(None, 180),
+            Duration::from_secs(180)
+        );
+        assert_eq!(
+            parse_spawn_timeout(Some("garbage".into()), 180),
+            Duration::from_secs(180)
+        );
     }
 }

--- a/src/embedding_host_launch.rs
+++ b/src/embedding_host_launch.rs
@@ -1,0 +1,199 @@
+//! Connect-or-spawn glue for the resident embedding-host (Phase 3b, Task 6).
+//!
+//! Only the top `julie` crate knows where `julie-embedding-host` lives, so
+//! the launch logic lives here rather than in `julie-pipeline`.
+//!
+//! # Behaviour
+//!
+//! 1. **Host already live** — `is_host_live` attempts a test connection and
+//!    succeeds.  Returns an [`RpcEmbeddingProvider`] immediately.
+//! 2. **Host not live** — locates the `julie-embedding-host` sibling binary
+//!    (same strategy as `src/adapter/launcher.rs` for `julie-daemon`), spawns
+//!    it as a detached background process, then polls until the socket/pipe
+//!    accepts connections or the 10-second timeout expires.
+//!
+//! All `JULIE_HOME` and `JULIE_EMBEDDING_*` env vars are inherited by the
+//! child process — no explicit forwarding needed.
+
+use std::io;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context as _, Result};
+use tracing::{debug, info};
+
+use crate::paths::DaemonPaths;
+use julie_pipeline::embeddings::{
+    host_transport::{HostAddress, HostClientConn},
+    rpc_client::RpcEmbeddingProvider,
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Connect to the per-`$JULIE_HOME` embedding-host, spawning it if necessary.
+///
+/// Returns an [`RpcEmbeddingProvider`] whose connection is lazy: the first
+/// real embedding call triggers the health handshake.
+pub fn connect_or_spawn_host(paths: &DaemonPaths) -> Result<RpcEmbeddingProvider> {
+    let addr = HostAddress::from_paths(paths);
+
+    if is_host_live(&addr) {
+        debug!("embedding-host already live; returning client directly");
+        return Ok(RpcEmbeddingProvider::new(addr));
+    }
+
+    info!("embedding-host not live; spawning it now");
+    spawn_host_process(paths)?;
+
+    poll_for_liveness(&addr, Duration::from_secs(10))
+        .context("embedding-host did not become live after spawn")?;
+
+    Ok(RpcEmbeddingProvider::new(addr))
+}
+
+// ---------------------------------------------------------------------------
+// Liveness check
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if the host is currently accepting connections.
+///
+/// Opens a test connection and drops it immediately — the returned
+/// `RpcEmbeddingProvider` makes its own connection on first use.
+fn is_host_live(addr: &HostAddress) -> bool {
+    HostClientConn::connect(addr).is_ok()
+}
+
+/// Poll `is_host_live` with exponential back-off until the host is up or
+/// `timeout` elapses.
+fn poll_for_liveness(addr: &HostAddress, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut delay = Duration::from_millis(10);
+    let max_delay = Duration::from_millis(200);
+
+    loop {
+        if is_host_live(addr) {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(anyhow::anyhow!(
+                "embedding-host did not become live within {:?}",
+                timeout
+            ));
+        }
+        std::thread::sleep(delay);
+        delay = (delay * 2).min(max_delay);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Process spawn
+// ---------------------------------------------------------------------------
+
+/// Spawn `julie-embedding-host` as a detached background process.
+///
+/// stdin/stdout/stderr are redirected to null.  The child inherits the
+/// parent's environment, including `JULIE_HOME` and all `JULIE_EMBEDDING_*`
+/// settings.  Process-group detachment mirrors `spawn_daemon` in
+/// `src/adapter/launcher.rs`.
+fn spawn_host_process(paths: &DaemonPaths) -> io::Result<()> {
+    let host_exe = locate_embedding_host()?;
+    info!("Spawning embedding-host: {}", host_exe.display());
+
+    // Ensure the socket/lock parent dirs exist before the child tries to bind.
+    paths.ensure_dirs().map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!("ensure_dirs failed before spawning embedding-host: {e}"),
+        )
+    })?;
+
+    let mut cmd = std::process::Command::new(&host_exe);
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt as _;
+        // Detach the child via setsid() so it survives the caller's exit and
+        // is not killed by SIGHUP to the controlling terminal. EPERM means
+        // the calling process is already a session leader (test harness) —
+        // ignore it; the child is still adequately detached.
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    let err = io::Error::last_os_error();
+                    if err.raw_os_error() != Some(libc::EPERM) {
+                        return Err(err);
+                    }
+                }
+                Ok(())
+            });
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt as _;
+        // DETACHED_PROCESS         (0x0000_0008): no console
+        // CREATE_NEW_PROCESS_GROUP (0x0000_0200): immune to Ctrl+C
+        // CREATE_NO_WINDOW         (0x0800_0000): no console window flash
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
+    }
+
+    cmd.spawn()?;
+    Ok(())
+}
+
+/// Locate `julie-embedding-host` using the same two-step strategy as
+/// `locate_julie_daemon` in `src/adapter/launcher.rs`:
+///
+/// 1. Sibling of the current executable (normal plugin / installed layout).
+/// 2. `PATH` lookup as a fallback.
+fn locate_embedding_host() -> io::Result<std::path::PathBuf> {
+    let bin_name = if cfg!(windows) {
+        "julie-embedding-host.exe"
+    } else {
+        "julie-embedding-host"
+    };
+
+    // (1) Sibling of the running process's own executable.
+    if let Ok(current) = std::env::current_exe() {
+        if let Some(parent) = current.parent() {
+            let sibling = parent.join(bin_name);
+            if sibling.is_file() {
+                debug!(
+                    "Resolved {} as sibling of current exe: {}",
+                    bin_name,
+                    sibling.display()
+                );
+                return Ok(sibling);
+            }
+        }
+    }
+
+    // (2) PATH lookup — verify the file exists before returning so errors
+    //     land here with a useful message rather than in a confusing spawn().
+    if let Ok(path_env) = std::env::var("PATH") {
+        let sep = if cfg!(windows) { ';' } else { ':' };
+        for entry in path_env.split(sep) {
+            let candidate = std::path::Path::new(entry).join(bin_name);
+            if candidate.is_file() {
+                debug!("Resolved {} via PATH: {}", bin_name, candidate.display());
+                return Ok(candidate);
+            }
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        format!(
+            "{bin_name} not found next to current executable or on PATH; \
+             check installation"
+        ),
+    ))
+}

--- a/src/embedding_host_launch.rs
+++ b/src/embedding_host_launch.rs
@@ -10,7 +10,9 @@
 //! 2. **Host not live** — locates the `julie-embedding-host` sibling binary
 //!    (same strategy as `src/adapter/launcher.rs` for `julie-daemon`), spawns
 //!    it as a detached background process, then polls until the socket/pipe
-//!    accepts connections or the 10-second timeout expires.
+//!    accepts connections or the spawn timeout expires (default 180 s, override
+//!    with `JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS`).  180 s covers a cold
+//!    sidecar initialisation (model download + venv bootstrap).
 //!
 //! `JULIE_HOME` is pinned from the `paths` argument when spawning, so the child
 //! binds the same socket this function polls; the `JULIE_EMBEDDING_*` vars are
@@ -47,10 +49,30 @@ pub fn connect_or_spawn_host(paths: &DaemonPaths) -> Result<RpcEmbeddingProvider
     info!("embedding-host not live; spawning it now");
     spawn_host_process(paths)?;
 
-    poll_for_liveness(&addr, Duration::from_secs(10))
+    poll_for_liveness(&addr, spawn_timeout())
         .context("embedding-host did not become live after spawn")?;
 
     Ok(RpcEmbeddingProvider::new(addr))
+}
+
+// ---------------------------------------------------------------------------
+// Spawn timeout
+// ---------------------------------------------------------------------------
+
+/// How long `poll_for_liveness` waits after spawning the host binary.
+///
+/// Default: 180 s — enough for a cold sidecar init (model download + venv
+/// bootstrap, which can take up to ~180 s on a slow machine).
+///
+/// Override with `JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS` for tests or
+/// deployments where startup is known to be faster or slower.
+fn spawn_timeout() -> Duration {
+    const DEFAULT_SECS: u64 = 180;
+    std::env::var("JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(Duration::from_secs(DEFAULT_SECS))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/embedding_host_launch.rs
+++ b/src/embedding_host_launch.rs
@@ -12,8 +12,9 @@
 //!    it as a detached background process, then polls until the socket/pipe
 //!    accepts connections or the 10-second timeout expires.
 //!
-//! All `JULIE_HOME` and `JULIE_EMBEDDING_*` env vars are inherited by the
-//! child process — no explicit forwarding needed.
+//! `JULIE_HOME` is pinned from the `paths` argument when spawning, so the child
+//! binds the same socket this function polls; the `JULIE_EMBEDDING_*` vars are
+//! inherited from the parent environment.
 
 use std::io;
 use std::time::{Duration, Instant};
@@ -92,10 +93,12 @@ fn poll_for_liveness(addr: &HostAddress, timeout: Duration) -> Result<()> {
 
 /// Spawn `julie-embedding-host` as a detached background process.
 ///
-/// stdin/stdout/stderr are redirected to null.  The child inherits the
-/// parent's environment, including `JULIE_HOME` and all `JULIE_EMBEDDING_*`
-/// settings.  Process-group detachment mirrors `spawn_daemon` in
-/// `src/adapter/launcher.rs`.
+/// stdin/stdout/stderr are redirected to null.  `JULIE_HOME` is pinned from the
+/// `paths` argument so the spawned host binds the exact socket this function
+/// polls (even when `paths` was built via `with_home(...)` and differs from the
+/// parent's own `$JULIE_HOME`, e.g. in tests).  The `JULIE_EMBEDDING_*` vars are
+/// inherited from the parent environment.  Process-group detachment mirrors
+/// `spawn_daemon` in `src/adapter/launcher.rs`.
 fn spawn_host_process(paths: &DaemonPaths) -> io::Result<()> {
     let host_exe = locate_embedding_host()?;
     info!("Spawning embedding-host: {}", host_exe.display());
@@ -112,6 +115,11 @@ fn spawn_host_process(paths: &DaemonPaths) -> io::Result<()> {
     cmd.stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
+
+    // Pin the child's $JULIE_HOME to the caller's `paths` so the host binds the
+    // exact socket this function polls — `connect_or_spawn_host` derives the
+    // address from `paths`, not from the parent's env, and the two must agree.
+    cmd.env("JULIE_HOME", paths.julie_home());
 
     #[cfg(unix)]
     {

--- a/src/embedding_host_launch.rs
+++ b/src/embedding_host_launch.rs
@@ -49,7 +49,7 @@ pub fn connect_or_spawn_host(paths: &DaemonPaths) -> Result<RpcEmbeddingProvider
     info!("embedding-host not live; spawning it now");
     spawn_host_process(paths)?;
 
-    poll_for_liveness(&addr, spawn_timeout())
+    poll_for_liveness(&addr, host_spawn_timeout())
         .context("embedding-host did not become live after spawn")?;
 
     Ok(RpcEmbeddingProvider::new(addr))
@@ -59,20 +59,29 @@ pub fn connect_or_spawn_host(paths: &DaemonPaths) -> Result<RpcEmbeddingProvider
 // Spawn timeout
 // ---------------------------------------------------------------------------
 
-/// How long `poll_for_liveness` waits after spawning the host binary.
+/// Default wait for the host process to become live after spawning.
 ///
-/// Default: 180 s — enough for a cold sidecar init (model download + venv
-/// bootstrap, which can take up to ~180 s on a slow machine).
+/// 180 s covers a cold sidecar init: model download + venv bootstrap can
+/// take up to ~3 minutes on a slow machine.
+const DEFAULT_HOST_SPAWN_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Parse a raw env-var string into a spawn timeout duration.
 ///
-/// Override with `JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS` for tests or
-/// deployments where startup is known to be faster or slower.
-fn spawn_timeout() -> Duration {
-    const DEFAULT_SECS: u64 = 180;
-    std::env::var("JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
+/// - `Some("0")` → `DEFAULT_HOST_SPAWN_TIMEOUT` (0 means "use the default").
+/// - `Some("<positive integer>")` → `Duration::from_secs(n)`.
+/// - `Some("<invalid>")` | `None` → `DEFAULT_HOST_SPAWN_TIMEOUT`.
+///
+/// Exposed as module-private so the inline `#[cfg(test)]` block can unit-test
+/// it without touching the process environment.
+fn parse_spawn_timeout(raw: Option<String>) -> Duration {
+    raw.and_then(|s| s.trim().parse::<u64>().ok())
+        .filter(|n| *n > 0)
         .map(Duration::from_secs)
-        .unwrap_or(Duration::from_secs(DEFAULT_SECS))
+        .unwrap_or(DEFAULT_HOST_SPAWN_TIMEOUT)
+}
+
+fn host_spawn_timeout() -> Duration {
+    parse_spawn_timeout(std::env::var("JULIE_EMBEDDING_HOST_SPAWN_TIMEOUT_SECS").ok())
 }
 
 // ---------------------------------------------------------------------------
@@ -226,4 +235,24 @@ fn locate_embedding_host() -> io::Result<std::path::PathBuf> {
              check installation"
         ),
     ))
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_spawn_timeout_values() {
+        assert_eq!(
+            parse_spawn_timeout(Some("5".into())),
+            Duration::from_secs(5)
+        );
+        assert_eq!(parse_spawn_timeout(None), DEFAULT_HOST_SPAWN_TIMEOUT);
+        // "0" is treated as "use the default" (not a valid timeout).
+        assert_eq!(parse_spawn_timeout(Some("0".into())), DEFAULT_HOST_SPAWN_TIMEOUT);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub use julie_runtime::workspace;
 pub mod adapter;
 pub mod daemon;
 pub mod dashboard;
+pub mod embedding_host_launch;
 pub mod migration;
 pub mod paths;
 

--- a/src/tests/daemon/embedding_host_multi_session.rs
+++ b/src/tests/daemon/embedding_host_multi_session.rs
@@ -3,44 +3,51 @@
 //!
 //! ## Architecture
 //!
-//! Three `std::thread`s each call `connect_or_spawn_host`.  The first to reach
-//! `is_host_live → false` spawns the real `julie-embedding-host` binary; the
-//! other two also spawn it but those copies fail the **fs2 singleton lock**
-//! (acquired before the factory/sidecar starts) and exit immediately.
+//! Three `tokio::spawn` tasks each call `run_embedding_host_default` with the
+//! **same** `lock_path` and **same** `addr`.  The fs2 singleton lock uses
+//! `flock(2)` semantics (per-open-file-description, not per-process), so the
+//! three tasks' independent `OpenOptions` file descriptors **genuinely race**
+//! even within a single process:
 //!
-//! The stub sidecar (`stub_sidecar.py`) is a self-contained Python script:
-//! - Appends one `"launch\n"` line to `$STUB_COUNTER_FILE` on startup — giving
-//!   a **cross-process** launch count even though the sidecar is a separate
-//!   OS process.
-//! - Writes `os.getppid()` (= the host binary PID) to `$STUB_PPID_FILE` so
-//!   the test can `SIGTERM` the host for a clean shutdown.
-//! - Serves `health` / `embed_query` / `embed_batch` / `shutdown` using the
-//!   standard sidecar wire protocol over stdin/stdout.
+//! - **Winner** (1 task): acquires the lock → calls `make_provider` →
+//!   `create_embedding_provider()` runs → sidecar spawns → socket bound.
+//! - **Losers** (2 tasks): `try_lock_exclusive` returns `Err` immediately →
+//!   `run_embedding_host_default` returns `Err` before ever touching the
+//!   provider factory.
 //!
-//! The host binary is located via `locate_embedding_host` (sibling of the
-//! current exe, then PATH).  The test prepends `target/debug/` to `PATH` so
-//! the binary is found when running with `cargo nextest run -p julie`.
+//! A build without the lock-first refactor would call `create_embedding_provider`
+//! (and spawn the Python sidecar) in all three tasks before any lock is held,
+//! making `counter==3` and breaking the HARD GATE.
+//!
+//! Three `connect_or_spawn_host` clients then take the fast path (socket is live)
+//! and perform concurrent `embed_query` + `embed_batch` calls through the single
+//! resident host.
 //!
 //! ## HARD GATE assertions
 //!
-//! (a) All 3 clients return correctly-dimensioned vectors for both
-//!     `embed_query` and `embed_batch`.
-//! (b) The counter file contains **exactly one** line — one sidecar spawn.
-//! (c) SIGTERM to the host PID → socket removed → lock re-acquirable.
+//! (a) All 3 clients return correctly-dimensioned vectors for `embed_query` and
+//!     `embed_batch`.
+//! (b) The counter file contains **exactly one** line — one sidecar spawn despite
+//!     the three-way host race.
+//! (c) `cancel()` → exactly **1 Ok / 2 Err** from the host handles (lock
+//!     ordering), socket removed, singleton lock re-acquirable.
 
 #[cfg(all(test, unix))]
 #[cfg(feature = "embeddings-sidecar")]
 mod unix {
     use std::path::{Path, PathBuf};
+    use std::sync::Arc;
     use std::time::{Duration, Instant};
 
     use fs2::FileExt as _;
     use serial_test::serial;
+    use tokio_util::sync::CancellationToken;
 
     use crate::embedding_host_launch::connect_or_spawn_host;
     use crate::paths::DaemonPaths;
+    use julie_pipeline::embeddings::host_server::run_embedding_host_default;
+    use julie_pipeline::embeddings::host_transport::{HostAddress, HostClientConn};
     use julie_pipeline::embeddings::EmbeddingProvider;
-    use julie_pipeline::embeddings::host_transport::HostAddress;
 
     /// Dimensionality the stub sidecar advertises.
     const STUB_DIMS: usize = 4;
@@ -105,12 +112,10 @@ mod unix {
 
     /// Write a self-contained Python stub sidecar to `dir/stub_sidecar.py`.
     ///
-    /// On startup the script:
-    /// - Appends `"launch\n"` to `$STUB_COUNTER_FILE` (cross-process count).
-    /// - Writes `os.getppid()` (= host PID) to `$STUB_PPID_FILE`.
-    /// - Serves the sidecar wire protocol over stdin/stdout.
-    ///
-    /// Vectors are deterministic: `[len(text) as f32; DIMS]`.
+    /// On startup the script appends `"launch\n"` to `$STUB_COUNTER_FILE`
+    /// (cross-process sidecar launch count), then serves the sidecar wire
+    /// protocol over stdin/stdout until `shutdown` or EOF.
+    /// Vectors: `[len(text) as f32; DIMS]`.
     fn write_stub(dir: &Path) -> PathBuf {
         let script = r#"#!/usr/bin/env python3
 import json, sys, os
@@ -120,13 +125,6 @@ counter_file = os.environ.get("STUB_COUNTER_FILE", "")
 if counter_file:
     with open(counter_file, "a") as f:
         f.write("launch\n")
-        f.flush()
-
-# Write host PID (our parent) so the test can SIGTERM it.
-ppid_file = os.environ.get("STUB_PPID_FILE", "")
-if ppid_file:
-    with open(ppid_file, "w") as f:
-        f.write(str(os.getppid()))
         f.flush()
 
 DIMS = 4
@@ -177,56 +175,45 @@ while True:
     }
 
     // -----------------------------------------------------------------------
+    // Helper: poll until the host's socket accepts connections.
+    // -----------------------------------------------------------------------
+
+    fn wait_for_live(addr: &HostAddress, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if HostClientConn::connect(addr).is_ok() {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "embedding-host did not become live within {timeout:?}"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Test
     // -----------------------------------------------------------------------
 
-    /// HARD GATE: one resident embedding-host serves three concurrent sessions,
-    /// and exactly one sidecar is launched despite the three concurrent spawns.
-    #[test]
+    /// HARD GATE: three concurrent hosts race for the same singleton lock;
+    /// exactly one wins → spawns exactly one sidecar → serves three clients.
+    #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    fn one_sidecar_serves_three_sessions() {
+    async fn one_sidecar_serves_three_sessions() {
         let dir = tempfile::tempdir().expect("tempdir");
         let counter_file = dir.path().join("sidecar_launches");
-        let ppid_file = dir.path().join("host_ppid");
         let python = test_python_interpreter();
         let stub_path = write_stub(dir.path());
 
-        // -------------------------------------------------------------------
-        // PATH: prepend target/debug so locate_embedding_host finds the binary.
-        //
-        // Test exe lives at  target/debug/deps/<name>
-        //                                          ^ .parent() = deps/
-        //                                   ^ .parent() = target/debug/
-        // julie-embedding-host is at target/debug/julie-embedding-host.
-        // -------------------------------------------------------------------
-        let target_debug = std::env::current_exe()
-            .expect("current_exe")
-            .parent()
-            .expect("exe parent (deps/)")
-            .parent()
-            .expect("exe grandparent (debug/)")
-            .to_path_buf();
-        let orig_path = std::env::var_os("PATH").unwrap_or_default();
-        let new_path = std::env::join_paths(
-            std::iter::once(target_debug.clone())
-                .chain(std::env::split_paths(&orig_path)),
-        )
-        .expect("join_paths");
+        // Pin JULIE_EMBEDDING_SIDECAR_ROOT so sidecar_root_path() resolves
+        // immediately via env-var priority (called even in script-override mode).
+        let sidecar_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .map(|a| a.join("python").join("embeddings_sidecar"))
+            .find(|p| p.join("pyproject.toml").exists())
+            .expect("python/embeddings_sidecar/pyproject.toml not found");
 
-        // Pin JULIE_EMBEDDING_SIDECAR_ROOT to the source checkout so
-        // sidecar_root_path() succeeds (it's called before the script
-        // override is honoured; the root itself is unused when a script
-        // override is set but the path must resolve).
-        let sidecar_root = {
-            let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-            manifest
-                .ancestors()
-                .map(|a| a.join("python").join("embeddings_sidecar"))
-                .find(|p| p.join("pyproject.toml").exists())
-                .expect("python/embeddings_sidecar/pyproject.toml not found from CARGO_MANIFEST_DIR")
-        };
-
-        let _path_g = EnvGuard::set("PATH", &new_path);
         let _prov_g = EnvGuard::set("JULIE_EMBEDDING_PROVIDER", "sidecar");
         let _prog_g = EnvGuard::set("JULIE_EMBEDDING_SIDECAR_PROGRAM", &python);
         let _scrpt_g = EnvGuard::set(
@@ -234,145 +221,189 @@ while True:
             stub_path.to_str().expect("stub path utf8"),
         );
         let _raw_g = EnvGuard::remove("JULIE_EMBEDDING_SIDECAR_RAW_PROGRAM");
-        let _root_g =
-            EnvGuard::set("JULIE_EMBEDDING_SIDECAR_ROOT", sidecar_root.to_str().expect("utf8"));
+        let _root_g = EnvGuard::set(
+            "JULIE_EMBEDDING_SIDECAR_ROOT",
+            sidecar_root.to_str().expect("sidecar root utf8"),
+        );
         let _cnt_g = EnvGuard::set(
             "STUB_COUNTER_FILE",
             counter_file.to_str().expect("counter path utf8"),
         );
-        let _ppid_g =
-            EnvGuard::set("STUB_PPID_FILE", ppid_file.to_str().expect("ppid path utf8"));
 
         let julie_home = dir.path().join("julie_home");
         let paths = DaemonPaths::with_home(julie_home.clone());
         paths.ensure_dirs().expect("ensure_dirs");
 
-        let addr = HostAddress::from_paths(&paths);
         let lock_path = paths.embedding_host_lock();
+        let addr = HostAddress::from_paths(&paths);
         let socket_path = addr.socket_path().to_path_buf();
 
         // -------------------------------------------------------------------
-        // 1. Three concurrent sessions.
+        // 1. Start 3 concurrent run_embedding_host_default tasks, all using
+        //    the SAME lock_path and SAME addr.
         //
-        // Thread 1: is_host_live→false → spawns binary → binary wins lock →
-        //           factory spawns sidecar → host binds socket → client returns.
-        // Thread 2: is_host_live→false → spawns binary → binary fails lock →
-        //           binary exits → poll_for_liveness waits for thread-1's socket.
-        // Thread 3: same as thread 2 (or is_host_live→true if socket is already
-        //           up by then → takes the fast path directly).
+        // Each task opens its own file descriptor via OpenOptions, so the
+        // three try_lock_exclusive() calls genuinely race (flock semantics
+        // are per-open-file-description, not per-process):
+        //   - Winner  (1): lock held → make_provider → sidecar spawns → socket bound.
+        //   - Losers  (2): try_lock_exclusive fails → Err returned immediately,
+        //                  before make_provider is ever called.
+        // -------------------------------------------------------------------
+        let cancel = CancellationToken::new();
+        let mut host_handles = Vec::new();
+        for _ in 0..3 {
+            let c = cancel.clone();
+            let a = HostAddress::from_paths(&paths);
+            let l = lock_path.clone();
+            host_handles.push(tokio::spawn(async move {
+                run_embedding_host_default(&a, &l, c).await
+            }));
+        }
+
+        // 2. Wait until the winner's socket is accepting connections.
+        let addr_wait = HostAddress::from_paths(&paths);
+        tokio::task::spawn_blocking(move || {
+            wait_for_live(&addr_wait, Duration::from_secs(15))
+        })
+        .await
+        .expect("wait_for_live join");
+
+        // -------------------------------------------------------------------
+        // 3. Three concurrent sessions via connect_or_spawn_host.
+        //    Socket is already live → all three take the fast path
+        //    (is_host_live → true → RpcEmbeddingProvider::new).
+        // -------------------------------------------------------------------
+        let paths1 = paths.clone();
+        let paths2 = paths.clone();
+        let paths3 = paths.clone();
+
+        let (r1, r2, r3) = tokio::join!(
+            tokio::task::spawn_blocking(move || connect_or_spawn_host(&paths1)),
+            tokio::task::spawn_blocking(move || connect_or_spawn_host(&paths2)),
+            tokio::task::spawn_blocking(move || connect_or_spawn_host(&paths3)),
+        );
+
+        let provider1: Arc<dyn EmbeddingProvider> =
+            Arc::new(r1.expect("join 1").expect("connect 1"));
+        let provider2: Arc<dyn EmbeddingProvider> =
+            Arc::new(r2.expect("join 2").expect("connect 2"));
+        let provider3: Arc<dyn EmbeddingProvider> =
+            Arc::new(r3.expect("join 3").expect("connect 3"));
+
+        // -------------------------------------------------------------------
+        // 4. Concurrent embed_query + embed_batch from all three providers.
         // -------------------------------------------------------------------
         let t0 = Instant::now();
 
-        let handles: Vec<_> = (0..3usize)
-            .map(|i| {
-                let home = julie_home.clone();
-                std::thread::spawn(move || -> anyhow::Result<(Vec<f32>, Vec<Vec<f32>>)> {
-                    let p = DaemonPaths::with_home(home);
-                    let t1 = Instant::now();
-                    let provider = connect_or_spawn_host(&p)?;
-                    let t_connect = t1.elapsed();
+        let (h1, h2, h3) = tokio::join!(
+            tokio::task::spawn_blocking({
+                let p = Arc::clone(&provider1);
+                move || {
+                    let q = p.embed_query("hello").expect("session1 embed_query");
+                    let b = p
+                        .embed_batch(&["a".to_string(), "bb".to_string()])
+                        .expect("session1 embed_batch");
+                    (q, b)
+                }
+            }),
+            tokio::task::spawn_blocking({
+                let p = Arc::clone(&provider2);
+                move || {
+                    let q = p.embed_query("hello").expect("session2 embed_query");
+                    let b = p
+                        .embed_batch(&["a".to_string(), "bb".to_string()])
+                        .expect("session2 embed_batch");
+                    (q, b)
+                }
+            }),
+            tokio::task::spawn_blocking({
+                let p = Arc::clone(&provider3);
+                move || {
+                    let q = p.embed_query("hello").expect("session3 embed_query");
+                    let b = p
+                        .embed_batch(&["a".to_string(), "bb".to_string()])
+                        .expect("session3 embed_batch");
+                    (q, b)
+                }
+            }),
+        );
 
-                    let t2 = Instant::now();
-                    let q = provider.embed_query("hello")?;
-                    let b = provider
-                        .embed_batch(&["a".to_string(), "bb".to_string()])?;
-                    let t_embed = t2.elapsed();
+        let embed_elapsed = t0.elapsed();
 
-                    eprintln!("session {i}: connect={t_connect:?} embed={t_embed:?}");
-                    Ok((q, b))
-                })
-            })
-            .collect();
-
-        let results: Vec<(Vec<f32>, Vec<Vec<f32>>)> = handles
-            .into_iter()
-            .enumerate()
-            .map(|(i, h)| {
-                h.join()
-                    .unwrap_or_else(|_| panic!("thread {i} panicked"))
-                    .unwrap_or_else(|e| panic!("session {i} error: {e}"))
-            })
-            .collect();
-
-        eprintln!("All 3 sessions completed in {:?}", t0.elapsed());
+        let (q1, b1) = h1.expect("join h1");
+        let (q2, b2) = h2.expect("join h2");
+        let (q3, b3) = h3.expect("join h3");
 
         // -------------------------------------------------------------------
         // HARD GATE (a): all 3 clients return correctly-dimensioned vectors.
         // -------------------------------------------------------------------
-        for (i, (qv, bv)) in results.iter().enumerate() {
-            assert_eq!(qv.len(), STUB_DIMS, "session {i} embed_query dims");
-            assert_eq!(bv.len(), 2, "session {i} embed_batch count");
+        let sessions: &[(&Vec<f32>, &Vec<Vec<f32>>)] = &[(&q1, &b1), (&q2, &b2), (&q3, &b3)];
+        for (i, (qv, bv)) in sessions.iter().enumerate() {
+            let session = i + 1;
+            assert_eq!(qv.len(), STUB_DIMS, "session {session} embed_query dims");
+            assert_eq!(bv.len(), 2, "session {session} embed_batch count");
             for (j, v) in bv.iter().enumerate() {
-                assert_eq!(v.len(), STUB_DIMS, "session {i} embed_batch[{j}] dims");
+                assert_eq!(v.len(), STUB_DIMS, "session {session} embed_batch[{j}] dims");
             }
         }
 
-        // Spot-check vector values: stub returns [len(text) as f32; DIMS].
-        // "hello".len()=5, "a".len()=1, "bb".len()=2
-        for (i, (qv, bv)) in results.iter().enumerate() {
-            assert_eq!(qv[0], 5.0f32, "session {i} embed_query value");
-            assert_eq!(bv[0][0], 1.0f32, "session {i} embed_batch[0] value");
-            assert_eq!(bv[1][0], 2.0f32, "session {i} embed_batch[1] value");
+        // Spot-check values: stub returns [len(text) as f32; DIMS].
+        // "hello"=5, "a"=1, "bb"=2
+        for (i, (qv, bv)) in sessions.iter().enumerate() {
+            let s = i + 1;
+            assert_eq!(qv[0], 5.0f32, "session {s} query value");
+            assert_eq!(bv[0][0], 1.0f32, "session {s} batch[0] value");
+            assert_eq!(bv[1][0], 2.0f32, "session {s} batch[1] value");
         }
 
         // -------------------------------------------------------------------
         // HARD GATE (b): exactly one sidecar launch (lock-first correctness).
+        //
+        // A build without the lock-first fix would show counter==3, because
+        // all three host tasks would call create_embedding_provider() before
+        // any of them held the lock.
         // -------------------------------------------------------------------
-        // By the time all embed calls have returned, the sidecar is live and
-        // has written its ppid.  Poll briefly as a safety net.
-        let deadline = Instant::now() + Duration::from_secs(5);
-        let host_pid: libc::pid_t = loop {
-            if let Ok(contents) = std::fs::read_to_string(&ppid_file) {
-                let trimmed = contents.trim();
-                if !trimmed.is_empty() {
-                    break trimmed
-                        .parse::<libc::pid_t>()
-                        .expect("parse host pid from ppid file");
-                }
-            }
-            assert!(
-                Instant::now() < deadline,
-                "STUB_PPID_FILE not written within 5s"
-            );
-            std::thread::sleep(Duration::from_millis(50));
-        };
-
         let counter_contents = std::fs::read_to_string(&counter_file).unwrap_or_default();
         let launch_count = counter_contents.lines().count();
         assert_eq!(
             launch_count,
             1,
             "HARD GATE: expected exactly 1 sidecar launch, got {launch_count}.\n\
-             Counter file contents:\n{counter_contents}"
+             Counter file:\n{counter_contents}"
         );
 
         // -------------------------------------------------------------------
-        // HARD GATE (c): SIGTERM → clean shutdown → socket removed → lock free.
+        // HARD GATE (c): cancel → 1 Ok / 2 Err (lock ordering) → clean shutdown.
         // -------------------------------------------------------------------
-        assert!(
-            socket_path.exists(),
-            "socket must exist before shutdown"
-        );
+        assert!(socket_path.exists(), "socket must exist while host is running");
 
-        // SAFETY: valid pid from ppid file; SIGTERM is safe signal.
-        unsafe { libc::kill(host_pid, libc::SIGTERM) };
+        cancel.cancel();
 
-        let deadline = Instant::now() + Duration::from_secs(10);
-        loop {
-            if !socket_path.exists() {
-                break;
+        let mut ok_count = 0usize;
+        let mut err_count = 0usize;
+        for h in host_handles {
+            match h.await.expect("host task join") {
+                Ok(()) => ok_count += 1,
+                Err(e) => {
+                    let msg = e.to_string();
+                    assert!(
+                        msg.contains("lock") || msg.contains("singleton"),
+                        "loser error must mention the lock; got: {msg:?}"
+                    );
+                    err_count += 1;
+                }
             }
-            assert!(
-                Instant::now() < deadline,
-                "embedding-host did not shut down within 10s after SIGTERM"
-            );
-            std::thread::sleep(Duration::from_millis(50));
         }
+        assert_eq!(ok_count, 1, "exactly one host must win the lock");
+        assert_eq!(err_count, 2, "exactly two hosts must fail the lock");
+
+        // Winner's shutdown removes the socket.
         assert!(
             !socket_path.exists(),
             "socket file must be removed after shutdown"
         );
 
+        // The singleton lock must be re-acquirable once the winner exits.
         let lf = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
@@ -385,8 +416,8 @@ while True:
 
         eprintln!(
             "T8 PASS — 3 sessions × (embed_query + embed_batch) | \
-             total={:?} | sidecar_launches={launch_count} | host_pid={host_pid}",
-            t0.elapsed()
+             embed_elapsed={embed_elapsed:?} | sidecar_launches={launch_count} | \
+             host_ok={ok_count} host_err={err_count}"
         );
     }
 }

--- a/src/tests/daemon/embedding_host_multi_session.rs
+++ b/src/tests/daemon/embedding_host_multi_session.rs
@@ -3,47 +3,101 @@
 //!
 //! ## Architecture
 //!
-//! The host runs as an **in-process** tokio task via `run_embedding_host_default`,
-//! configured with a stub Python sidecar that:
-//! - Appends one line to a counter file (`$JULIE_SIDECAR_COUNTER_FILE`) on each
-//!   startup — giving a **cross-process** launch count even though the sidecar is a
-//!   separate OS process.
-//! - Serves `health` / `embed_query` / `embed_batch` / `shutdown` using the
-//!   standard sidecar wire protocol (same technique as `sidecar_provider.rs`
-//!   circuit-breaker test).
+//! Three `std::thread`s each call `connect_or_spawn_host`.  The first to reach
+//! `is_host_live → false` spawns the real `julie-embedding-host` binary; the
+//! other two also spawn it but those copies fail the **fs2 singleton lock**
+//! (acquired before the factory/sidecar starts) and exit immediately.
 //!
-//! Three concurrent sessions are created by calling
-//! `connect_or_spawn_host(&paths)` three times.  Because the host is already
-//! live, all three take the **fast path** (`is_host_live → true → return client
-//! directly`).  The singleton `fs2` lock is held by the in-process host; any
-//! stray spawn attempt would fail the lock and produce no extra sidecar.
+//! The stub sidecar (`stub_sidecar.py`) is a self-contained Python script:
+//! - Appends one `"launch\n"` line to `$STUB_COUNTER_FILE` on startup — giving
+//!   a **cross-process** launch count even though the sidecar is a separate
+//!   OS process.
+//! - Writes `os.getppid()` (= the host binary PID) to `$STUB_PPID_FILE` so
+//!   the test can `SIGTERM` the host for a clean shutdown.
+//! - Serves `health` / `embed_query` / `embed_batch` / `shutdown` using the
+//!   standard sidecar wire protocol over stdin/stdout.
+//!
+//! The host binary is located via `locate_embedding_host` (sibling of the
+//! current exe, then PATH).  The test prepends `target/debug/` to `PATH` so
+//! the binary is found when running with `cargo nextest run -p julie`.
 //!
 //! ## HARD GATE assertions
 //!
-//! (a) All 3 clients return correctly-dimensioned vectors for both `embed_query`
-//!     and `embed_batch`.
+//! (a) All 3 clients return correctly-dimensioned vectors for both
+//!     `embed_query` and `embed_batch`.
 //! (b) The counter file contains **exactly one** line — one sidecar spawn.
-//! (c) Cancelling the host shuts it down cleanly: socket removed, lock
-//!     re-acquirable.
+//! (c) SIGTERM to the host PID → socket removed → lock re-acquirable.
 
 #[cfg(all(test, unix))]
 #[cfg(feature = "embeddings-sidecar")]
 mod unix {
-    use std::sync::Arc;
+    use std::path::{Path, PathBuf};
     use std::time::{Duration, Instant};
 
     use fs2::FileExt as _;
-    use tokio_util::sync::CancellationToken;
+    use serial_test::serial;
 
-    use julie_core::paths::DaemonPaths;
-    use julie_pipeline::embeddings::{
-        EmbeddingProvider,
-        host_server::run_embedding_host_default,
-        host_transport::{HostAddress, HostClientConn},
-    };
+    use crate::embedding_host_launch::connect_or_spawn_host;
+    use crate::paths::DaemonPaths;
+    use julie_pipeline::embeddings::EmbeddingProvider;
+    use julie_pipeline::embeddings::host_transport::HostAddress;
 
     /// Dimensionality the stub sidecar advertises.
     const STUB_DIMS: usize = 4;
+
+    // -----------------------------------------------------------------------
+    // RAII env guard: restores the previous value on drop.
+    // SAFETY: serialised by #[serial] so no concurrent thread mutates the env.
+    // -----------------------------------------------------------------------
+
+    struct EnvGuard {
+        key: String,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value.as_ref()) };
+            Self { key: key.to_owned(), previous }
+        }
+
+        fn remove(key: &str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::remove_var(key) };
+            Self { key: key.to_owned(), previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => unsafe { std::env::set_var(&self.key, v) },
+                None => unsafe { std::env::remove_var(&self.key) },
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Python interpreter detection
+    // -----------------------------------------------------------------------
+
+    fn test_python_interpreter() -> String {
+        if let Ok(py) = std::env::var("JULIE_TEST_PYTHON") {
+            return py;
+        }
+        for candidate in &["python3", "python"] {
+            if std::process::Command::new(candidate)
+                .args(["-c", "import sys; sys.exit(0)"])
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+            {
+                return candidate.to_string();
+            }
+        }
+        panic!("no python3/python found; set JULIE_TEST_PYTHON to override");
+    }
 
     // -----------------------------------------------------------------------
     // Stub sidecar
@@ -51,20 +105,28 @@ mod unix {
 
     /// Write a self-contained Python stub sidecar to `dir/stub_sidecar.py`.
     ///
-    /// On startup the script appends `"launch\n"` to the path in
-    /// `$JULIE_SIDECAR_COUNTER_FILE`, then serves the sidecar wire protocol
-    /// over stdin/stdout until the `shutdown` method or EOF.  Vectors are
-    /// deterministic: `[len(text) as f32; DIMS]`.
-    fn write_stub_sidecar(dir: &std::path::Path) -> std::path::PathBuf {
-        use std::os::unix::fs::PermissionsExt;
-
+    /// On startup the script:
+    /// - Appends `"launch\n"` to `$STUB_COUNTER_FILE` (cross-process count).
+    /// - Writes `os.getppid()` (= host PID) to `$STUB_PPID_FILE`.
+    /// - Serves the sidecar wire protocol over stdin/stdout.
+    ///
+    /// Vectors are deterministic: `[len(text) as f32; DIMS]`.
+    fn write_stub(dir: &Path) -> PathBuf {
         let script = r#"#!/usr/bin/env python3
 import json, sys, os
 
-counter_file = os.environ.get("JULIE_SIDECAR_COUNTER_FILE", "")
+# Record this sidecar launch.
+counter_file = os.environ.get("STUB_COUNTER_FILE", "")
 if counter_file:
     with open(counter_file, "a") as f:
         f.write("launch\n")
+        f.flush()
+
+# Write host PID (our parent) so the test can SIGTERM it.
+ppid_file = os.environ.get("STUB_PPID_FILE", "")
+if ppid_file:
+    with open(ppid_file, "w") as f:
+        f.write(str(os.getppid()))
         f.flush()
 
 DIMS = 4
@@ -84,7 +146,8 @@ while True:
         resp = {"schema": "julie.embedding.sidecar", "version": 1,
                 "request_id": req_id,
                 "result": {"ready": True, "runtime": "stub",
-                           "device": "cpu", "dims": DIMS}}
+                           "device": "cpu", "dims": DIMS,
+                           "model_id": "stub-model"}}
     elif method == "embed_query":
         text = req.get("params", {}).get("text", "")
         resp = {"schema": "julie.embedding.sidecar", "version": 1,
@@ -108,33 +171,9 @@ while True:
     sys.stdout.write(json.dumps(resp) + "\n")
     sys.stdout.flush()
 "#;
-
         let path = dir.join("stub_sidecar.py");
         std::fs::write(&path, script).expect("write stub sidecar");
-        let mut perms = std::fs::metadata(&path)
-            .expect("stub metadata")
-            .permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&path, perms).expect("chmod stub");
         path
-    }
-
-    // -----------------------------------------------------------------------
-    // Helper: poll until host accepts connections
-    // -----------------------------------------------------------------------
-
-    fn wait_for_live(addr: &HostAddress, timeout: Duration) {
-        let deadline = Instant::now() + timeout;
-        loop {
-            if HostClientConn::connect(addr).is_ok() {
-                return;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "embedding-host did not become live within {timeout:?}"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -142,195 +181,198 @@ while True:
     // -----------------------------------------------------------------------
 
     /// HARD GATE: one resident embedding-host serves three concurrent sessions,
-    /// and exactly one sidecar is launched despite three concurrent clients.
-    #[tokio::test]
-    async fn one_sidecar_serves_three_sessions() {
+    /// and exactly one sidecar is launched despite the three concurrent spawns.
+    #[test]
+    #[serial]
+    fn one_sidecar_serves_three_sessions() {
         let dir = tempfile::tempdir().expect("tempdir");
         let counter_file = dir.path().join("sidecar_launches");
-        let stub_exe = write_stub_sidecar(dir.path());
+        let ppid_file = dir.path().join("host_ppid");
+        let python = test_python_interpreter();
+        let stub_path = write_stub(dir.path());
 
-        // Set env vars. cargo nextest runs each test in its own OS process, so
-        // there are no competing threads reading the environment here.
-        unsafe {
-            std::env::set_var("JULIE_EMBEDDING_PROVIDER", "sidecar");
-            std::env::set_var("JULIE_EMBEDDING_SIDECAR_PROGRAM", &stub_exe);
-            std::env::set_var("JULIE_EMBEDDING_SIDECAR_RAW_PROGRAM", "1");
-            std::env::set_var("JULIE_SIDECAR_COUNTER_FILE", &counter_file);
-        }
+        // -------------------------------------------------------------------
+        // PATH: prepend target/debug so locate_embedding_host finds the binary.
+        //
+        // Test exe lives at  target/debug/deps/<name>
+        //                                          ^ .parent() = deps/
+        //                                   ^ .parent() = target/debug/
+        // julie-embedding-host is at target/debug/julie-embedding-host.
+        // -------------------------------------------------------------------
+        let target_debug = std::env::current_exe()
+            .expect("current_exe")
+            .parent()
+            .expect("exe parent (deps/)")
+            .parent()
+            .expect("exe grandparent (debug/)")
+            .to_path_buf();
+        let orig_path = std::env::var_os("PATH").unwrap_or_default();
+        let new_path = std::env::join_paths(
+            std::iter::once(target_debug.clone())
+                .chain(std::env::split_paths(&orig_path)),
+        )
+        .expect("join_paths");
+
+        // Pin JULIE_EMBEDDING_SIDECAR_ROOT to the source checkout so
+        // sidecar_root_path() succeeds (it's called before the script
+        // override is honoured; the root itself is unused when a script
+        // override is set but the path must resolve).
+        let sidecar_root = {
+            let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            manifest
+                .ancestors()
+                .map(|a| a.join("python").join("embeddings_sidecar"))
+                .find(|p| p.join("pyproject.toml").exists())
+                .expect("python/embeddings_sidecar/pyproject.toml not found from CARGO_MANIFEST_DIR")
+        };
+
+        let _path_g = EnvGuard::set("PATH", &new_path);
+        let _prov_g = EnvGuard::set("JULIE_EMBEDDING_PROVIDER", "sidecar");
+        let _prog_g = EnvGuard::set("JULIE_EMBEDDING_SIDECAR_PROGRAM", &python);
+        let _scrpt_g = EnvGuard::set(
+            "JULIE_EMBEDDING_SIDECAR_SCRIPT",
+            stub_path.to_str().expect("stub path utf8"),
+        );
+        let _raw_g = EnvGuard::remove("JULIE_EMBEDDING_SIDECAR_RAW_PROGRAM");
+        let _root_g =
+            EnvGuard::set("JULIE_EMBEDDING_SIDECAR_ROOT", sidecar_root.to_str().expect("utf8"));
+        let _cnt_g = EnvGuard::set(
+            "STUB_COUNTER_FILE",
+            counter_file.to_str().expect("counter path utf8"),
+        );
+        let _ppid_g =
+            EnvGuard::set("STUB_PPID_FILE", ppid_file.to_str().expect("ppid path utf8"));
 
         let julie_home = dir.path().join("julie_home");
         let paths = DaemonPaths::with_home(julie_home.clone());
         paths.ensure_dirs().expect("ensure_dirs");
 
-        let lock_path = paths.embedding_host_lock();
         let addr = HostAddress::from_paths(&paths);
+        let lock_path = paths.embedding_host_lock();
+        let socket_path = addr.socket_path().to_path_buf();
 
         // -------------------------------------------------------------------
-        // 1. Start the resident host in-process.
+        // 1. Three concurrent sessions.
         //
-        // `run_embedding_host_default` acquires the singleton lock, spawns
-        // the sidecar (which writes to counter_file), runs the health probe,
-        // then enters the accept loop.  The blocking Python spawn happens on a
-        // tokio worker thread; the multi-thread runtime keeps other tasks alive.
-        // -------------------------------------------------------------------
-        let cancel = CancellationToken::new();
-        let cancel_server = cancel.clone();
-        let addr_server = HostAddress::from_paths(&paths);
-        let lock_server = lock_path.clone();
-        let host_task = tokio::spawn(async move {
-            run_embedding_host_default(&addr_server, &lock_server, cancel_server).await
-        });
-
-        // Wait until the host accepts connections (sidecar health-checked, socket bound).
-        let addr_wait = HostAddress::from_paths(&paths);
-        tokio::task::spawn_blocking(move || {
-            wait_for_live(&addr_wait, Duration::from_secs(15))
-        })
-        .await
-        .expect("wait_for_live join");
-
-        // -------------------------------------------------------------------
-        // 2. Three concurrent sessions via connect_or_spawn_host.
-        //
-        // The host is already live, so all three calls take the fast path
-        // (is_host_live → true → RpcEmbeddingProvider::new).  No additional
-        // binary spawn occurs.
-        // -------------------------------------------------------------------
-        let paths1 = paths.clone();
-        let paths2 = paths.clone();
-        let paths3 = paths.clone();
-
-        let (r1, r2, r3) = tokio::join!(
-            tokio::task::spawn_blocking(move || {
-                crate::embedding_host_launch::connect_or_spawn_host(&paths1)
-            }),
-            tokio::task::spawn_blocking(move || {
-                crate::embedding_host_launch::connect_or_spawn_host(&paths2)
-            }),
-            tokio::task::spawn_blocking(move || {
-                crate::embedding_host_launch::connect_or_spawn_host(&paths3)
-            }),
-        );
-
-        let provider1: Arc<dyn EmbeddingProvider> =
-            Arc::new(r1.expect("join 1").expect("connect 1"));
-        let provider2: Arc<dyn EmbeddingProvider> =
-            Arc::new(r2.expect("join 2").expect("connect 2"));
-        let provider3: Arc<dyn EmbeddingProvider> =
-            Arc::new(r3.expect("join 3").expect("connect 3"));
-
-        // -------------------------------------------------------------------
-        // 3. Concurrent embed_query + embed_batch from all three providers.
+        // Thread 1: is_host_live→false → spawns binary → binary wins lock →
+        //           factory spawns sidecar → host binds socket → client returns.
+        // Thread 2: is_host_live→false → spawns binary → binary fails lock →
+        //           binary exits → poll_for_liveness waits for thread-1's socket.
+        // Thread 3: same as thread 2 (or is_host_live→true if socket is already
+        //           up by then → takes the fast path directly).
         // -------------------------------------------------------------------
         let t0 = Instant::now();
 
-        let (h1, h2, h3) = tokio::join!(
-            tokio::task::spawn_blocking({
-                let p = Arc::clone(&provider1);
-                move || {
-                    let q = p.embed_query("hello").expect("session1 embed_query");
-                    let b = p
-                        .embed_batch(&["hi".to_string(), "there".to_string()])
-                        .expect("session1 embed_batch");
-                    (q, b)
-                }
-            }),
-            tokio::task::spawn_blocking({
-                let p = Arc::clone(&provider2);
-                move || {
-                    let q = p.embed_query("world!").expect("session2 embed_query");
-                    let b = p
-                        .embed_batch(&["ab".to_string(), "cde".to_string()])
-                        .expect("session2 embed_batch");
-                    (q, b)
-                }
-            }),
-            tokio::task::spawn_blocking({
-                let p = Arc::clone(&provider3);
-                move || {
-                    let q = p.embed_query("foo").expect("session3 embed_query");
-                    let b = p
-                        .embed_batch(&["x".to_string(), "yy".to_string()])
-                        .expect("session3 embed_batch");
-                    (q, b)
-                }
-            }),
-        );
+        let handles: Vec<_> = (0..3usize)
+            .map(|i| {
+                let home = julie_home.clone();
+                std::thread::spawn(move || -> anyhow::Result<(Vec<f32>, Vec<Vec<f32>>)> {
+                    let p = DaemonPaths::with_home(home);
+                    let t1 = Instant::now();
+                    let provider = connect_or_spawn_host(&p)?;
+                    let t_connect = t1.elapsed();
 
-        let embed_elapsed = t0.elapsed();
+                    let t2 = Instant::now();
+                    let q = provider.embed_query("hello")?;
+                    let b = provider
+                        .embed_batch(&["a".to_string(), "bb".to_string()])?;
+                    let t_embed = t2.elapsed();
 
-        let (q1, b1) = h1.expect("join h1");
-        let (q2, b2) = h2.expect("join h2");
-        let (q3, b3) = h3.expect("join h3");
+                    eprintln!("session {i}: connect={t_connect:?} embed={t_embed:?}");
+                    Ok((q, b))
+                })
+            })
+            .collect();
+
+        let results: Vec<(Vec<f32>, Vec<Vec<f32>>)> = handles
+            .into_iter()
+            .enumerate()
+            .map(|(i, h)| {
+                h.join()
+                    .unwrap_or_else(|_| panic!("thread {i} panicked"))
+                    .unwrap_or_else(|e| panic!("session {i} error: {e}"))
+            })
+            .collect();
+
+        eprintln!("All 3 sessions completed in {:?}", t0.elapsed());
 
         // -------------------------------------------------------------------
         // HARD GATE (a): all 3 clients return correctly-dimensioned vectors.
         // -------------------------------------------------------------------
-        let sessions: &[(&Vec<f32>, &Vec<Vec<f32>>)] = &[(&q1, &b1), (&q2, &b2), (&q3, &b3)];
-        for (i, (qv, bv)) in sessions.iter().enumerate() {
-            let session = i + 1;
-            assert_eq!(
-                qv.len(),
-                STUB_DIMS,
-                "session {session} embed_query dims mismatch"
-            );
-            assert_eq!(bv.len(), 2, "session {session} embed_batch count mismatch");
+        for (i, (qv, bv)) in results.iter().enumerate() {
+            assert_eq!(qv.len(), STUB_DIMS, "session {i} embed_query dims");
+            assert_eq!(bv.len(), 2, "session {i} embed_batch count");
             for (j, v) in bv.iter().enumerate() {
-                assert_eq!(
-                    v.len(),
-                    STUB_DIMS,
-                    "session {session} embed_batch[{j}] dims mismatch"
-                );
+                assert_eq!(v.len(), STUB_DIMS, "session {i} embed_batch[{j}] dims");
             }
         }
 
-        // Spot-check actual vector values (stub: vec = [len(text) as f32; DIMS]).
-        // Session 1: "hello".len()=5, "hi".len()=2, "there".len()=5
-        assert_eq!(q1, vec![5.0f32; STUB_DIMS], "session1 query value");
-        assert_eq!(b1[0], vec![2.0f32; STUB_DIMS], "session1 batch[0] value");
-        assert_eq!(b1[1], vec![5.0f32; STUB_DIMS], "session1 batch[1] value");
-        // Session 2: "world!".len()=6, "ab".len()=2, "cde".len()=3
-        assert_eq!(q2, vec![6.0f32; STUB_DIMS], "session2 query value");
-        assert_eq!(b2[0], vec![2.0f32; STUB_DIMS], "session2 batch[0] value");
-        assert_eq!(b2[1], vec![3.0f32; STUB_DIMS], "session2 batch[1] value");
-        // Session 3: "foo".len()=3, "x".len()=1, "yy".len()=2
-        assert_eq!(q3, vec![3.0f32; STUB_DIMS], "session3 query value");
-        assert_eq!(b3[0], vec![1.0f32; STUB_DIMS], "session3 batch[0] value");
-        assert_eq!(b3[1], vec![2.0f32; STUB_DIMS], "session3 batch[1] value");
+        // Spot-check vector values: stub returns [len(text) as f32; DIMS].
+        // "hello".len()=5, "a".len()=1, "bb".len()=2
+        for (i, (qv, bv)) in results.iter().enumerate() {
+            assert_eq!(qv[0], 5.0f32, "session {i} embed_query value");
+            assert_eq!(bv[0][0], 1.0f32, "session {i} embed_batch[0] value");
+            assert_eq!(bv[1][0], 2.0f32, "session {i} embed_batch[1] value");
+        }
 
         // -------------------------------------------------------------------
-        // HARD GATE (b): exactly one sidecar launch.
+        // HARD GATE (b): exactly one sidecar launch (lock-first correctness).
         // -------------------------------------------------------------------
+        // By the time all embed calls have returned, the sidecar is live and
+        // has written its ppid.  Poll briefly as a safety net.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let host_pid: libc::pid_t = loop {
+            if let Ok(contents) = std::fs::read_to_string(&ppid_file) {
+                let trimmed = contents.trim();
+                if !trimmed.is_empty() {
+                    break trimmed
+                        .parse::<libc::pid_t>()
+                        .expect("parse host pid from ppid file");
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "STUB_PPID_FILE not written within 5s"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        };
+
         let counter_contents = std::fs::read_to_string(&counter_file).unwrap_or_default();
         let launch_count = counter_contents.lines().count();
         assert_eq!(
             launch_count,
             1,
             "HARD GATE: expected exactly 1 sidecar launch, got {launch_count}.\n\
-             Counter file:\n{counter_contents}"
+             Counter file contents:\n{counter_contents}"
         );
 
         // -------------------------------------------------------------------
-        // HARD GATE (c): clean shutdown.
+        // HARD GATE (c): SIGTERM → clean shutdown → socket removed → lock free.
         // -------------------------------------------------------------------
-        let socket_path = addr.socket_path().to_path_buf();
         assert!(
             socket_path.exists(),
-            "socket must exist while host is running"
+            "socket must exist before shutdown"
         );
 
-        cancel.cancel();
-        host_task
-            .await
-            .expect("host task join")
-            .expect("host task completed ok");
+        // SAFETY: valid pid from ppid file; SIGTERM is safe signal.
+        unsafe { libc::kill(host_pid, libc::SIGTERM) };
 
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if !socket_path.exists() {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "embedding-host did not shut down within 10s after SIGTERM"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
         assert!(
             !socket_path.exists(),
             "socket file must be removed after shutdown"
         );
 
-        // The singleton lock must be re-acquirable after shutdown.
         let lf = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
@@ -341,18 +383,10 @@ while True:
             "singleton lock must be acquirable after shutdown"
         );
 
-        // Report-only: per-call latency.
-        println!(
+        eprintln!(
             "T8 PASS — 3 sessions × (embed_query + embed_batch) | \
-             embed_elapsed={embed_elapsed:?} | sidecar_launches={launch_count}"
+             total={:?} | sidecar_launches={launch_count} | host_pid={host_pid}",
+            t0.elapsed()
         );
-
-        // Restore env (good hygiene; nextest uses fresh processes anyway).
-        unsafe {
-            std::env::remove_var("JULIE_EMBEDDING_PROVIDER");
-            std::env::remove_var("JULIE_EMBEDDING_SIDECAR_PROGRAM");
-            std::env::remove_var("JULIE_EMBEDDING_SIDECAR_RAW_PROGRAM");
-            std::env::remove_var("JULIE_SIDECAR_COUNTER_FILE");
-        }
     }
 }

--- a/src/tests/daemon/embedding_host_multi_session.rs
+++ b/src/tests/daemon/embedding_host_multi_session.rs
@@ -1,0 +1,8 @@
+//! Acceptance test (Phase 3b, Task 8, HARD GATE): one resident embedding-host
+//! serves three concurrent sessions backed by exactly one sidecar.
+//!
+//! IMPLEMENTED IN TASK 8. The lead owns `src/tests/daemon/mod.rs` registration;
+//! fill this file only. Prove: 3 concurrent `connect_or_spawn_host` sessions
+//! against one $JULIE_HOME share a single host (singleton lock) and a single
+//! sidecar (counted cross-process via a stub-sidecar counter file), and all
+//! three embed successfully.

--- a/src/tests/daemon/embedding_host_multi_session.rs
+++ b/src/tests/daemon/embedding_host_multi_session.rs
@@ -1,8 +1,358 @@
 //! Acceptance test (Phase 3b, Task 8, HARD GATE): one resident embedding-host
 //! serves three concurrent sessions backed by exactly one sidecar.
 //!
-//! IMPLEMENTED IN TASK 8. The lead owns `src/tests/daemon/mod.rs` registration;
-//! fill this file only. Prove: 3 concurrent `connect_or_spawn_host` sessions
-//! against one $JULIE_HOME share a single host (singleton lock) and a single
-//! sidecar (counted cross-process via a stub-sidecar counter file), and all
-//! three embed successfully.
+//! ## Architecture
+//!
+//! The host runs as an **in-process** tokio task via `run_embedding_host_default`,
+//! configured with a stub Python sidecar that:
+//! - Appends one line to a counter file (`$JULIE_SIDECAR_COUNTER_FILE`) on each
+//!   startup — giving a **cross-process** launch count even though the sidecar is a
+//!   separate OS process.
+//! - Serves `health` / `embed_query` / `embed_batch` / `shutdown` using the
+//!   standard sidecar wire protocol (same technique as `sidecar_provider.rs`
+//!   circuit-breaker test).
+//!
+//! Three concurrent sessions are created by calling
+//! `connect_or_spawn_host(&paths)` three times.  Because the host is already
+//! live, all three take the **fast path** (`is_host_live → true → return client
+//! directly`).  The singleton `fs2` lock is held by the in-process host; any
+//! stray spawn attempt would fail the lock and produce no extra sidecar.
+//!
+//! ## HARD GATE assertions
+//!
+//! (a) All 3 clients return correctly-dimensioned vectors for both `embed_query`
+//!     and `embed_batch`.
+//! (b) The counter file contains **exactly one** line — one sidecar spawn.
+//! (c) Cancelling the host shuts it down cleanly: socket removed, lock
+//!     re-acquirable.
+
+#[cfg(all(test, unix))]
+#[cfg(feature = "embeddings-sidecar")]
+mod unix {
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    use fs2::FileExt as _;
+    use tokio_util::sync::CancellationToken;
+
+    use julie_core::paths::DaemonPaths;
+    use julie_pipeline::embeddings::{
+        EmbeddingProvider,
+        host_server::run_embedding_host_default,
+        host_transport::{HostAddress, HostClientConn},
+    };
+
+    /// Dimensionality the stub sidecar advertises.
+    const STUB_DIMS: usize = 4;
+
+    // -----------------------------------------------------------------------
+    // Stub sidecar
+    // -----------------------------------------------------------------------
+
+    /// Write a self-contained Python stub sidecar to `dir/stub_sidecar.py`.
+    ///
+    /// On startup the script appends `"launch\n"` to the path in
+    /// `$JULIE_SIDECAR_COUNTER_FILE`, then serves the sidecar wire protocol
+    /// over stdin/stdout until the `shutdown` method or EOF.  Vectors are
+    /// deterministic: `[len(text) as f32; DIMS]`.
+    fn write_stub_sidecar(dir: &std::path::Path) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let script = r#"#!/usr/bin/env python3
+import json, sys, os
+
+counter_file = os.environ.get("JULIE_SIDECAR_COUNTER_FILE", "")
+if counter_file:
+    with open(counter_file, "a") as f:
+        f.write("launch\n")
+        f.flush()
+
+DIMS = 4
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+    line = line.strip()
+    if not line:
+        continue
+    req = json.loads(line)
+    method = req.get("method", "")
+    req_id = req.get("request_id", "")
+
+    if method == "health":
+        resp = {"schema": "julie.embedding.sidecar", "version": 1,
+                "request_id": req_id,
+                "result": {"ready": True, "runtime": "stub",
+                           "device": "cpu", "dims": DIMS}}
+    elif method == "embed_query":
+        text = req.get("params", {}).get("text", "")
+        resp = {"schema": "julie.embedding.sidecar", "version": 1,
+                "request_id": req_id,
+                "result": {"dims": DIMS, "vector": [float(len(text))] * DIMS}}
+    elif method == "embed_batch":
+        texts = req.get("params", {}).get("texts", [])
+        resp = {"schema": "julie.embedding.sidecar", "version": 1,
+                "request_id": req_id,
+                "result": {"dims": DIMS,
+                           "vectors": [[float(len(t))] * DIMS for t in texts]}}
+    elif method == "shutdown":
+        resp = {"schema": "julie.embedding.sidecar", "version": 1,
+                "request_id": req_id, "result": {"stopping": True}}
+        sys.stdout.write(json.dumps(resp) + "\n")
+        sys.stdout.flush()
+        break
+    else:
+        continue
+
+    sys.stdout.write(json.dumps(resp) + "\n")
+    sys.stdout.flush()
+"#;
+
+        let path = dir.join("stub_sidecar.py");
+        std::fs::write(&path, script).expect("write stub sidecar");
+        let mut perms = std::fs::metadata(&path)
+            .expect("stub metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).expect("chmod stub");
+        path
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper: poll until host accepts connections
+    // -----------------------------------------------------------------------
+
+    fn wait_for_live(addr: &HostAddress, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if HostClientConn::connect(addr).is_ok() {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "embedding-host did not become live within {timeout:?}"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test
+    // -----------------------------------------------------------------------
+
+    /// HARD GATE: one resident embedding-host serves three concurrent sessions,
+    /// and exactly one sidecar is launched despite three concurrent clients.
+    #[tokio::test]
+    async fn one_sidecar_serves_three_sessions() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let counter_file = dir.path().join("sidecar_launches");
+        let stub_exe = write_stub_sidecar(dir.path());
+
+        // Set env vars. cargo nextest runs each test in its own OS process, so
+        // there are no competing threads reading the environment here.
+        unsafe {
+            std::env::set_var("JULIE_EMBEDDING_PROVIDER", "sidecar");
+            std::env::set_var("JULIE_EMBEDDING_SIDECAR_PROGRAM", &stub_exe);
+            std::env::set_var("JULIE_EMBEDDING_SIDECAR_RAW_PROGRAM", "1");
+            std::env::set_var("JULIE_SIDECAR_COUNTER_FILE", &counter_file);
+        }
+
+        let julie_home = dir.path().join("julie_home");
+        let paths = DaemonPaths::with_home(julie_home.clone());
+        paths.ensure_dirs().expect("ensure_dirs");
+
+        let lock_path = paths.embedding_host_lock();
+        let addr = HostAddress::from_paths(&paths);
+
+        // -------------------------------------------------------------------
+        // 1. Start the resident host in-process.
+        //
+        // `run_embedding_host_default` acquires the singleton lock, spawns
+        // the sidecar (which writes to counter_file), runs the health probe,
+        // then enters the accept loop.  The blocking Python spawn happens on a
+        // tokio worker thread; the multi-thread runtime keeps other tasks alive.
+        // -------------------------------------------------------------------
+        let cancel = CancellationToken::new();
+        let cancel_server = cancel.clone();
+        let addr_server = HostAddress::from_paths(&paths);
+        let lock_server = lock_path.clone();
+        let host_task = tokio::spawn(async move {
+            run_embedding_host_default(&addr_server, &lock_server, cancel_server).await
+        });
+
+        // Wait until the host accepts connections (sidecar health-checked, socket bound).
+        let addr_wait = HostAddress::from_paths(&paths);
+        tokio::task::spawn_blocking(move || {
+            wait_for_live(&addr_wait, Duration::from_secs(15))
+        })
+        .await
+        .expect("wait_for_live join");
+
+        // -------------------------------------------------------------------
+        // 2. Three concurrent sessions via connect_or_spawn_host.
+        //
+        // The host is already live, so all three calls take the fast path
+        // (is_host_live → true → RpcEmbeddingProvider::new).  No additional
+        // binary spawn occurs.
+        // -------------------------------------------------------------------
+        let paths1 = paths.clone();
+        let paths2 = paths.clone();
+        let paths3 = paths.clone();
+
+        let (r1, r2, r3) = tokio::join!(
+            tokio::task::spawn_blocking(move || {
+                crate::embedding_host_launch::connect_or_spawn_host(&paths1)
+            }),
+            tokio::task::spawn_blocking(move || {
+                crate::embedding_host_launch::connect_or_spawn_host(&paths2)
+            }),
+            tokio::task::spawn_blocking(move || {
+                crate::embedding_host_launch::connect_or_spawn_host(&paths3)
+            }),
+        );
+
+        let provider1: Arc<dyn EmbeddingProvider> =
+            Arc::new(r1.expect("join 1").expect("connect 1"));
+        let provider2: Arc<dyn EmbeddingProvider> =
+            Arc::new(r2.expect("join 2").expect("connect 2"));
+        let provider3: Arc<dyn EmbeddingProvider> =
+            Arc::new(r3.expect("join 3").expect("connect 3"));
+
+        // -------------------------------------------------------------------
+        // 3. Concurrent embed_query + embed_batch from all three providers.
+        // -------------------------------------------------------------------
+        let t0 = Instant::now();
+
+        let (h1, h2, h3) = tokio::join!(
+            tokio::task::spawn_blocking({
+                let p = Arc::clone(&provider1);
+                move || {
+                    let q = p.embed_query("hello").expect("session1 embed_query");
+                    let b = p
+                        .embed_batch(&["hi".to_string(), "there".to_string()])
+                        .expect("session1 embed_batch");
+                    (q, b)
+                }
+            }),
+            tokio::task::spawn_blocking({
+                let p = Arc::clone(&provider2);
+                move || {
+                    let q = p.embed_query("world!").expect("session2 embed_query");
+                    let b = p
+                        .embed_batch(&["ab".to_string(), "cde".to_string()])
+                        .expect("session2 embed_batch");
+                    (q, b)
+                }
+            }),
+            tokio::task::spawn_blocking({
+                let p = Arc::clone(&provider3);
+                move || {
+                    let q = p.embed_query("foo").expect("session3 embed_query");
+                    let b = p
+                        .embed_batch(&["x".to_string(), "yy".to_string()])
+                        .expect("session3 embed_batch");
+                    (q, b)
+                }
+            }),
+        );
+
+        let embed_elapsed = t0.elapsed();
+
+        let (q1, b1) = h1.expect("join h1");
+        let (q2, b2) = h2.expect("join h2");
+        let (q3, b3) = h3.expect("join h3");
+
+        // -------------------------------------------------------------------
+        // HARD GATE (a): all 3 clients return correctly-dimensioned vectors.
+        // -------------------------------------------------------------------
+        let sessions: &[(&Vec<f32>, &Vec<Vec<f32>>)] = &[(&q1, &b1), (&q2, &b2), (&q3, &b3)];
+        for (i, (qv, bv)) in sessions.iter().enumerate() {
+            let session = i + 1;
+            assert_eq!(
+                qv.len(),
+                STUB_DIMS,
+                "session {session} embed_query dims mismatch"
+            );
+            assert_eq!(bv.len(), 2, "session {session} embed_batch count mismatch");
+            for (j, v) in bv.iter().enumerate() {
+                assert_eq!(
+                    v.len(),
+                    STUB_DIMS,
+                    "session {session} embed_batch[{j}] dims mismatch"
+                );
+            }
+        }
+
+        // Spot-check actual vector values (stub: vec = [len(text) as f32; DIMS]).
+        // Session 1: "hello".len()=5, "hi".len()=2, "there".len()=5
+        assert_eq!(q1, vec![5.0f32; STUB_DIMS], "session1 query value");
+        assert_eq!(b1[0], vec![2.0f32; STUB_DIMS], "session1 batch[0] value");
+        assert_eq!(b1[1], vec![5.0f32; STUB_DIMS], "session1 batch[1] value");
+        // Session 2: "world!".len()=6, "ab".len()=2, "cde".len()=3
+        assert_eq!(q2, vec![6.0f32; STUB_DIMS], "session2 query value");
+        assert_eq!(b2[0], vec![2.0f32; STUB_DIMS], "session2 batch[0] value");
+        assert_eq!(b2[1], vec![3.0f32; STUB_DIMS], "session2 batch[1] value");
+        // Session 3: "foo".len()=3, "x".len()=1, "yy".len()=2
+        assert_eq!(q3, vec![3.0f32; STUB_DIMS], "session3 query value");
+        assert_eq!(b3[0], vec![1.0f32; STUB_DIMS], "session3 batch[0] value");
+        assert_eq!(b3[1], vec![2.0f32; STUB_DIMS], "session3 batch[1] value");
+
+        // -------------------------------------------------------------------
+        // HARD GATE (b): exactly one sidecar launch.
+        // -------------------------------------------------------------------
+        let counter_contents = std::fs::read_to_string(&counter_file).unwrap_or_default();
+        let launch_count = counter_contents.lines().count();
+        assert_eq!(
+            launch_count,
+            1,
+            "HARD GATE: expected exactly 1 sidecar launch, got {launch_count}.\n\
+             Counter file:\n{counter_contents}"
+        );
+
+        // -------------------------------------------------------------------
+        // HARD GATE (c): clean shutdown.
+        // -------------------------------------------------------------------
+        let socket_path = addr.socket_path().to_path_buf();
+        assert!(
+            socket_path.exists(),
+            "socket must exist while host is running"
+        );
+
+        cancel.cancel();
+        host_task
+            .await
+            .expect("host task join")
+            .expect("host task completed ok");
+
+        assert!(
+            !socket_path.exists(),
+            "socket file must be removed after shutdown"
+        );
+
+        // The singleton lock must be re-acquirable after shutdown.
+        let lf = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(&lock_path)
+            .expect("open lock file after shutdown");
+        assert!(
+            lf.try_lock_exclusive().is_ok(),
+            "singleton lock must be acquirable after shutdown"
+        );
+
+        // Report-only: per-call latency.
+        println!(
+            "T8 PASS — 3 sessions × (embed_query + embed_batch) | \
+             embed_elapsed={embed_elapsed:?} | sidecar_launches={launch_count}"
+        );
+
+        // Restore env (good hygiene; nextest uses fresh processes anyway).
+        unsafe {
+            std::env::remove_var("JULIE_EMBEDDING_PROVIDER");
+            std::env::remove_var("JULIE_EMBEDDING_SIDECAR_PROGRAM");
+            std::env::remove_var("JULIE_EMBEDDING_SIDECAR_RAW_PROGRAM");
+            std::env::remove_var("JULIE_SIDECAR_COUNTER_FILE");
+        }
+    }
+}

--- a/src/tests/daemon/embedding_host_optin.rs
+++ b/src/tests/daemon/embedding_host_optin.rs
@@ -178,7 +178,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     #[serial(embedding_host_optin_env)]
-    async fn host_path_publishes_unavailable_when_host_not_ready() {
+    async fn host_unavailable_when_health_not_ready() {
         use julie_pipeline::embeddings::host_transport::{HostAddress, HostListener};
         use julie_pipeline::embeddings::{
             HealthResult, ResponseEnvelope, SIDECAR_PROTOCOL_SCHEMA, SIDECAR_PROTOCOL_VERSION,
@@ -232,10 +232,16 @@ mod tests {
 
         let outcome = svc.wait_until_settled(Duration::from_secs(5)).await;
 
-        assert!(
-            matches!(outcome, EmbeddingServiceSettled::Unavailable { .. }),
-            "expected Unavailable when host reports ready=false",
-        );
+        match &outcome {
+            EmbeddingServiceSettled::Unavailable { reason, .. } => {
+                assert!(
+                    reason.contains("embedding-host health handshake failed")
+                        || reason.contains("not ready"),
+                    "reason should mention the health failure; got: {reason:?}",
+                );
+            }
+            _ => panic!("expected Unavailable when host reports ready=false"),
+        }
         server.await.expect("fake host server task");
     }
 }

--- a/src/tests/daemon/embedding_host_optin.rs
+++ b/src/tests/daemon/embedding_host_optin.rs
@@ -1,19 +1,25 @@
 //! Tests for the opt-in embedding-host coexistence wiring (Phase 3b, Task 7).
 //!
-//! These tests drive `use_embedding_host()` directly — a unit-level check that
-//! proves "env unset → existing `create_embedding_provider` path is selected,
-//! host path only when truthy." The heavy integration (shared sidecar across
-//! sessions) is covered by T8.
+//! Gate invariant: env unset → `create_embedding_provider` path (incl.
+//! model-sync); env truthy → host path, `Ready` only after a real health
+//! handshake (because the existing `(Some,Some)` arm calls `device_info()`
+//! which triggers the RPC client's lazy health round-trip).
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
     use serial_test::serial;
 
-    use crate::daemon::app::use_embedding_host;
+    use crate::daemon::app::spawn_embedding_init;
+    use crate::daemon::embedding_service::{EmbeddingService, EmbeddingServiceSettled};
+    use crate::daemon::watcher_pool::WatcherPool;
+    use crate::paths::DaemonPaths;
 
     // -----------------------------------------------------------------------
-    // EnvGuard — sets/restores an env var on drop (SAFETY: serialised by
-    // #[serial] so no other thread touches the var concurrently).
+    // EnvGuard — sets/restores an env var on drop.
+    // SAFETY: serialised by #[serial] so no concurrent thread touches the var.
     // -----------------------------------------------------------------------
 
     fn with_env(key: &str, value: &str) -> EnvGuard {
@@ -42,48 +48,124 @@ mod tests {
         }
     }
 
-    const KEY: &str = "JULIE_EMBEDDING_USE_HOST";
-
-    // -----------------------------------------------------------------------
-    // Test 1: env unset → false (existing create_embedding_provider path)
-    // -----------------------------------------------------------------------
-
-    #[test]
-    #[serial(embedding_host_optin_env)]
-    fn false_when_env_unset() {
-        let _guard = without_env(KEY);
-        assert!(!use_embedding_host(), "expected false when {KEY} is unset");
+    fn temp_paths() -> (tempfile::TempDir, DaemonPaths) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = DaemonPaths::with_home(dir.path().to_path_buf());
+        (dir, paths)
     }
 
     // -----------------------------------------------------------------------
-    // Test 2: truthy values → true (host path selected)
+    // Test 1: env truthy → host path → Ready (after real health handshake)
+    // The fake server answers the health request so device_info() can
+    // populate the RPC client's OnceLock — proving the host responds before
+    // Ready is published.
     // -----------------------------------------------------------------------
 
-    #[test]
+    #[cfg(unix)]
+    #[tokio::test]
     #[serial(embedding_host_optin_env)]
-    fn true_for_all_truthy_values() {
-        for value in &["1", "true", "on", "TRUE", "On", "ON"] {
-            let _guard = with_env(KEY, value);
-            assert!(
-                use_embedding_host(),
-                "expected true for {KEY}={value:?}"
-            );
-        }
+    async fn host_path_taken_when_env_set() {
+        use julie_pipeline::embeddings::host_transport::{HostAddress, HostListener};
+        use julie_pipeline::embeddings::{
+            HealthResult, ResponseEnvelope, SIDECAR_PROTOCOL_SCHEMA, SIDECAR_PROTOCOL_VERSION,
+        };
+
+        let (_dir, paths) = temp_paths();
+        let addr = HostAddress::from_paths(&paths);
+        let listener = HostListener::bind(&addr).await.expect("bind listener");
+
+        // Fake host: serve the is_host_live probe (connect+drop) then answer
+        // the real health handshake that RpcEmbeddingProvider issues on first
+        // use (triggered by device_info() in the (Some,Some) match arm).
+        let server = tokio::spawn(async move {
+            // Connection 1: is_host_live probe — client connects then drops.
+            let _ = listener.accept().await.expect("accept probe");
+
+            // Connection 2: RpcEmbeddingProvider health round-trip.
+            let mut conn = listener.accept().await.expect("accept health conn");
+            let line = conn
+                .read_line()
+                .await
+                .expect("read health req")
+                .expect("health req line");
+            let req: serde_json::Value =
+                serde_json::from_str(&line).expect("parse health request");
+            let request_id = req["request_id"].as_str().unwrap_or("1").to_string();
+
+            let resp = serde_json::to_string(&ResponseEnvelope {
+                schema: SIDECAR_PROTOCOL_SCHEMA.to_string(),
+                version: SIDECAR_PROTOCOL_VERSION,
+                request_id,
+                result: Some(HealthResult {
+                    ready: true,
+                    dims: Some(4),
+                    device: Some("cpu".to_string()),
+                    runtime: Some("fake".to_string()),
+                    model_id: Some("fake-model".to_string()),
+                    resolved_backend: None,
+                    accelerated: Some(false),
+                    degraded_reason: None,
+                    capabilities: None,
+                    load_policy: None,
+                }),
+                error: None,
+            })
+            .expect("serialize health response");
+            conn.write_line(&resp).await.expect("write health response");
+        });
+
+        let _guard_host = with_env("JULIE_EMBEDDING_USE_HOST", "1");
+
+        let svc = Arc::new(EmbeddingService::initializing());
+        let pool = Arc::new(WatcherPool::new(Duration::from_secs(30)));
+        let _handle = spawn_embedding_init(Arc::clone(&svc), None, Arc::clone(&pool), paths);
+
+        let outcome = svc.wait_until_settled(Duration::from_secs(5)).await;
+
+        assert!(
+            matches!(outcome, EmbeddingServiceSettled::Ready { .. }),
+            "expected Ready when JULIE_EMBEDDING_USE_HOST=1 and host answers health",
+        );
+        server.await.expect("fake host server task");
     }
 
     // -----------------------------------------------------------------------
-    // Test 3: falsy / unrecognised values → false
+    // Test 2: env unset → existing create_embedding_provider path
+    // Asserts Unavailable AND the reason is from create_embedding_provider,
+    // not the host path (i.e. reason does NOT contain "embedding-host").
     // -----------------------------------------------------------------------
 
-    #[test]
+    #[tokio::test]
     #[serial(embedding_host_optin_env)]
-    fn false_for_falsy_and_unrecognised_values() {
-        for value in &["0", "false", "off", "no", "", "yes", "maybe"] {
-            let _guard = with_env(KEY, value);
-            assert!(
-                !use_embedding_host(),
-                "expected false for {KEY}={value:?}"
-            );
+    async fn existing_path_taken_when_env_unset() {
+        let (_dir, paths) = temp_paths();
+
+        let _guard_host = without_env("JULIE_EMBEDDING_USE_HOST");
+        // Disable the sidecar so create_embedding_provider returns quickly
+        // with (None, _) instead of spawning a real Python process.
+        let _guard_provider = with_env("JULIE_EMBEDDING_PROVIDER", "none");
+
+        let svc = Arc::new(EmbeddingService::initializing());
+        let pool = Arc::new(WatcherPool::new(Duration::from_secs(30)));
+        let _handle = spawn_embedding_init(Arc::clone(&svc), None, Arc::clone(&pool), paths);
+
+        let outcome = svc.wait_until_settled(Duration::from_secs(5)).await;
+
+        // Must be Unavailable (provider=none disables embeddings).
+        // Reason must NOT mention "embedding-host" — that's the host path's
+        // reason string, so its absence positively distinguishes the branch.
+        match outcome {
+            EmbeddingServiceSettled::Unavailable { reason, .. } => {
+                assert!(
+                    !reason.contains("embedding-host"),
+                    "reason should come from create_embedding_provider, not the host path; \
+                     got: {reason:?}",
+                );
+            }
+            _ => panic!(
+                "expected Unavailable when JULIE_EMBEDDING_USE_HOST is unset \
+                 and JULIE_EMBEDDING_PROVIDER=none, got a different outcome"
+            ),
         }
     }
 }

--- a/src/tests/daemon/embedding_host_optin.rs
+++ b/src/tests/daemon/embedding_host_optin.rs
@@ -1,6 +1,97 @@
 //! Tests for the opt-in embedding-host coexistence wiring (Phase 3b, Task 7).
 //!
-//! IMPLEMENTED IN TASK 7. The lead owns `src/tests/daemon/mod.rs` registration;
-//! fill this file only. Verify that `spawn_embedding_init` only takes the host
-//! path when `JULIE_EMBEDDING_USE_HOST` is truthy, and is byte-for-byte the
-//! existing `create_embedding_provider` path when the env is unset.
+//! Verifies that `spawn_embedding_init` takes the host path when
+//! `JULIE_EMBEDDING_USE_HOST` is truthy, and falls through to the existing
+//! `create_embedding_provider` path when the env var is absent.
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use julie_pipeline::embeddings::host_transport::{HostAddress, HostListener};
+
+    use crate::daemon::app::spawn_embedding_init;
+    use crate::daemon::embedding_service::{EmbeddingService, EmbeddingServiceSettled};
+    use crate::daemon::watcher_pool::WatcherPool;
+    use crate::paths::DaemonPaths;
+
+    // Serialize env-var mutation so the two tests cannot clobber each other
+    // when the test runner executes them on the same thread pool.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn temp_paths() -> (tempfile::TempDir, DaemonPaths) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = DaemonPaths::with_home(dir.path().to_path_buf());
+        (dir, paths)
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 1: JULIE_EMBEDDING_USE_HOST=1  →  publish_ready (host path)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn host_path_taken_when_env_set() {
+        let (_dir, paths) = temp_paths();
+        let addr = HostAddress::from_paths(&paths);
+
+        // Bind the listener so is_host_live() inside connect_or_spawn_host
+        // succeeds: it does a plain connect() which only needs the socket to
+        // be accepting connections.
+        let _listener = HostListener::bind(&addr).await.expect("bind listener");
+
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::set_var("JULIE_EMBEDDING_USE_HOST", "1") };
+
+        let svc = Arc::new(EmbeddingService::initializing());
+        let pool = Arc::new(WatcherPool::new(Duration::from_secs(30)));
+
+        let _handle =
+            spawn_embedding_init(Arc::clone(&svc), None, Arc::clone(&pool), paths);
+
+        let outcome = svc.wait_until_settled(Duration::from_secs(5)).await;
+
+        // Clean up before the assertion so the env var is always removed.
+        unsafe { std::env::remove_var("JULIE_EMBEDDING_USE_HOST") };
+
+        assert!(
+            matches!(outcome, EmbeddingServiceSettled::Ready { .. }),
+            "expected Ready when JULIE_EMBEDDING_USE_HOST=1",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 2: JULIE_EMBEDDING_USE_HOST unset  →  existing create_embedding_provider path
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn existing_path_taken_when_env_unset() {
+        let (_dir, paths) = temp_paths();
+
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            // Ensure the host opt-in is NOT set.
+            std::env::remove_var("JULIE_EMBEDDING_USE_HOST");
+            // Disable the sidecar so create_embedding_provider returns quickly
+            // with (None, _) instead of trying to spawn a real Python process.
+            std::env::set_var("JULIE_EMBEDDING_PROVIDER", "none");
+        }
+
+        let svc = Arc::new(EmbeddingService::initializing());
+        let pool = Arc::new(WatcherPool::new(Duration::from_secs(30)));
+
+        let _handle =
+            spawn_embedding_init(Arc::clone(&svc), None, Arc::clone(&pool), paths);
+
+        let outcome = svc.wait_until_settled(Duration::from_secs(5)).await;
+
+        unsafe { std::env::remove_var("JULIE_EMBEDDING_PROVIDER") };
+
+        // create_embedding_provider with JULIE_EMBEDDING_PROVIDER=none publishes
+        // Unavailable, confirming the host branch was NOT entered.
+        assert!(
+            matches!(outcome, EmbeddingServiceSettled::Unavailable { .. }),
+            "expected Unavailable when JULIE_EMBEDDING_USE_HOST is unset and provider=none",
+        );
+    }
+}

--- a/src/tests/daemon/embedding_host_optin.rs
+++ b/src/tests/daemon/embedding_host_optin.rs
@@ -168,4 +168,74 @@ mod tests {
             ),
         }
     }
+
+    // -----------------------------------------------------------------------
+    // Test 3: host answers health with ready=false → daemon settles Unavailable
+    // Proves that ensure_ready() surfaces ready=false before the provider is
+    // promoted to Arc<dyn EmbeddingProvider>, preventing a spurious Ready.
+    // -----------------------------------------------------------------------
+
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial(embedding_host_optin_env)]
+    async fn host_path_publishes_unavailable_when_host_not_ready() {
+        use julie_pipeline::embeddings::host_transport::{HostAddress, HostListener};
+        use julie_pipeline::embeddings::{
+            HealthResult, ResponseEnvelope, SIDECAR_PROTOCOL_SCHEMA, SIDECAR_PROTOCOL_VERSION,
+        };
+
+        let (_dir, paths) = temp_paths();
+        let addr = HostAddress::from_paths(&paths);
+        let listener = HostListener::bind(&addr).await.expect("bind listener");
+
+        // Fake host: probe + health with ready=false (host still warming up).
+        let server = tokio::spawn(async move {
+            let _ = listener.accept().await.expect("accept probe");
+
+            let mut conn = listener.accept().await.expect("accept health conn");
+            let line = conn
+                .read_line()
+                .await
+                .expect("read health req")
+                .expect("health req line");
+            let req: serde_json::Value =
+                serde_json::from_str(&line).expect("parse health request");
+            let request_id = req["request_id"].as_str().unwrap_or("1").to_string();
+
+            let resp = serde_json::to_string(&ResponseEnvelope {
+                schema: SIDECAR_PROTOCOL_SCHEMA.to_string(),
+                version: SIDECAR_PROTOCOL_VERSION,
+                request_id,
+                result: Some(HealthResult {
+                    ready: false, // <-- host not ready yet
+                    dims: None,
+                    device: None,
+                    runtime: None,
+                    model_id: None,
+                    resolved_backend: None,
+                    accelerated: None,
+                    degraded_reason: Some("model still loading".to_string()),
+                    capabilities: None,
+                    load_policy: None,
+                }),
+                error: None,
+            })
+            .expect("serialize health response");
+            conn.write_line(&resp).await.expect("write health response");
+        });
+
+        let _guard_host = with_env("JULIE_EMBEDDING_USE_HOST", "1");
+
+        let svc = Arc::new(EmbeddingService::initializing());
+        let pool = Arc::new(WatcherPool::new(Duration::from_secs(30)));
+        let _handle = spawn_embedding_init(Arc::clone(&svc), None, Arc::clone(&pool), paths);
+
+        let outcome = svc.wait_until_settled(Duration::from_secs(5)).await;
+
+        assert!(
+            matches!(outcome, EmbeddingServiceSettled::Unavailable { .. }),
+            "expected Unavailable when host reports ready=false",
+        );
+        server.await.expect("fake host server task");
+    }
 }

--- a/src/tests/daemon/embedding_host_optin.rs
+++ b/src/tests/daemon/embedding_host_optin.rs
@@ -1,0 +1,6 @@
+//! Tests for the opt-in embedding-host coexistence wiring (Phase 3b, Task 7).
+//!
+//! IMPLEMENTED IN TASK 7. The lead owns `src/tests/daemon/mod.rs` registration;
+//! fill this file only. Verify that `spawn_embedding_init` only takes the host
+//! path when `JULIE_EMBEDDING_USE_HOST` is truthy, and is byte-for-byte the
+//! existing `create_embedding_provider` path when the env is unset.

--- a/src/tests/daemon/embedding_host_optin.rs
+++ b/src/tests/daemon/embedding_host_optin.rs
@@ -1,97 +1,89 @@
 //! Tests for the opt-in embedding-host coexistence wiring (Phase 3b, Task 7).
 //!
-//! Verifies that `spawn_embedding_init` takes the host path when
-//! `JULIE_EMBEDDING_USE_HOST` is truthy, and falls through to the existing
-//! `create_embedding_provider` path when the env var is absent.
+//! These tests drive `use_embedding_host()` directly — a unit-level check that
+//! proves "env unset → existing `create_embedding_provider` path is selected,
+//! host path only when truthy." The heavy integration (shared sidecar across
+//! sessions) is covered by T8.
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-    use std::time::Duration;
+    use serial_test::serial;
 
-    use julie_pipeline::embeddings::host_transport::{HostAddress, HostListener};
+    use crate::daemon::app::use_embedding_host;
 
-    use crate::daemon::app::spawn_embedding_init;
-    use crate::daemon::embedding_service::{EmbeddingService, EmbeddingServiceSettled};
-    use crate::daemon::watcher_pool::WatcherPool;
-    use crate::paths::DaemonPaths;
+    // -----------------------------------------------------------------------
+    // EnvGuard — sets/restores an env var on drop (SAFETY: serialised by
+    // #[serial] so no other thread touches the var concurrently).
+    // -----------------------------------------------------------------------
 
-    // Serialize env-var mutation so the two tests cannot clobber each other
-    // when the test runner executes them on the same thread pool.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn temp_paths() -> (tempfile::TempDir, DaemonPaths) {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let paths = DaemonPaths::with_home(dir.path().to_path_buf());
-        (dir, paths)
+    fn with_env(key: &str, value: &str) -> EnvGuard {
+        let previous = std::env::var(key).ok();
+        unsafe { std::env::set_var(key, value) };
+        EnvGuard { key: key.to_owned(), previous }
     }
 
-    // -----------------------------------------------------------------------
-    // Test 1: JULIE_EMBEDDING_USE_HOST=1  →  publish_ready (host path)
-    // -----------------------------------------------------------------------
-
-    #[tokio::test]
-    async fn host_path_taken_when_env_set() {
-        let (_dir, paths) = temp_paths();
-        let addr = HostAddress::from_paths(&paths);
-
-        // Bind the listener so is_host_live() inside connect_or_spawn_host
-        // succeeds: it does a plain connect() which only needs the socket to
-        // be accepting connections.
-        let _listener = HostListener::bind(&addr).await.expect("bind listener");
-
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { std::env::set_var("JULIE_EMBEDDING_USE_HOST", "1") };
-
-        let svc = Arc::new(EmbeddingService::initializing());
-        let pool = Arc::new(WatcherPool::new(Duration::from_secs(30)));
-
-        let _handle =
-            spawn_embedding_init(Arc::clone(&svc), None, Arc::clone(&pool), paths);
-
-        let outcome = svc.wait_until_settled(Duration::from_secs(5)).await;
-
-        // Clean up before the assertion so the env var is always removed.
-        unsafe { std::env::remove_var("JULIE_EMBEDDING_USE_HOST") };
-
-        assert!(
-            matches!(outcome, EmbeddingServiceSettled::Ready { .. }),
-            "expected Ready when JULIE_EMBEDDING_USE_HOST=1",
-        );
+    fn without_env(key: &str) -> EnvGuard {
+        let previous = std::env::var(key).ok();
+        unsafe { std::env::remove_var(key) };
+        EnvGuard { key: key.to_owned(), previous }
     }
 
-    // -----------------------------------------------------------------------
-    // Test 2: JULIE_EMBEDDING_USE_HOST unset  →  existing create_embedding_provider path
-    // -----------------------------------------------------------------------
+    struct EnvGuard {
+        key: String,
+        previous: Option<String>,
+    }
 
-    #[tokio::test]
-    async fn existing_path_taken_when_env_unset() {
-        let (_dir, paths) = temp_paths();
-
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe {
-            // Ensure the host opt-in is NOT set.
-            std::env::remove_var("JULIE_EMBEDDING_USE_HOST");
-            // Disable the sidecar so create_embedding_provider returns quickly
-            // with (None, _) instead of trying to spawn a real Python process.
-            std::env::set_var("JULIE_EMBEDDING_PROVIDER", "none");
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => unsafe { std::env::set_var(&self.key, v) },
+                None => unsafe { std::env::remove_var(&self.key) },
+            }
         }
+    }
 
-        let svc = Arc::new(EmbeddingService::initializing());
-        let pool = Arc::new(WatcherPool::new(Duration::from_secs(30)));
+    const KEY: &str = "JULIE_EMBEDDING_USE_HOST";
 
-        let _handle =
-            spawn_embedding_init(Arc::clone(&svc), None, Arc::clone(&pool), paths);
+    // -----------------------------------------------------------------------
+    // Test 1: env unset → false (existing create_embedding_provider path)
+    // -----------------------------------------------------------------------
 
-        let outcome = svc.wait_until_settled(Duration::from_secs(5)).await;
+    #[test]
+    #[serial(embedding_host_optin_env)]
+    fn false_when_env_unset() {
+        let _guard = without_env(KEY);
+        assert!(!use_embedding_host(), "expected false when {KEY} is unset");
+    }
 
-        unsafe { std::env::remove_var("JULIE_EMBEDDING_PROVIDER") };
+    // -----------------------------------------------------------------------
+    // Test 2: truthy values → true (host path selected)
+    // -----------------------------------------------------------------------
 
-        // create_embedding_provider with JULIE_EMBEDDING_PROVIDER=none publishes
-        // Unavailable, confirming the host branch was NOT entered.
-        assert!(
-            matches!(outcome, EmbeddingServiceSettled::Unavailable { .. }),
-            "expected Unavailable when JULIE_EMBEDDING_USE_HOST is unset and provider=none",
-        );
+    #[test]
+    #[serial(embedding_host_optin_env)]
+    fn true_for_all_truthy_values() {
+        for value in &["1", "true", "on", "TRUE", "On", "ON"] {
+            let _guard = with_env(KEY, value);
+            assert!(
+                use_embedding_host(),
+                "expected true for {KEY}={value:?}"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 3: falsy / unrecognised values → false
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[serial(embedding_host_optin_env)]
+    fn false_for_falsy_and_unrecognised_values() {
+        for value in &["0", "false", "off", "no", "", "yes", "maybe"] {
+            let _guard = with_env(KEY, value);
+            assert!(
+                !use_embedding_host(),
+                "expected false for {KEY}={value:?}"
+            );
+        }
     }
 }

--- a/src/tests/daemon/mod.rs
+++ b/src/tests/daemon/mod.rs
@@ -5,6 +5,8 @@ pub mod daemon_state_atomic;
 pub mod database;
 pub mod discovery_test;
 pub mod drain_timeout;
+pub mod embedding_host_multi_session;
+pub mod embedding_host_optin;
 pub mod embedding_service;
 pub mod embedding_service_shutdown;
 pub mod handler;


### PR DESCRIPTION
**Status:** Complete · **Branch:** julie-rescue-phase3b · **Plan:** docs/plans/2026-06-04-julie-phase3b-embedding-host.md
**Tasks:** 8/8 · **Branch-gate:** `cargo xtask test dev` 37/37 (1264.9s) @ 6d74c0df · **Acceptance HARD GATE:** `one_sidecar_serves_three_sessions` PASS

## What shipped
A resident **embedding-host** process that owns ONE PyTorch sidecar and serves `embed_query` / `embed_batch` / `health` to N Julie processes over a UDS (unix) / named-pipe (windows) front door. **Additive and opt-in** (`JULIE_EMBEDDING_USE_HOST=1`), runs alongside the existing daemon, and proves "one sidecar serves N processes." Does NOT flip the daemon default or rewire stdio (that's Phase 3c).

- **T1** `DaemonPaths` socket/lock/pipe helpers
- **T2** Cross-platform IPC transport seam (blocking client + async listener), protocol ungated
- **T3** `RpcEmbeddingProvider` — blocking RPC-client `EmbeddingProvider`, lazy connect + reconnect-once
- **T4** Embedding-host server — accept loop, per-conn dispatch, graceful shutdown, lock-first factory
- **T5** `julie-embedding-host` binary
- **T6** `connect_or_spawn_host` launch glue (sibling locate, detached spawn, pinned child `JULIE_HOME`)
- **T7** Opt-in coexistence wiring in `spawn_embedding_init` (Ready gated on a real health handshake)
- **T8 (HARD GATE)** Lock-first refactor + hermetic 3-host-race acceptance: exactly one sidecar serves three concurrent sessions

## External review (codex, adversarial)
4 findings, **all verified real and fixed**, 0 dismissed, 0 flagged:
- **F1 (HIGH)** shutdown released the singleton lock before dropping the listener socket → 2nd-host race. Fixed `drop(listener)` before `drop(lock_file)` (`03fde74a`).
- **F2 (HIGH)** `RpcEmbeddingProvider` getters swallow health-handshake errors → daemon could publish Ready against a broken host. Added fallible `ensure_ready()`, gate host path on it inside `spawn_blocking`, Err → Unavailable + new test (`db8ea61b`).
- **F3 (MED)** 10s spawn-liveness timeout < ~120–180s cold sidecar init. → 180s default + env override + parse test (`6d6d6ad4`).
- **F4 (MED)** no RPC socket timeout → stalled host hangs forever. → `connect_with_timeout(Option<Duration>)`, 120s default (not 30s — would abort a legit cold CPU batch), env override, timeout-fires + parse tests (`6d6d6ad4`).

Full judgment-call log, verification ledger, and the process-incident note are in the run report committed on this branch: `.memories/autonomous-run-2026-06-04-julie-phase3b-embedding-host.md`.

## Blockers
None. One resolved process incident: an un-frozen worker committed `5c9d949e` re-shaping accepted timeout helpers (regressing both `"0"` escape hatches, broke the gate mid-run); restored the verified shape as lead-revert `6d74c0df` and re-ran the gate green.

## Next steps
- Human-merge-gate this PR (per rescue-plan phases #22–#26).
- After merge: **Phase 3c** — flip daemon default / rewire stdio onto the resident host.
- Branch history contains the `5c9d949e` churn + `6d74c0df` revert; net tree is correct — squash-merge collapses it.