### PR TITLE
fix(daemon): suppress dashboard browser auto-open under test/CI

### DIFF
--- a/src/daemon/app.rs
+++ b/src/daemon/app.rs
@@ -14,7 +14,7 @@ use anyhow::{Context, Result};
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::dashboard::state::DashboardEvent;
 use crate::paths::DaemonPaths;
@@ -36,6 +36,36 @@ mod runtime;
 
 pub use handle::DaemonHandle;
 pub use runtime::DaemonRuntimeContext;
+
+/// Whether the dashboard browser auto-open is suppressed by the environment.
+///
+/// `julie-daemon` auto-opens the dashboard in a browser on startup as an
+/// interactive convenience. The test suite, however, spawns REAL daemons (both
+/// directly via `julie-daemon start` and indirectly via the adapter's
+/// `spawn_daemon`), so without a guard every daemon-spawning test pops a browser
+/// window — dozens during a full run. Suppress the auto-open under the test
+/// runner (`NEXTEST`, set by `cargo nextest` / `cargo xtask test`), in CI (`CI`),
+/// or when an operator opts out (`JULIE_NO_BROWSER`). A human running
+/// `julie daemon` in a terminal (none of these set) still gets the dashboard.
+pub(crate) fn dashboard_browser_open_suppressed_by_env() -> bool {
+    browser_open_suppressed_from(
+        std::env::var_os("NEXTEST").is_some(),
+        std::env::var_os("CI").is_some(),
+        std::env::var_os("JULIE_NO_BROWSER").is_some(),
+    )
+}
+
+/// Pure suppression policy: the dashboard browser auto-open is suppressed when
+/// ANY of the signals is present. Split out from
+/// [`dashboard_browser_open_suppressed_by_env`] so the policy is unit-testable
+/// without mutating process-global environment state.
+pub(crate) fn browser_open_suppressed_from(
+    nextest: bool,
+    ci: bool,
+    explicit_opt_out: bool,
+) -> bool {
+    nextest || ci || explicit_opt_out
+}
 
 /// Configuration for constructing a `DaemonApp`.
 pub struct DaemonConfig {
@@ -403,13 +433,25 @@ impl DaemonApp {
 
         // Auto-open browser unless suppressed. Background task: `opener::open`
         // can shell out for 1-3s on a cold Windows system.
-        if !self.no_dashboard {
+        //
+        // The env guard (`dashboard_browser_open_suppressed_by_env`) is what stops
+        // the browser-window flood during test runs: the suite spawns REAL daemons
+        // (directly and via the adapter), so without it every daemon-spawning test
+        // pops a browser window. Suppressed under the test runner / CI / explicit
+        // opt-out; the dashboard HTTP server below still runs regardless.
+        if !self.no_dashboard && !dashboard_browser_open_suppressed_by_env() {
             let url = dashboard_url.clone();
             tokio::spawn(async move {
                 if let Err(e) = opener::open(&url) {
                     warn!("Failed to open browser: {}", e);
                 }
             });
+        } else if !self.no_dashboard {
+            debug!(
+                url = %dashboard_url,
+                "Dashboard browser auto-open suppressed by environment \
+                 (NEXTEST / CI / JULIE_NO_BROWSER); dashboard is still served"
+            );
         }
 
         // Spawn dashboard server as a background task.

--- a/src/tests/daemon/dashboard_browser_open.rs
+++ b/src/tests/daemon/dashboard_browser_open.rs
@@ -1,0 +1,56 @@
+//! Dashboard browser auto-open suppression (test/CI guard).
+//!
+//! `julie-daemon` auto-opens the dashboard in a browser on startup. The test
+//! suite spawns REAL daemons — directly via `julie-daemon start` and indirectly
+//! via the adapter's `spawn_daemon` — so without a guard every daemon-spawning
+//! test pops a browser window (dozens during a full run). These tests pin the
+//! suppression policy: any of `NEXTEST` / `CI` / `JULIE_NO_BROWSER` suppresses
+//! the auto-open, while an interactive `julie daemon` (none set) still opens it.
+
+use crate::daemon::app::{browser_open_suppressed_from, dashboard_browser_open_suppressed_by_env};
+
+/// The pure policy: suppress iff ANY of the test/CI/opt-out signals is present.
+#[test]
+fn test_browser_open_suppression_policy_truth_table() {
+    // No signal → the interactive auto-open is allowed.
+    assert!(
+        !browser_open_suppressed_from(false, false, false),
+        "with no test/CI/opt-out signal, a human-launched daemon must still auto-open the dashboard"
+    );
+
+    // Any single signal → suppressed.
+    assert!(
+        browser_open_suppressed_from(true, false, false),
+        "NEXTEST (cargo nextest / cargo xtask test) must suppress the auto-open"
+    );
+    assert!(
+        browser_open_suppressed_from(false, true, false),
+        "CI must suppress the auto-open"
+    );
+    assert!(
+        browser_open_suppressed_from(false, false, true),
+        "JULIE_NO_BROWSER must suppress the auto-open"
+    );
+
+    // Combinations → still suppressed.
+    assert!(browser_open_suppressed_from(true, true, true));
+    assert!(browser_open_suppressed_from(true, false, true));
+}
+
+/// End-to-end guard against the actual regression: this test runs under
+/// `cargo nextest` (which sets `NEXTEST`) or in `CI`, so the env reader MUST
+/// report suppression — i.e. a daemon spawned during this very run will NOT pop
+/// a browser window. Guarded on the precondition so the test is also correct
+/// under a plain `cargo test` invocation (where neither var is set).
+#[test]
+fn test_dashboard_open_suppressed_under_test_runner() {
+    let under_runner =
+        std::env::var_os("NEXTEST").is_some() || std::env::var_os("CI").is_some();
+    if under_runner {
+        assert!(
+            dashboard_browser_open_suppressed_by_env(),
+            "under the test runner / CI the dashboard browser auto-open MUST be suppressed — \
+             this is exactly what stops the browser-window flood while tests run"
+        );
+    }
+}

--- a/src/tests/daemon/mod.rs
+++ b/src/tests/daemon/mod.rs
@@ -2,6 +2,7 @@ pub mod admit_initialize_short_circuit;
 pub mod app_test;
 pub mod connection_pool_test;
 pub mod daemon_state_atomic;
+pub mod dashboard_browser_open;
 pub mod database;
 pub mod discovery_test;
 pub mod drain_timeout;


### PR DESCRIPTION
## Summary

Suppress the daemon's dashboard browser auto-open when running under a test runner or CI. Previously, every daemon startup during a test run called `opener::open(<dashboard-url>)`, flooding the desktop with browser windows/tabs while the suite ran.

## What changed

- `src/daemon/app.rs`: the `opener::open` call is now gated behind a new environment policy in addition to the existing `!no_dashboard` check. The dashboard HTTP server still starts unconditionally — only the *browser launch* is suppressed.
- Suppression policy (`browser_open_suppressed_from`): suppress when **any** of `NEXTEST`, `CI`, or `JULIE_NO_BROWSER` is set in the environment. The policy is a pure function so it is unit-testable without env mutation; `dashboard_browser_open_suppressed_by_env()` reads the real environment and delegates to it.
- When suppressed, logs a `debug!` line instead of opening a browser.

## Tests

- `src/tests/daemon/dashboard_browser_open.rs` (new):
  - `test_browser_open_suppression_policy_truth_table` — pure policy: no env → open; any of nextest/ci/explicit → suppress.
  - `test_dashboard_open_suppressed_under_test_runner` — guarded on real `NEXTEST`/`CI` presence; asserts the real env reader suppresses under the test runner.

## Verification

- `cargo xtask test system` + `cargo xtask test reliability` GREEN @ `456013f7` (these tiers exercise the daemon/dashboard startup path).
- `JULIE_NO_BROWSER` gives users/operators an explicit opt-out independent of the test/CI heuristic.

## Notes

- Root cause was `spawn_daemon` (`src/adapter/launcher.rs`) launching `julie-daemon start` without `--no-dashboard`; fixed at the daemon source (env guard) rather than the launcher so the suppression holds for every daemon-start path, not just the adapter's.
